### PR TITLE
open source -> open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">JSON Resume</h1>
 
 <p align="center">
-  <b>A community-driven open source initiative to create a JSON-based standard for resumes</b>
+  <b>A community-driven open-source initiative to create a JSON-based standard for resumes</b>
 </p>
 
 <p align="center">

--- a/apps/homepage2/app/page.js
+++ b/apps/homepage2/app/page.js
@@ -9,7 +9,7 @@ export default async function Page() {
             <div className="col-sm-12">
               <h1>JSON Resume</h1>
               <p>
-                The open source initiative to create a JSON-based standard for
+                The open-source initiative to create a JSON-based standard for
                 resumes. For developers, by developers.
               </p>
               <a href="/schema/" className="btn btn-red btn-big">

--- a/apps/homepage2/app/schema/page.js
+++ b/apps/homepage2/app/schema/page.js
@@ -28,7 +28,7 @@ export default function Schema() {
           <div class="col-md-5">
             <h4>What is it?</h4>
             <p>
-              JSON Resume is a community driven open source initiative to create
+              JSON Resume is a community driven open-source initiative to create
               JSON-based standard for resumes.
             </p>
             <h4>Why JSON?</h4>

--- a/apps/registry/app/page.js
+++ b/apps/registry/app/page.js
@@ -224,7 +224,7 @@ export default async function Page() {
                 <span className="font-bold text-xl">JSON Resume</span>
               </div>
               <p className="text-gray-600 mb-4 max-w-md">
-                An open source initiative to create a JSON-based standard for
+                An open-source initiative to create a JSON-based standard for
                 resumes. Helping developers showcase their work and experience.
               </p>
               <div className="flex gap-4">

--- a/apps/registry/pages/api/samples/resume.js
+++ b/apps/registry/pages/api/samples/resume.js
@@ -184,7 +184,7 @@ const resume = {
         'Tens of thousands of users',
       ],
       summary:
-        "JSON Resume is a community driven open source initiative to create a JSON based standard for resumes. There is no reason why there can't be a common standard for writing a resume that can be extended with an ecosystem of open source tools.",
+        "JSON Resume is a community driven open-source initiative to create a JSON based standard for resumes. There is no reason why there can't be a common standard for writing a resume that can be extended with an ecosystem of open source tools.",
       website: 'http://jsonresume.org',
       pinned: true,
       name: 'JSON Resume',


### PR DESCRIPTION
"open source" is a lexicalized compound noun. "open-source" is a compound modifier which is what was probably meant here.

https://opensource.org/blog/is-open-source-ever-hyphenated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated text across the platform to consistently use the hyphenated "open‑source," enhancing clarity and grammatical accuracy in the initiative's description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->