### PR TITLE
docs(website): Fix attribute `description`

### DIFF
--- a/apps/homepage/schema.html
+++ b/apps/homepage/schema.html
@@ -146,7 +146,7 @@ title: Schema
     "name": <span>"Project",</span>
     "startDate": <span>"2019-01-01",</span>
     "endDate": <span>"2021-01-01",</span>
-    "summary": <span>"Summary...",</span>
+    "description": <span>"Description...",</span>
     "highlights": [
       <span>"Won award at AIHacks 2016"</span>
     ],


### PR DESCRIPTION
 ## Changes

This confused me a lot. I thought the website is right and the reference
implementation is wrong:
https://github.com/rbardini/jsonresume-theme-even/blob/main/components/projects.js#L15

But no, the website is wrong. The source of truth for `jsonresume` schema is here:
https://github.com/jsonresume/resume-schema/blob/master/schema.json

 ## How to test

1. Visit https://www.jsonschemavalidator.net/
2. Paste schema.json
3. Set `"additionalProperties"` to `false` in the entire document
4. Paste the sample json from the website
5. See:
```
Found 1 error(s)

Message:
    Property 'summary' has not been defined and the schema does not allow additional properties.
Schema path:
    #/properties/projects/items/additionalProperties
```

 ## Other

Why don't we simply take the sample json from `resume-schema`?
https://github.com/jsonresume/resume-schema/blob/master/sample.resume.json

