### PR TITLE
enable mac compatibility

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,30 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+        working-directory: apps/registry
+      - name: Run Playwright tests
+        run: pnpm turbo test:e2e
+        env:
+          GITHUB_TOKEN: ${{ secrets.LEVINS_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -27,7 +27,6 @@
     "json-to-pretty-yaml": "^1.2.2",
     "jsonresume-theme-ace": "^1.1.0",
     "jsonresume-theme-actual": "^0.2.1",
-    "jsonresume-theme-apage": "^1.0.2",
     "jsonresume-theme-autumn": "^1.0.1",
     "jsonresume-theme-caffeine": "^1.2.3",
     "jsonresume-theme-class": "^0.1.2",

--- a/apps/registry/pages/api/formatters/template.js
+++ b/apps/registry/pages/api/formatters/template.js
@@ -1,7 +1,6 @@
 export const THEMES = {
   ace: require('jsonresume-theme-ace'),
   actual: require('jsonresume-theme-actual'),
-  apage: require('jsonresume-theme-apage'),
   autumn: require('jsonresume-theme-autumn'),
   caffeine: require('jsonresume-theme-caffeine'),
   class: require('jsonresume-theme-class'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       jsonresume-theme-actual:
         specifier: ^0.2.1
         version: 0.2.1
-      jsonresume-theme-apage:
-        specifier: ^1.0.2
-        version: 1.0.2
       jsonresume-theme-autumn:
         specifier: ^1.0.1
         version: 1.0.1
@@ -6628,12 +6625,6 @@ packages:
       markdown-it: 13.0.1
       moment: 2.29.4
       pug: 3.0.2
-    dev: false
-
-  /jsonresume-theme-apage@1.0.2:
-    resolution: {integrity: sha512-NOVX6ghNr1Gsb1A3KFUOjxYMj9Jz+PPUbayvqx8mN68QakvsJCE63sqRha0RhYE1ZC7ZTG0XRfZbb0rNGtYQ8w==}
-    dependencies:
-      handlebars: 4.7.7
     dev: false
 
   /jsonresume-theme-autumn@1.0.1:


### PR DESCRIPTION
Based on #25. The `apage` theme requires an environment variable `LANG` to be present, which is not the case on MacOS, but probably only on linux. I think that makes the theme essentially broken and we should remove it, until this issue has been fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated Playwright tests in the CI/CD pipeline for enhanced quality assurance.

- **Chores**
  - Removed an unused theme from the application's theme registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->