### PR TITLE
Add stackoverflow theme Author back

### DIFF
--- a/apps/homepage2/app/themes/page.js
+++ b/apps/homepage2/app/themes/page.js
@@ -48,9 +48,9 @@ export default function GettingStarted() {
     {
       name: 'Stack Overflow',
       slug: 'stackoverflow',
-      github: '',
-      author: '',
-      link: '',
+      github: 'phoinixi',
+      author: 'Francesco Esposito',
+      link: 'https://github.com/phoinixi',
     },
     {
       name: 'Rickosborne',


### PR DESCRIPTION
Hi @thomasdavis 

I am adding myself back as author of the stackoverflow theme -> https://github.com/phoinixi/jsonresume-theme-stackoverflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the “Stack Overflow” theme by updating its displayed details. Users will now benefit from complete information—including an updated author name, GitHub username, and a direct link to the author’s profile—providing richer context and a more informative experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->