### PR TITLE
Feat: Allow empty endDate for ongoing work, volunteer, education, awards, certificates, publications and projects experiences in schema.js

### DIFF
--- a/apps/registry/pages/api/schema.js
+++ b/apps/registry/pages/api/schema.js
@@ -5,9 +5,9 @@ const schema = {
     iso8601: {
       type: 'string',
       description:
-        'Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04',
+        'Similar to the standard date type, but each section after the year is optional. e.g. 2014-06-29 or 2023-04. The value can also be an empty string for ongoing roles.',
       pattern:
-        '^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3})$',
+        '^([1-2][0-9]{3}-[0-1][0-9]-[0-3][0-9]|[1-2][0-9]{3}-[0-1][0-9]|[1-2][0-9]{3}|)$',
     },
   },
   properties: {


### PR DESCRIPTION
This commit addresses the validation error that occurs when the `endDate` field is left empty for an ongoing work, volunteer, education, awards, certificates, publications and projects.

The previous schema pattern for `iso8601` did not allow for an empty string, causing validation to fail. This update modifies the `iso8601` pattern to correctly handle empty strings, aligning the schema with the expected behavior of indicating a "Present" or ongoing role.

This change resolves issue https://github.com/jsonresume/jsonresume.org/issues/194, ensuring resumes with empty `endDate` fields can be successfully validated and displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Date fields using ISO 8601 now accept an empty value to represent ongoing roles.
  - Validation broadened to accept yyyy, yyyy-mm, yyyy-mm-dd, or empty string.
  - Improves form/API submissions that previously failed when end dates were not applicable.
  - No other endpoints or behaviors changed; this is a non-breaking validation update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->