### PR TITLE
docs: refresh package READMEs for the consolidated monorepo

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,18 +1,14 @@
 # resume-cli
 
-[![matrix](https://img.shields.io/badge/matrix-join%20chat-%230dbd8b)](https://matrix.to/#/#json-resume:one.ems.host)
-[![Build status](https://img.shields.io/github/actions/workflow/status/jsonresume/resume-cli/test.yml?branch=master)](https://github.com/jsonresume/resume-cli/actions)
 [![npm package](https://badge.fury.io/js/resume-cli.svg)](https://www.npmjs.org/package/resume-cli)
 
 This is the command line tool for [JSON Resume](https://jsonresume.org), the open-source initiative to create a JSON-based standard for resumes.
 
-## Project Status
-
-This repository is not actively maintained. It's recommended to use one of the third-party clients that support the JSON Resume standard instead:
-
-* [Resumed](https://github.com/rbardini/resumed)
+> **Note:** `resume-cli` has been revived and now lives in the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org) as `packages/cli` (modernized for Node.js 18+). It keeps its npm identity as [`resume-cli`](https://www.npmjs.com/package/resume-cli) and is published from this workspace. The old standalone [jsonresume/resume-cli](https://github.com/jsonresume/resume-cli) repository is archived — please open issues and PRs against the monorepo.
 
 ## Getting Started
+
+Requires Node.js 18 or newer.
 
 Install the command-line tool:
 
@@ -90,6 +86,17 @@ Supported resume data MIME types are:
 
 - `application/json`
 - `text/yaml`
+
+## Development
+
+This package is part of the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org). From `packages/cli`:
+
+```
+pnpm dev    # run the CLI from source (babel-node lib/main.js)
+pnpm build  # compile lib/ to build/ with Babel
+pnpm test   # run the Jest test suite
+pnpm lint   # run ESLint
+```
 
 ## License
 

--- a/packages/core-rust/README.md
+++ b/packages/core-rust/README.md
@@ -1,15 +1,20 @@
-# json-resume
+# json-resume-serde
 
-A Rust implementation of the [JSON Resume schema](https://github.com/jsonresume/resume-schema/blob/master/schema.json) with Serde and Validate support for serialization and deserialization.
+A Rust implementation of the [JSON Resume schema](https://jsonresume.org/schema/) with [Serde](https://serde.rs/) and [`serde_valid`](https://crates.io/crates/serde_valid) support for serialization, deserialization, and validation.
+
+This crate provides strongly-typed Rust structs (`Resume`, `Basics`, `Work`, etc.) that mirror the JSON Resume schema, so you can parse a `resume.json`, validate it, and serialize it back out with full type safety.
+
+> **Note:** This crate is part of the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org) as `packages/core-rust`. The types here are kept in sync with the canonical schema in [`packages/schema`](../schema) (`@jsonresume/schema`); when the schema changes, update these structs and their validation rules to match. Publishing to [crates.io](https://crates.io) is TBD — for now, depend on it via a Git or path dependency. Please open issues and PRs against the monorepo.
 
 ## Usage
 
 ### From Serialized JSON
+
 ```rs
 use serde_valid::Validate;
 
 #[axum::debug_handler]
-async fn post(Json(resume): Json<json_resume::Resume>) -> Result<Json<Resume>, ResumeError> {
+async fn post(Json(resume): Json<json_resume_serde::Resume>) -> Result<Json<Resume>, ResumeError> {
 
    let result = resume.validate()
 
@@ -20,15 +25,16 @@ async fn post(Json(resume): Json<json_resume::Resume>) -> Result<Json<Resume>, R
 ```
 
 ### Build manually
+
 ```rs
 use serde_valid::Validate;
 
-    let resume = json_resume::Resume {
-        basics: Some(json_resume::Basics {
+    let resume = json_resume_serde::Resume {
+        basics: Some(json_resume_serde::Basics {
             //...
         }),
         work: vec![
-            json_resume::Work {
+            json_resume_serde::Work {
                 // ...
             }
         ],
@@ -46,7 +52,6 @@ use serde_valid::Validate;
 
     resume.validate().unwrap();
 ```
-
 
 ## License
 

--- a/packages/eslint-config-custom/README.md
+++ b/packages/eslint-config-custom/README.md
@@ -1,0 +1,25 @@
+# @repo/eslint-config-custom
+
+Shared ESLint configuration for the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org). It centralizes lint rules (extending `eslint:recommended`, `prettier`, and `next`, plus TypeScript and React variants) so every app and package lints consistently.
+
+## Usage
+
+Extend the appropriate config from a package's `.eslintrc`:
+
+```js
+module.exports = {
+  root: true,
+  extends: ['@repo/eslint-config-custom/next'],
+};
+```
+
+Available configs:
+
+- `@repo/eslint-config-custom` — base config (`index.js`)
+- `@repo/eslint-config-custom/next` — Next.js apps
+- `@repo/eslint-config-custom/react` — React libraries
+- `@repo/eslint-config-custom/typescript` — TypeScript projects
+
+## Part of the jsonresume.org monorepo
+
+Report issues in the [monorepo issue tracker](https://github.com/jsonresume/jsonresume.org/issues).

--- a/packages/schema/README.md
+++ b/packages/schema/README.md
@@ -38,8 +38,8 @@ resumeSchema.validate(
 Or against a full `resume.json`
 
 ```js
-import fs = require('fs');
-import schema from 'resume-schema';
+const fs = require('fs');
+const resumeSchema = require('@jsonresume/schema');
 const resumeObject = JSON.parse(fs.readFileSync('./resume.json', 'utf8'));
 resumeSchema.validate(resumeObject);
 ```
@@ -47,12 +47,12 @@ resumeSchema.validate(resumeObject);
 The JSON Resume schema is available from:
 
 ```js
-require("resume-schema").schema;
+require('@jsonresume/schema').schema;
 ```
 
 ### Contribute
 
-We encourage anyone who's interested in participating in the formation of this standard to join the discussions [here on GitHub](https://github.com/jsonresume/resume-schema/issues). Also feel free to fork this project and submit new ideas to add to the JSON Resume Schema standard. To make sure all formatting is kept in check, please install the [EditorConfig plugin](http://editorconfig.org/) for your editor of choice.
+We encourage anyone who's interested in participating in the formation of this standard to join the discussions [here on GitHub](https://github.com/jsonresume/jsonresume.org/issues). Also feel free to fork this project and submit new ideas to add to the JSON Resume Schema standard. To make sure all formatting is kept in check, please install the [EditorConfig plugin](http://editorconfig.org/) for your editor of choice.
 
 ### Versioning
 
@@ -65,14 +65,7 @@ a major-version release. As a result of this policy, you can (and should)
 specify any dependency on JSON Resume Schema by using the Pessimistic Version
 Constraint with two digits of precision.
 
-We use automatic semver system.
-
-Pull requests titles should be formatted as such
-
-```
-"fix: added something" - will bump the patch version
-"feat: added something" - will bump the minor version
-```
+Releases are managed from the monorepo with [Changesets](https://github.com/changesets/changesets). Add a changeset describing your change and the appropriate version bump (`patch`/`minor`/`major`) in the same pull request.
 
 `major` version bumps will be few and far between for this schema.
 
@@ -83,7 +76,7 @@ A draft schema for job descriptions is available in this project as well. It is 
 The JSON Job schema is available from:
 
 ```js
-require("resume-schema").jobSchema;
+require('@jsonresume/schema').jobSchema;
 ```
 
 ### Other resume standards

--- a/packages/theme-config/README.md
+++ b/packages/theme-config/README.md
@@ -1,0 +1,25 @@
+# @repo/theme-config
+
+Shared theme configuration and metadata for JSON Resume themes. This package exposes the theme metadata (names, display info, helpers like `getRandomTheme`) consumed by both the `registry` and `homepage2` apps in the monorepo.
+
+This is a private, internal workspace package (`@repo/theme-config`) — it is not published to npm.
+
+## Usage
+
+```js
+import { THEME_METADATA, THEME_NAMES, getRandomTheme } from '@repo/theme-config';
+```
+
+Metadata is also available directly via `@repo/theme-config/metadata`.
+
+## Development
+
+From `packages/theme-config`:
+
+```
+pnpm lint   # run ESLint
+```
+
+## Part of the jsonresume.org monorepo
+
+See the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org). Report issues in the [monorepo issue tracker](https://github.com/jsonresume/jsonresume.org/issues).

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,23 @@
+# tsconfig
+
+Shared TypeScript configurations for the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org). Apps and packages extend these base configs instead of duplicating compiler options.
+
+## Usage
+
+Reference the relevant config from a package's `tsconfig.json`:
+
+```json
+{
+  "extends": "tsconfig/nextjs.json"
+}
+```
+
+Available configs:
+
+- `base.json` — default base compiler options
+- `nextjs.json` — Next.js apps
+- `react-library.json` — React libraries
+
+## Part of the jsonresume.org monorepo
+
+Report issues in the [monorepo issue tracker](https://github.com/jsonresume/jsonresume.org/issues).

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,1 +1,30 @@
-# `@repo/ui`
+# @repo/ui
+
+Shared React UI component library for the [jsonresume.org monorepo](https://github.com/jsonresume/jsonresume.org). Built on [Radix UI](https://www.radix-ui.com/) primitives and Tailwind CSS (shadcn-style), it provides the buttons, inputs, and other components used across the `registry` and `homepage2` apps.
+
+This is a private, internal workspace package (`@repo/ui`) consumed via the pnpm workspace — it is not published to npm.
+
+## Usage
+
+Import components from the package barrel within the monorepo:
+
+```js
+import { Button } from '@repo/ui';
+```
+
+Individual components are also reachable directly (e.g. `@repo/ui/components/button`), and styles are exported via `@repo/ui/styles.css` (alias `@repo/ui/globals.css`).
+
+## Development
+
+From `packages/ui`:
+
+```
+pnpm storybook        # run Storybook on port 6006
+pnpm build-storybook  # build the static Storybook
+pnpm lint             # run ESLint
+pnpm ui:add           # add a shadcn-ui component
+```
+
+## Issues
+
+Report bugs and request features in the [monorepo issue tracker](https://github.com/jsonresume/jsonresume.org/issues).


### PR DESCRIPTION
## Summary

Refreshes the package-level READMEs now that the org has consolidated into this monorepo (tracking #275). Removes references to the archived standalone repos, repoints issue/contribution/CI links at the monorepo, and adds minimal accurate READMEs where they were missing.

Scope was limited to `packages/*` (excluding `packages/themes/*`). The root README and `apps/*` are owned by a parallel effort and were not touched.

## Changes per package

- **packages/schema** — kept the moved-here banner and all spec content; swept the body for stale `github.com/jsonresume/resume-schema` links and repointed the Contribute link at the monorepo issue tracker; updated the `require('resume-schema')` usage examples to the current `@jsonresume/schema` package name; replaced the semantic-release-era "automatic semver" note with the Changesets workflow now used in the monorepo.
- **packages/cli** — added a top note that `resume-cli` has been revived and now lives in the monorepo as `packages/cli` (Node.js 18+); removed the dead "not actively maintained" status block and the dead matrix/CI badges pointing at the archived repo; kept the correct `npm install -g resume-cli` instructions; added a Development section with the verified `pnpm dev/build/test/lint` commands; pointed issues at the monorepo. (Note: `packages/cli` is `.prettierignore`d — it carries its own toolchain.)
- **packages/core-rust** — states it is part of the monorepo, documents what the crate does (Serde types + `serde_valid` validation for the schema), how it tracks `packages/schema`, and that crates.io publishing is TBD; corrected the crate path in the examples from `json_resume::` to the actual `json_resume_serde::` (crate `json-resume-serde`, structs re-exported at the crate root).
- **packages/ui** — replaced the one-line stub with a real README (purpose, barrel-import usage verified against the codebase, Storybook/lint dev commands, monorepo + issues note).
- **packages/theme-config**, **packages/eslint-config-custom**, **packages/tsconfig** — added minimal accurate READMEs (purpose, verified exports/usage, dev/lint commands, monorepo + issues note).

`packages/resume-core`, `packages/ats-validator`, and `packages/job-search` already had accurate, comprehensive READMEs with no stale references and issues pointed at the monorepo, so they were left unchanged.

## Verification

```
PUPPETEER_SKIP_DOWNLOAD=true pnpm install --frozen-lockfile   # ok
pnpm turbo prettier      # All matched files use Prettier code style (exit 0)
pnpm turbo typecheck     # 3 successful (exit 0)
```

`pnpm turbo lint` has one failure, `@repo/ui#lint`, which is pre-existing on `master` (an ESLint 8.57 "Converting circular structure to JSON" error from the eslint-config-custom flat/legacy config) and is unrelated to these docs-only changes — it reproduces identically with this branch stashed. READMEs do not affect ESLint.

Refs #275

Do not merge — for review.