### PR TITLE
Fix: professional theme Linkedin url

### DIFF
--- a/packages/jsonresume-theme-professional/src/ui/Hero.js
+++ b/packages/jsonresume-theme-professional/src/ui/Hero.js
@@ -84,7 +84,7 @@ const HeroComponent = ({ basics }) => {
           {linkedin && (
             <Info>
               <FaLinkedin />
-              <a href={`https://linkedin.com/${linkedin.username}`}>
+              <a href={`https://linkedin.com/in/${linkedin.username}`}>
                 {linkedin.username}
               </a>
             </Info>


### PR DESCRIPTION
In the professional theme, the LinkedIn link with the username is not working correctly. The current implementation fails to properly construct the URL for the user's LinkedIn profile. A simple fix is needed to ensure the LinkedIn URL is correctly formatted to showcase the user's profile. This issue affects the user's ability to link their professional presence effectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the LinkedIn profile link format in the Hero component for improved usability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->