### PR TITLE
fix: sort resumes api by descending first

### DIFF
--- a/apps/registry/pages/api/resumes.js
+++ b/apps/registry/pages/api/resumes.js
@@ -12,7 +12,7 @@ export default async function handler(req, res) {
   const { data } = await supabase
     .from('resumes')
     .select()
-    .sort('created_at', { ascending: false })
+    .order('created_at', { ascending: false })
     .limit(limit || 1000);
 
   const resumes = data.map((row) => {

--- a/apps/registry/pages/api/resumes.js
+++ b/apps/registry/pages/api/resumes.js
@@ -12,6 +12,7 @@ export default async function handler(req, res) {
   const { data } = await supabase
     .from('resumes')
     .select()
+    .sort('created_at', { ascending: false })
     .limit(limit || 1000);
 
   const resumes = data.map((row) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Resume data is now displayed in descending order based on the creation date, ensuring the most recently added resumes appear first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->