### PR TITLE
test(resume-core): add unit suite for calculation helpers (19 fns)

### DIFF
--- a/packages/resume-core/src/helpers/__tests__/calculations.test.js
+++ b/packages/resume-core/src/helpers/__tests__/calculations.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import * as barrel from '../calculations.js';
+import { calculateTotalExperience } from '../experience.js';
+import { work } from './fixtures.js';
+
+/** Every public calculation helper, grouped by implementation module. */
+const EXPECTED_EXPORTS = [
+  // experience.js
+  'calculateTotalExperience',
+  'calculateCurrentRoleExperience',
+  'countCareerPositions',
+  'getCareerProgressionRate',
+  'countTotalHighlights',
+  // counts.js
+  'countCompanies',
+  'countProjects',
+  'countPublications',
+  'countAwards',
+  'countTotalSkills',
+  'countSkillCategories',
+  'countLanguages',
+  // education.js
+  'calculateEducationYears',
+  'getHighestDegree',
+  // workHistory.js
+  'calculateVolunteerYears',
+  'getUniqueIndustries',
+  'getCurrentEmployer',
+  'isCurrentlyEmployed',
+  // keyMetrics.js
+  'calculateKeyMetrics',
+];
+
+describe('calculations barrel', () => {
+  it('re-exports exactly the 19 calculation helpers', () => {
+    expect(EXPECTED_EXPORTS).toHaveLength(19);
+    expect(Object.keys(barrel).sort()).toEqual([...EXPECTED_EXPORTS].sort());
+  });
+
+  it('exports a function for every helper', () => {
+    for (const name of EXPECTED_EXPORTS) {
+      expect(barrel[name], `${name} should be a function`).toBeTypeOf(
+        'function'
+      );
+    }
+  });
+
+  it('re-exports the same implementations as the focused modules', () => {
+    expect(barrel.calculateTotalExperience).toBe(calculateTotalExperience);
+  });
+
+  it('helpers are callable through the barrel', () => {
+    // countCompanies is date-independent: 2 unique companies in the fixture.
+    expect(barrel.countCompanies(work)).toBe(2);
+  });
+});

--- a/packages/resume-core/src/helpers/__tests__/counts.test.js
+++ b/packages/resume-core/src/helpers/__tests__/counts.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  countCompanies,
+  countProjects,
+  countPublications,
+  countAwards,
+  countTotalSkills,
+  countSkillCategories,
+  countLanguages,
+} from '../counts.js';
+import {
+  work,
+  skills,
+  projects,
+  publications,
+  awards,
+  languages,
+} from './fixtures.js';
+
+describe('countCompanies', () => {
+  it('counts unique company names', () => {
+    // Acme Corp appears twice in the fixture
+    expect(countCompanies(work)).toBe(2);
+  });
+
+  it('ignores entries without a name', () => {
+    expect(
+      countCompanies([{ name: 'A' }, { position: 'Engineer' }, { name: 'B' }])
+    ).toBe(2);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countCompanies([])).toBe(0);
+    expect(countCompanies()).toBe(0);
+    expect(countCompanies(null)).toBe(0);
+    expect(countCompanies('not-an-array')).toBe(0);
+  });
+});
+
+describe('countProjects', () => {
+  it('returns the number of projects', () => {
+    expect(countProjects(projects)).toBe(2);
+    expect(countProjects([{ name: 'Solo' }])).toBe(1);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countProjects([])).toBe(0);
+    expect(countProjects()).toBe(0);
+    expect(countProjects(null)).toBe(0);
+    expect(countProjects({})).toBe(0);
+  });
+});
+
+describe('countPublications', () => {
+  it('returns the number of publications', () => {
+    expect(countPublications(publications)).toBe(1);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countPublications([])).toBe(0);
+    expect(countPublications()).toBe(0);
+    expect(countPublications(null)).toBe(0);
+  });
+});
+
+describe('countAwards', () => {
+  it('returns the number of awards', () => {
+    expect(countAwards(awards)).toBe(1);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countAwards([])).toBe(0);
+    expect(countAwards()).toBe(0);
+    expect(countAwards(null)).toBe(0);
+  });
+});
+
+describe('countTotalSkills', () => {
+  it('sums keywords across all skill categories', () => {
+    // 3 (Web) + 1 (Ops) + 0 (Soft Skills, no keywords)
+    expect(countTotalSkills(skills)).toBe(4);
+  });
+
+  it('treats categories without keywords as contributing 0', () => {
+    expect(countTotalSkills([{ name: 'Empty' }])).toBe(0);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countTotalSkills([])).toBe(0);
+    expect(countTotalSkills()).toBe(0);
+    expect(countTotalSkills(null)).toBe(0);
+  });
+});
+
+describe('countSkillCategories', () => {
+  it('returns the number of skill categories', () => {
+    expect(countSkillCategories(skills)).toBe(3);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countSkillCategories([])).toBe(0);
+    expect(countSkillCategories()).toBe(0);
+    expect(countSkillCategories(null)).toBe(0);
+  });
+});
+
+describe('countLanguages', () => {
+  it('returns the number of languages', () => {
+    expect(countLanguages(languages)).toBe(2);
+    expect(countLanguages([{ language: 'English' }])).toBe(1);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countLanguages([])).toBe(0);
+    expect(countLanguages()).toBe(0);
+    expect(countLanguages(null)).toBe(0);
+  });
+});

--- a/packages/resume-core/src/helpers/__tests__/education.test.js
+++ b/packages/resume-core/src/helpers/__tests__/education.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { calculateEducationYears, getHighestDegree } from '../education.js';
+import { education, FIXED_NOW } from './fixtures.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('calculateEducationYears', () => {
+  // KNOWN BUG (documented, not fixed here): the implementation divides by
+  // ((1000 * 60 * 60 * 24) / 365.25) instead of (1000 * 60 * 60 * 24 * 365.25),
+  // so it returns days * 365.25 rather than years. The fixture spans ~5.5 real
+  // years of study but the function reports 733057. These assertions lock in
+  // CURRENT behavior; update them when the formula is fixed.
+  it('returns the current (inflated) value for the fixture', () => {
+    expect(calculateEducationYears(education)).toBe(733057);
+  });
+
+  it('returns the current (inflated) value for a single entry', () => {
+    expect(
+      calculateEducationYears([
+        { startDate: '2012-09-01', endDate: '2016-06-01' },
+      ])
+    ).toBe(500027);
+  });
+
+  it('skips entries without a startDate', () => {
+    expect(calculateEducationYears([{ endDate: '2016-06-01' }, {}])).toBe(0);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(calculateEducationYears([])).toBe(0);
+    expect(calculateEducationYears()).toBe(0);
+    expect(calculateEducationYears(null)).toBe(0);
+    expect(calculateEducationYears('not-an-array')).toBe(0);
+  });
+});
+
+describe('getHighestDegree', () => {
+  it('returns the studyType of the highest ranked degree', () => {
+    expect(getHighestDegree(education)).toBe('Master of Science');
+  });
+
+  it('ranks doctorates above masters above bachelors', () => {
+    expect(
+      getHighestDegree([
+        { studyType: 'Bachelor of Arts' },
+        { studyType: 'PhD in Physics' },
+        { studyType: 'Master of Science' },
+      ])
+    ).toBe('PhD in Physics');
+  });
+
+  it('matches degree keywords case-insensitively', () => {
+    expect(getHighestDegree([{ studyType: 'BACHELOR OF ARTS' }])).toBe(
+      'BACHELOR OF ARTS'
+    );
+    expect(getHighestDegree([{ studyType: 'MBA' }])).toBe('MBA');
+  });
+
+  it('keeps the first entry on rank ties', () => {
+    expect(
+      getHighestDegree([{ studyType: 'Doctorate' }, { studyType: 'PhD' }])
+    ).toBe('Doctorate');
+  });
+
+  it('returns an empty string when no studyType matches a known degree', () => {
+    expect(getHighestDegree([{ studyType: 'Bootcamp' }])).toBe('');
+    expect(getHighestDegree([{ institution: 'No Study Type U' }])).toBe('');
+  });
+
+  it('returns an empty string for empty, missing, or non-array input', () => {
+    expect(getHighestDegree([])).toBe('');
+    expect(getHighestDegree()).toBe('');
+    expect(getHighestDegree(null)).toBe('');
+  });
+});

--- a/packages/resume-core/src/helpers/__tests__/experience.test.js
+++ b/packages/resume-core/src/helpers/__tests__/experience.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  calculateTotalExperience,
+  calculateCurrentRoleExperience,
+  countCareerPositions,
+  getCareerProgressionRate,
+  countTotalHighlights,
+} from '../experience.js';
+import { work, FIXED_NOW } from './fixtures.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('calculateTotalExperience', () => {
+  it('sums tenure across all jobs, rounded to nearest year', () => {
+    // ~5.0 (ongoing) + ~3.0 + ~2.0 years
+    expect(calculateTotalExperience(work)).toBe(10);
+  });
+
+  it('uses the current date for ongoing roles (no endDate)', () => {
+    expect(calculateTotalExperience([{ startDate: '2021-01-01' }])).toBe(5);
+  });
+
+  it('skips entries without a startDate', () => {
+    expect(
+      calculateTotalExperience([
+        { startDate: '2018-01-01', endDate: '2021-01-01' },
+        { endDate: '2020-01-01' },
+        {},
+      ])
+    ).toBe(3);
+  });
+
+  it('double-counts overlapping periods (naive per-job sum)', () => {
+    expect(
+      calculateTotalExperience([
+        { startDate: '2018-01-01', endDate: '2020-01-01' },
+        { startDate: '2019-01-01', endDate: '2021-01-01' },
+      ])
+    ).toBe(4);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(calculateTotalExperience([])).toBe(0);
+    expect(calculateTotalExperience()).toBe(0);
+    expect(calculateTotalExperience(null)).toBe(0);
+    expect(calculateTotalExperience('not-an-array')).toBe(0);
+  });
+});
+
+describe('calculateCurrentRoleExperience', () => {
+  it('measures the first role without an endDate, rounded to 1 decimal', () => {
+    expect(calculateCurrentRoleExperience(work)).toBe(5);
+  });
+
+  it('finds the current role even when it is not first in the array', () => {
+    expect(
+      calculateCurrentRoleExperience([
+        { startDate: '2018-01-01', endDate: '2021-01-01' },
+        { startDate: '2023-07-01' },
+      ])
+    ).toBe(2.5);
+  });
+
+  it('falls back to the first entry when every role has ended', () => {
+    expect(
+      calculateCurrentRoleExperience([
+        { startDate: '2018-01-01', endDate: '2021-01-01' },
+        { startDate: '2016-01-01', endDate: '2018-01-01' },
+      ])
+    ).toBe(3);
+  });
+
+  it('returns 0 when the selected role has no startDate', () => {
+    expect(calculateCurrentRoleExperience([{ position: 'Engineer' }])).toBe(0);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(calculateCurrentRoleExperience([])).toBe(0);
+    expect(calculateCurrentRoleExperience()).toBe(0);
+    expect(calculateCurrentRoleExperience(null)).toBe(0);
+  });
+});
+
+describe('countCareerPositions', () => {
+  it('counts unique position titles', () => {
+    expect(countCareerPositions(work)).toBe(3);
+  });
+
+  it('deduplicates repeated titles and ignores missing ones', () => {
+    expect(
+      countCareerPositions([
+        { position: 'Engineer' },
+        { position: 'Engineer' },
+        { name: 'No Position Inc' },
+        { position: 'Manager' },
+      ])
+    ).toBe(2);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countCareerPositions([])).toBe(0);
+    expect(countCareerPositions()).toBe(0);
+    expect(countCareerPositions(null)).toBe(0);
+  });
+});
+
+describe('getCareerProgressionRate', () => {
+  it('returns average years per position, rounded to 1 decimal', () => {
+    // 10 total years / 3 unique positions
+    expect(getCareerProgressionRate(work)).toBe(3.3);
+  });
+
+  it('returns 0 when there is no work history', () => {
+    expect(getCareerProgressionRate([])).toBe(0);
+    expect(getCareerProgressionRate()).toBe(0);
+  });
+
+  it('returns 0 when total experience rounds down to 0 years', () => {
+    expect(
+      getCareerProgressionRate([
+        { position: 'Intern', startDate: '2025-11-01', endDate: '2025-12-01' },
+      ])
+    ).toBe(0);
+  });
+});
+
+describe('countTotalHighlights', () => {
+  it('sums highlights across all jobs', () => {
+    expect(countTotalHighlights(work)).toBe(5);
+  });
+
+  it('treats jobs without highlights as contributing 0', () => {
+    expect(
+      countTotalHighlights([{ highlights: ['a', 'b'] }, { name: 'None Inc' }])
+    ).toBe(2);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(countTotalHighlights([])).toBe(0);
+    expect(countTotalHighlights()).toBe(0);
+    expect(countTotalHighlights(null)).toBe(0);
+  });
+});

--- a/packages/resume-core/src/helpers/__tests__/fixtures.js
+++ b/packages/resume-core/src/helpers/__tests__/fixtures.js
@@ -1,0 +1,103 @@
+/**
+ * Shared fixtures for calculation helper tests.
+ *
+ * All date math in these tests pins "now" to FIXED_NOW via vi.setSystemTime
+ * so that open-ended entries (no endDate) produce deterministic values.
+ */
+
+/** Pinned system time used by every date-dependent test. */
+export const FIXED_NOW = new Date('2026-01-01T00:00:00Z');
+
+/**
+ * Work history (most recent first, matching JSON Resume convention):
+ * - Acme Corp (current, no endDate): 2021-01-01 -> now = ~5.0 years
+ * - Globex: 2018-01-01 -> 2021-01-01 = ~3.0 years
+ * - Acme Corp (again, duplicate company name): 2016-01-01 -> 2018-01-01 = ~2.0 years
+ * Total ~10.0 years, 2 unique companies, 3 unique positions, 5 highlights.
+ */
+export const work = [
+  {
+    name: 'Acme Corp',
+    position: 'Senior Engineer',
+    startDate: '2021-01-01',
+    industry: 'Technology',
+    highlights: ['Led platform migration', 'Mentored four engineers'],
+  },
+  {
+    name: 'Globex',
+    position: 'Engineer',
+    startDate: '2018-01-01',
+    endDate: '2021-01-01',
+    industry: 'Finance',
+    highlights: [
+      'Shipped payments service',
+      'Cut API latency 40%',
+      'On-call rotation lead',
+    ],
+  },
+  {
+    name: 'Acme Corp',
+    position: 'Junior Engineer',
+    startDate: '2016-01-01',
+    endDate: '2018-01-01',
+  },
+];
+
+export const education = [
+  {
+    institution: 'State University',
+    studyType: 'Bachelor of Science',
+    area: 'Computer Science',
+    startDate: '2012-09-01',
+    endDate: '2016-06-01',
+  },
+  {
+    institution: 'State University',
+    studyType: 'Master of Science',
+    area: 'Computer Science',
+    startDate: '2016-09-01',
+    endDate: '2018-06-01',
+  },
+];
+
+export const volunteer = [
+  {
+    organization: 'Code Club',
+    position: 'Mentor',
+    startDate: '2019-01-01',
+    endDate: '2022-01-01',
+  },
+  // No startDate: must be skipped by duration calculations.
+  { organization: 'Food Bank', position: 'Helper' },
+];
+
+export const skills = [
+  { name: 'Web', keywords: ['JavaScript', 'TypeScript', 'React'] },
+  { name: 'Ops', keywords: ['Docker'] },
+  // No keywords: contributes 0 to countTotalSkills but 1 category.
+  { name: 'Soft Skills' },
+];
+
+export const projects = [{ name: 'Project One' }, { name: 'Project Two' }];
+
+export const publications = [{ name: 'A Paper' }];
+
+export const awards = [{ title: 'Best Engineer' }];
+
+export const languages = [
+  { language: 'English', fluency: 'Native' },
+  { language: 'Spanish', fluency: 'Professional' },
+];
+
+/** A representative, fully-populated JSON Resume object. */
+export const fullResume = {
+  basics: { name: 'Jane Developer' },
+  work,
+  education,
+  volunteer,
+  skills,
+  projects,
+  publications,
+  awards,
+  languages,
+};

--- a/packages/resume-core/src/helpers/__tests__/keyMetrics.test.js
+++ b/packages/resume-core/src/helpers/__tests__/keyMetrics.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { calculateKeyMetrics } from '../keyMetrics.js';
+import { fullResume, skills, languages, FIXED_NOW } from './fixtures.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('calculateKeyMetrics', () => {
+  it('builds the full dashboard metric list in order for a populated resume', () => {
+    expect(calculateKeyMetrics(fullResume)).toEqual([
+      { label: 'Years Experience', value: 10 },
+      { label: 'Companies', value: 2 },
+      { label: 'Projects', value: 2 },
+      { label: 'Core Skills', value: 4 },
+      { label: 'Publications', value: 1 },
+      { label: 'Awards', value: 1 },
+      { label: 'Education', value: 'Master of Science' },
+      { label: 'Languages', value: 2 },
+    ]);
+  });
+
+  it('returns an empty array for an empty resume object', () => {
+    expect(calculateKeyMetrics({})).toEqual([]);
+  });
+
+  it('only includes metrics for populated sections', () => {
+    expect(calculateKeyMetrics({ skills })).toEqual([
+      { label: 'Core Skills', value: 4 },
+    ]);
+  });
+
+  it('omits the Languages metric unless multilingual (more than one)', () => {
+    expect(calculateKeyMetrics({ languages: [languages[0]] })).toEqual([]);
+    expect(calculateKeyMetrics({ languages })).toEqual([
+      { label: 'Languages', value: 2 },
+    ]);
+  });
+
+  it('omits Education when no studyType matches a known degree', () => {
+    expect(
+      calculateKeyMetrics({ education: [{ institution: 'No Degree U' }] })
+    ).toEqual([]);
+  });
+
+  // Documents current behavior: the resume argument has no default, so
+  // destructuring undefined throws. Callers must pass an object.
+  it('throws when called without a resume object', () => {
+    expect(() => calculateKeyMetrics()).toThrow(TypeError);
+  });
+});

--- a/packages/resume-core/src/helpers/__tests__/workHistory.test.js
+++ b/packages/resume-core/src/helpers/__tests__/workHistory.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  calculateVolunteerYears,
+  getUniqueIndustries,
+  getCurrentEmployer,
+  isCurrentlyEmployed,
+} from '../workHistory.js';
+import { work, volunteer, FIXED_NOW } from './fixtures.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('calculateVolunteerYears', () => {
+  it('sums volunteer tenure, skipping entries without a startDate', () => {
+    // 3 years at Code Club; Food Bank entry has no startDate
+    expect(calculateVolunteerYears(volunteer)).toBe(3);
+  });
+
+  it('uses the current date for ongoing roles (no endDate)', () => {
+    expect(calculateVolunteerYears([{ startDate: '2024-01-01' }])).toBe(2);
+  });
+
+  it('returns 0 for empty, missing, or non-array input', () => {
+    expect(calculateVolunteerYears([])).toBe(0);
+    expect(calculateVolunteerYears()).toBe(0);
+    expect(calculateVolunteerYears(null)).toBe(0);
+    expect(calculateVolunteerYears('not-an-array')).toBe(0);
+  });
+});
+
+describe('getUniqueIndustries', () => {
+  it('returns unique industries in insertion order, skipping missing ones', () => {
+    expect(getUniqueIndustries(work)).toEqual(['Technology', 'Finance']);
+  });
+
+  it('deduplicates repeated industries', () => {
+    expect(
+      getUniqueIndustries([
+        { industry: 'Technology' },
+        { industry: 'Technology' },
+        { industry: 'Healthcare' },
+      ])
+    ).toEqual(['Technology', 'Healthcare']);
+  });
+
+  it('returns an empty array for empty, missing, or non-array input', () => {
+    expect(getUniqueIndustries([])).toEqual([]);
+    expect(getUniqueIndustries()).toEqual([]);
+    expect(getUniqueIndustries(null)).toEqual([]);
+  });
+});
+
+describe('getCurrentEmployer', () => {
+  it('returns the first job without an endDate', () => {
+    expect(getCurrentEmployer(work)).toBe(work[0]);
+  });
+
+  it('finds the current job even when it is not first in the array', () => {
+    const current = { name: 'Now Co', startDate: '2024-01-01' };
+    expect(
+      getCurrentEmployer([
+        { name: 'Old Co', startDate: '2018-01-01', endDate: '2021-01-01' },
+        current,
+      ])
+    ).toBe(current);
+  });
+
+  it('falls back to the first entry when every job has ended', () => {
+    const jobs = [
+      { name: 'A', startDate: '2018-01-01', endDate: '2021-01-01' },
+      { name: 'B', startDate: '2016-01-01', endDate: '2018-01-01' },
+    ];
+    expect(getCurrentEmployer(jobs)).toBe(jobs[0]);
+  });
+
+  it('returns null for empty, missing, or non-array input', () => {
+    expect(getCurrentEmployer([])).toBeNull();
+    expect(getCurrentEmployer()).toBeNull();
+    expect(getCurrentEmployer(null)).toBeNull();
+  });
+});
+
+describe('isCurrentlyEmployed', () => {
+  it('returns true when any job has no endDate', () => {
+    expect(isCurrentlyEmployed(work)).toBe(true);
+  });
+
+  it('returns false when every job has ended', () => {
+    expect(
+      isCurrentlyEmployed([
+        { name: 'A', startDate: '2018-01-01', endDate: '2021-01-01' },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for empty, missing, or non-array input', () => {
+    expect(isCurrentlyEmployed([])).toBe(false);
+    expect(isCurrentlyEmployed()).toBe(false);
+    expect(isCurrentlyEmployed(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`@jsonresume/core` had a vitest `test` script but zero test files, so `vitest run` exited 1 with "No test files found". This adds a real unit suite for the calculation helpers split in #280 and makes the package test green.

Part of the consolidation/health work tracked in #275.

## What's covered

6 test files under `packages/resume-core/src/helpers/__tests__/` — **68 tests**, all passing:

- `experience.test.js` — calculateTotalExperience, calculateCurrentRoleExperience, countCareerPositions, getCareerProgressionRate, countTotalHighlights
- `counts.test.js` — countCompanies, countProjects, countPublications, countAwards, countTotalSkills, countSkillCategories, countLanguages
- `education.test.js` — calculateEducationYears, getHighestDegree
- `workHistory.test.js` — calculateVolunteerYears, getUniqueIndustries, getCurrentEmployer, isCurrentlyEmployed
- `keyMetrics.test.js` — calculateKeyMetrics (full resume, empty resume, partial sections, multilingual gate, throws on undefined)
- `calculations.test.js` — asserts the barrel re-exports **exactly the 19 helper names**, all functions, same implementations as the focused modules

Shared `fixtures.js` provides a compact populated resume with deterministic dates; `vi.setSystemTime` pins "now" (2026-01-01) so open-ended entries (no `endDate`) are stable. Edge cases per function: empty array, missing argument, `null`/non-array input, missing dates, missing fields, single entries, duplicates.

## Known bug documented (NOT fixed here)

`calculateEducationYears` divides by `((1000 * 60 * 60 * 24) / 365.25)` instead of multiplying, so it returns `days * 365.25` — inflating results by ~133,000x (a ~5.5-year education reports **733,057** "years"). The bug predates #280 and survived the split. Tests lock in current behavior with an explanatory comment so the fix (a separate PR) will show up as a deliberate assertion change.

## Verification

- `pnpm install --frozen-lockfile` (no dependency changes; vitest was already a devDep)
- `pnpm --filter @jsonresume/core test` → 6 files, 68 tests passed, exit 0
- `pnpm turbo lint typecheck prettier` → exit 0

Refs #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for resume calculation and analysis helpers, including experience metrics, education assessment, work history analysis, skill quantification, and key resume analytics.
  * Added standardized test fixtures to support consistent validation of helper functions across various resume sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->