### PR TITLE
docs: add community health files (contributing, CoC, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 💬 GitHub Discussions
     url: https://github.com/jsonresume/jsonresume.org/discussions
     about: Ask questions and discuss ideas with the community
+  - name: 📖 Registry API Docs
+    url: https://registry.jsonresume.org/api/docs
+    about: Read the hosted registry API documentation
   - name: 🔒 Security Vulnerability
     url: https://github.com/jsonresume/jsonresume.org/security/advisories/new
     about: Report security vulnerabilities privately (DO NOT create a public issue)

--- a/.github/ISSUE_TEMPLATE/theme_request.yml
+++ b/.github/ISSUE_TEMPLATE/theme_request.yml
@@ -1,0 +1,37 @@
+name: 🎨 Theme Request
+description: Request that a JSON Resume theme be added to the registry
+title: '[Theme]: '
+labels: ['theme']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want a theme added to the registry? Themes must be serverless-compatible (no `fs` usage). See `docs/AGENT_THEME_DEVELOPMENT.md`.
+  - type: input
+    id: name
+    attributes:
+      label: Theme name
+      placeholder: jsonresume-theme-example
+    validations:
+      required: true
+  - type: input
+    id: npm
+    attributes:
+      label: npm package
+      placeholder: https://www.npmjs.com/package/jsonresume-theme-example
+    validations:
+      required: true
+  - type: input
+    id: repo
+    attributes:
+      label: Source repository
+      placeholder: https://github.com/user/jsonresume-theme-example
+    validations:
+      required: true
+  - type: checkboxes
+    id: serverless
+    attributes:
+      label: Compatibility
+      options:
+        - label: This theme does not use `fs` or other filesystem operations
+          required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), version 2.1.
+
+We are committed to providing a welcoming and harassment-free experience for everyone. By participating, you agree to uphold these standards.
+
+To report unacceptable behavior, contact the maintainers at [@thomasdavis](https://github.com/thomasdavis) or via the [GitHub Discussions](https://github.com/jsonresume/jsonresume.org/discussions). All reports are handled confidentially.
+
+The full text is available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ We welcome contributions from the community! Here's how you can help:
 
 Please make sure to follow our code style and include appropriate tests for your changes.
 
+Before opening a PR, please read our [Contributing Guide](CONTRIBUTING.md) for the full setup, checks, and conventions. All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md), and security issues should be reported per our [Security Policy](SECURITY.md).
+
 ## Contributors
 
 [![Contributors](https://4.vercel.app/github/contributors/jsonresume/jsonresume.org?strokeopacity=1)](https://github.com/jsonresume/jsonresume.org/graphs/contributors)


### PR DESCRIPTION
## Description

Adds the remaining community-health files to round out the repo's contributor experience. CONTRIBUTING.md, SECURITY.md, the bug/feature issue templates, and the PR template already exist on `master`, so this PR fills the gaps:

- **CODE_OF_CONDUCT.md** — short policy adopting [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) by reference (not inlined).
- **.github/ISSUE_TEMPLATE/theme_request.yml** — minimal issue form for requesting a theme be added to the registry (links to the serverless-compatibility guide).
- **.github/ISSUE_TEMPLATE/config.yml** — set `blank_issues_enabled: true` and added a contact link to the registry API docs.
- **README.md** — added a short paragraph in the Contributing section linking CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md. (CI + license badges were already present near the top.)

Existing large files were intentionally left untouched to avoid removing content.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm turbo lint typecheck prettier` — exit 0 (18/18 tasks)
- `pnpm --filter registry test -- --run` — 1318 passed
- `prettier -c .` — all files formatted

## Related

Part of the org-consolidation tracking effort, #275.