### PR TITLE
Add ancv to projects

### DIFF
--- a/apps/homepage/_data/projects.yaml
+++ b/apps/homepage/_data/projects.yaml
@@ -147,4 +147,9 @@
   link: https://github.com/nikaro/resume-pycli
   description: Python CLI tool to build a beautiful resume from a JSON Resume file.
   category: cli
+
+- name: ancv
+  link: https://github.com/alexpovel/ancv/
+  description:  Renders your JSON Resume for online & pretty terminal display
+  category: visualization
 # https://github.com/renoirb/jsonresume-from-yaml


### PR DESCRIPTION
Hi!

A small [project](https://github.com/alexpovel/ancv/) I put together that builds on top of JSON Resume. Perhaps you find it useful.

I guessed at where the entry would go to have it appear on https://jsonresume.org/projects/ . Please advise if that guess was wrong.