### PR TITLE
chore: set npm publish boundaries

### DIFF
--- a/apps/docs/content/docs/002-repository-structure.md
+++ b/apps/docs/content/docs/002-repository-structure.md
@@ -212,7 +212,7 @@ This package provides utilities for validating Applicant Tracking System (ATS) c
 
 ### Key Points
 
-- Named `@resume/ats-validator`.
+- Named `@jsonresume/ats-validator`.
 - Exports a module with main entry `src/index.js`.
 - Depends on `cheerio` for HTML parsing.
 - Dev dependency on Vitest for testing.

--- a/packages/ats-validator/README.md
+++ b/packages/ats-validator/README.md
@@ -1,4 +1,4 @@
-# @resume/ats-validator
+# @jsonresume/ats-validator
 
 **Machine-readable ATS compatibility validation for resume HTML**
 
@@ -15,13 +15,13 @@ Validate resume HTML against ATS (Applicant Tracking System) best practices with
 ## Installation
 
 ```bash
-npm install @resume/ats-validator
+npm install @jsonresume/ats-validator
 ```
 
 ## Quick Start
 
 ```javascript
-import { validateATS, getRecommendations } from '@resume/ats-validator';
+import { validateATS, getRecommendations } from '@jsonresume/ats-validator';
 
 const html = `
   <!DOCTYPE html>
@@ -192,7 +192,7 @@ Validate themes built with @resume/core:
 
 ```javascript
 import { render } from 'jsonresume-theme-modern-classic';
-import { validateATS } from '@resume/ats-validator';
+import { validateATS } from '@jsonresume/ats-validator';
 
 const html = render(resumeData);
 const result = validateATS(html);

--- a/packages/ats-validator/package.json
+++ b/packages/ats-validator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@resume/ats-validator",
+  "name": "@jsonresume/ats-validator",
   "version": "0.1.0",
   "description": "ATS (Applicant Tracking System) validation utilities for resume HTML",
   "type": "module",

--- a/packages/ats-validator/src/index.js
+++ b/packages/ats-validator/src/index.js
@@ -1,5 +1,5 @@
 /**
- * @resume/ats-validator
+ * @jsonresume/ats-validator
  * Machine-readable validation rules for ATS-friendly resume HTML
  *
  * Based on research:

--- a/packages/themes/jsonresume-theme-reference/README.md
+++ b/packages/themes/jsonresume-theme-reference/README.md
@@ -46,7 +46,7 @@ const html = render(resume);
 
 ```javascript
 import { render } from 'jsonresume-theme-reference';
-import { validateATS } from '@resume/ats-validator';
+import { validateATS } from '@jsonresume/ats-validator';
 import fs from 'fs';
 
 // Complete JSON Resume with all 11 sections
@@ -285,11 +285,11 @@ const html = render(minimalResume); // No errors, renders what's available
 
 ## ATS Validation Integration
 
-This theme is built following ATS-friendly guidelines. You can validate any theme output using `@resume/ats-validator`:
+This theme is built following ATS-friendly guidelines. You can validate any theme output using `@jsonresume/ats-validator`:
 
 ```javascript
 import { render } from 'jsonresume-theme-reference';
-import { validateATS } from '@resume/ats-validator';
+import { validateATS } from '@jsonresume/ats-validator';
 
 const resume = { /* your resume data */ };
 const html = render(resume);


### PR DESCRIPTION
## Set npm publish boundaries

Merging the pending "Version Packages" PR (#327) runs `changeset publish`, which publishes **every** non-private workspace package whose version is not already on npm. This PR audits every workspace package against npm and fixes the one boundary problem so only intended packages publish.

Refs #275.

### Change in this PR

- **Rename `@resume/ats-validator` -> `@jsonresume/ats-validator`.** The `@resume` scope is **not ours**; the package is unpublished. Renamed under our scope so the first publish lands in the right place. Updated the package name, the `src/index.js` header, and every doc/README reference (`packages/ats-validator/README.md`, `packages/themes/jsonresume-theme-reference/README.md`, `apps/docs/content/docs/002-repository-structure.md`). No code consumer imported it yet, so the lockfile needs no change (importers are keyed by path).

No other source changes were required: every other public package is ours and version-matched (publish would be a no-op skip), and every non-ours / infra package is already `private: true`.

### Publish plan

#### willPublish (first-publish on next release)

| Package | Local version | npm | Reason |
|---|---|---|---|
| `@jsonresume/ats-validator` | 0.1.0 | 404 (renamed from `@resume/ats-validator`) | First publish under our scope; has `main` + `publishConfig.access=public` |

> Note: `jsonresume-theme-operations-precision` (ours, thomasdavis) is 0.1.0 on npm == 0.1.0 in-tree, so it is a skip **as cloned**. The pending changeset `add-markdown-rendering-operations-precision` bumps it to 0.2.0; once #327 applies that bump it will publish 0.2.0 — intended.

#### markedPrivate (set / kept `private: true` this release)

_None._ Every package that needed to be private already is. For the record, the non-ours packages confirmed correctly private:

| Package | npm owner |
|---|---|
| `jsonresume-theme-flat` (vendored copy) | erming |
| `tsconfig` (unscoped) | basarat / blakeembrey |

#### Infra — already `private: true` (never publish)

`docs` (apps/docs), `homepage2`, `registry`, `docs` (apps/registry/apps/docs), `@repo/ui`, `@repo/eslint-config-custom`, `@repo/theme-config`, `tsconfig`, plus WIP themes `jsonresume-theme-claude`, `jsonresume-theme-creative-confidence`, `jsonresume-theme-tailwind`, and the vendored `jsonresume-theme-flat`.

#### skippedSameVersion (published, ours, in-tree version == npm version)

`resume-cli` 3.1.2, `@jsonresume/schema` 1.2.1, `@jsonresume/core` 0.1.0, `@jsonresume/jobs` 0.14.1, `@jsonresume/jsonresume-to-rendercv` 1.0.13, `@jsonresume/theme-stackoverflow` 2.1.2, `@jsonresume/jsonresume-theme-professional` 1.0.19, `@jsonresume/jsonresume-theme-consultant-polished` 1.0.1, `@jsonresume/jsonresume-theme-creative-studio` 1.0.1, `@jsonresume/jsonresume-theme-tokyo-modernist` 1.0.1, and the unscoped themes `academic-cv-lite` 0.1.0, `architects-portfolio` 1.0.0, `asymmetric-timeline` 1.0.0, `berlin-grid` 0.1.0, `bold-header-statement` 1.0.0, `californian-warm` 0.1.0, `coastal-creative` 0.1.0, `community-garden` 0.1.0, `data-driven` 0.1.0, `desert-modern` 0.1.0, `developer-mono` 0.1.0, `diagonal-accent-bar` 1.0.0, `elegant-pink` 0.1.0, `executive-slate` 1.0.0, `french-atelier` 0.1.0, `government-standard` 0.1.0, `graph-paper-grid` 1.0.0, `investor-brief` 0.1.0, `london-bureau` 0.1.0, `marketing-narrative` 0.1.0, `mid-century-resume` 1.0.0, `minimalist-grid` 0.1.0, `modern-classic` 1.0.0, `monochrome-noir` 1.0.0, `new-york-editorial` 0.1.0, `nordic-minimal` 1.0.0, `operations-precision` 0.1.0, `pacific-horizon` 0.1.0, `product-manager-canvas` 0.1.0, `reference` 0.1.0, `sales-hunter` 0.1.0, `sidebar` 0.1.0, `sidebar-photo-strip` 1.0.0, `two-column-modernist` 1.0.0, `typewriter-modern` 1.0.0, `university-first` 0.1.0, `urban-techno` 0.1.0, `writers-portfolio` 0.1.0.

All published packages are maintained by thomasdavis (themes) or thomasdavis/levino/sethiii (scoped pkgs), versions verified against npm.

### Verification

- `PUPPETEER_SKIP_DOWNLOAD=true pnpm install` — success, lockfile consistent
- `pnpm turbo lint typecheck prettier` — exit 0 (18/18 tasks)
- `pnpm --filter registry test -- --run` — green (1318 passed, 24 pre-existing skips)
- `pnpm --filter @jsonresume/ats-validator test` — green (16 passed)

Do **not** merge until the publish plan above is confirmed — it gates the real publish.

— AI
