### PR TITLE
fix(homepage2): emit real <title> + meta description via App Router metadata (closes #273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **Org/Repo:** `jsonresume/jsonresume.org` — ALWAYS use `owner: "jsonresume"`
 - **Stack:** Next.js monorepo (Turborepo + pnpm), Vercel deployment, Supabase DB (`registry`)
-- **AI SDK:** Use Vercel AI SDK v5 (`ai` + `@ai-sdk/openai`), never vendor SDKs directly
+- **AI SDK:** Use Vercel AI SDK v6 (`ai` + `@ai-sdk/openai`), never vendor SDKs directly
 
 ## Code Standards
 

--- a/apps/homepage2/app/layout.js
+++ b/apps/homepage2/app/layout.js
@@ -7,10 +7,16 @@ import { Footer } from './components/layout/Footer';
 import { ExternalScripts } from './components/layout/ExternalScripts';
 import './global.css';
 
+export const metadata = {
+  title: 'JSON Resume',
+  description:
+    'JSON Resume is the open-source initiative to create a JSON-based standard for resumes. For developers, by developers.',
+};
+
 export default async function Layout({ children }) {
   return (
     <html lang="en" className={fontVariables}>
-      <head title="JSON Resume">
+      <head>
         <link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
         <link rel="dns-prefetch" href="//static.getclicky.com" />
         {(process.env.NODE_ENV === 'development' ||
@@ -40,7 +46,6 @@ export default async function Layout({ children }) {
 
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-        <meta name="description" content="{{site.description}}" />
         <link rel="shortcut icon" href="/img/favicon.png" />
 
         <link


### PR DESCRIPTION
## Problem (#273)

The production homepage shipped **no `<title>` element at all**. Root cause in `apps/homepage2/app/layout.js`:

- `<head title="JSON Resume">` — a bogus `title` **attribute** on the `<head>` element (invalid HTML, ignored by browsers), not a `<title>` element.
- `<meta name="description" content="{{site.description}}" />` — literal unrendered Jekyll-era template junk emitted into production HTML.

## Fix

App-Router-correct metadata in the root layout:

- `export const metadata = { title: 'JSON Resume', description: '…' }` using the actual homepage tagline ("The open-source initiative to create a JSON-based standard for resumes. For developers, by developers.").
- Removed the invalid `title` attribute and the `{{site.description}}` meta tag.
- Child pages (`/themes`, `/getting-started`, `/ai`, etc.) already export their own **full** titles (e.g. `Themes — JSON Resume`), so the root provides a plain default — no `title.template`, which would have doubled the suffix.

Also fixes doc drift flagged during the #275 consolidation audit: `CLAUDE.md` said "Vercel AI SDK v5" but the registry is on `ai ^6.0.116` — updated to v6.

## Verification

- `pnpm --filter homepage2 build` succeeds.
- Built `.next/server/app/index.html` now contains `<title>JSON Resume</title>` and the real meta description; zero `{{site.description}}` occurrences.
- Child page titles unchanged (`<title>Themes — JSON Resume</title>`).
- `pnpm turbo lint typecheck prettier` exits 0.

Refs #275.

Closes #273