### PR TITLE
fix: add a link to a github issue when themes are missing

### DIFF
--- a/apps/registry/pages/api/[payload].js
+++ b/apps/registry/pages/api/[payload].js
@@ -120,7 +120,7 @@ export default async function handler(req, res) {
     });
   } catch (e) {
     // If gist url is invalid, flush the gistid in cache
-    return res.status(200).send(failMessage('Cannot fetch gist, no idea why'));
+    return res.status(400).send(failMessage('Cannot fetch gist, no idea why'));
   }
 
   let realTheme =
@@ -132,7 +132,7 @@ export default async function handler(req, res) {
   const validation = v.validate(selectedResume, schema);
 
   if (!validation.valid) {
-    return res.status(200).send(
+    return res.status(400).send(
       failMessage('Validation failed') +
         `
     
@@ -175,7 +175,7 @@ ${JSON.stringify(validation.errors, null, 2)}
     // @todo - do this better
     if (e.message === 'theme-missing') {
       return res
-        .status(200)
+        .status(400)
         .send(
           failMessage(
             'This theme is currently unsupported. Please visit this Github issue to request it https://github.com/jsonresume/jsonresume.org/issues/36 (unfortunately we have recently (11/2023) disabled a bunch of legacy themes due to critical flaws in them, please request if you would like them back.)'
@@ -184,7 +184,7 @@ ${JSON.stringify(validation.errors, null, 2)}
     }
 
     return res
-      .status(200)
+      .status(400)
       .send(
         failMessage(
           'Cannot format resume, no idea why #likely-a-validation-error'

--- a/apps/registry/pages/api/[payload].js
+++ b/apps/registry/pages/api/[payload].js
@@ -54,7 +54,7 @@ export default async function handler(req, res) {
   const formatter = FORMATTERS[fileType];
 
   if (!formatter) {
-    return res.status(200).send(failMessage('not supported formatted'));
+    return res.status(200).send(failMessage('not supported formatter'));
   }
 
   if (
@@ -172,7 +172,17 @@ ${JSON.stringify(validation.errors, null, 2)}
   try {
     formatted = await formatter.format(selectedResume, options);
   } catch (e) {
-    console.log(e);
+    // @todo - do this better
+    if (e.message === 'theme-missing') {
+      return res
+        .status(200)
+        .send(
+          failMessage(
+            'This theme is currently unsupported. Please visit this Github issue to request it https://github.com/jsonresume/jsonresume.org/issues/36 (unfortunately we have recently (11/2023) disabled a bunch of legacy themes due to critical flaws in them, please request if you would like them back.)'
+          )
+        );
+    }
+
     return res
       .status(200)
       .send(

--- a/apps/registry/pages/api/formatters/template.js
+++ b/apps/registry/pages/api/formatters/template.js
@@ -48,6 +48,11 @@ const getTheme = (theme) => {
 const format = async function (resume, options) {
   const theme = options.theme ?? 'elegant';
   const themeRenderer = getTheme(theme);
+
+  if (!themeRenderer) {
+    throw new Error('theme-missing');
+  }
+
   const resumeHTML = themeRenderer.render(resume);
 
   return {


### PR DESCRIPTION
Fix #38 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typo in error messages to accurately reflect "not supported formatter."
  - Improved error handling for missing themes with informative messages and resource links.
  - Updated HTTP status codes for specific errors to enhance API response accuracy.

- **Documentation**
  - Clarified that there are no changes to function signatures or global structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->