### PR TITLE
chore(turbo): declare empty outputs for no-artifact tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -50,7 +50,7 @@
         "tsconfig.json",
         "tsconfig*.json"
       ],
-      "outputs": ["node_modules/.cache/.eslintcache"]
+      "outputs": []
     },
     "typecheck": {
       "inputs": [
@@ -61,7 +61,7 @@
         "tsconfig.json",
         "tsconfig*.json"
       ],
-      "outputs": ["node_modules/.cache/tsbuildinfo"]
+      "outputs": []
     },
     "check": {
       "dependsOn": ["lint", "typecheck"]
@@ -77,10 +77,14 @@
         "vitest.config.*",
         "vitest.setup.*"
       ],
-      "outputs": ["coverage/**"]
+      "outputs": []
     },
-    "//#format": {},
-    "//#prettier": {},
+    "//#format": {
+      "outputs": []
+    },
+    "//#prettier": {
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Problem

Every CI run logs a dozen+ lines like:

```
WARNING  no output files found for task <pkg>#lint. Please check your outputs key in turbo.json
```

This happens for tasks whose declared `outputs` globs match nothing during CI runs:
- `lint` declared `node_modules/.cache/.eslintcache` (only written with `eslint --cache`)
- `typecheck` declared `node_modules/.cache/tsbuildinfo` (only written with `--incremental`/composite)
- `test` declared `coverage/**` (only written with `--coverage`; the unit run uses `vitest --run`)
- `//#format` and `//#prettier` had no `outputs` key at all

## Fix

For tasks that genuinely produce no artifacts, declare `"outputs": []` — turbo's documented way to say "cache the logs only" — which silences the warning.

- `lint`, `typecheck`, `test`: `outputs` -> `[]`
- `//#format`, `//#prettier`: add `"outputs": []`
- `build` outputs left unchanged
- No task dependency graphs changed (`build.dependsOn`, `check.dependsOn` untouched)

JSON validated with `node -e "require('./turbo.json')"`. PR CI exercises the full pipeline.

Refs #275

— AI