### PR TITLE
ci: run CI on pull_request (fork PRs currently get zero required checks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches: [master]
+  pull_request:
   merge_group:
 
 env:


### PR DESCRIPTION
ci.yml only triggered on `push` + `merge_group`, so fork PRs never received the 6 required status checks — community PRs (#269/#282/#272) are permanently BLOCKED and auto-merge can never fire. This adds `pull_request` and restricts `push` to `master` (same-repo PR branches previously double-covered by push now run once via pull_request). Note: fork runs get empty secrets — turbo remote-cache falls back with a warning; that's acceptable advisory signal. Part of #275.