### PR TITLE
docs: RELEASING.md + OIDC trusted-publishing prep

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -29,9 +29,18 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# Job-level permissions for the GITHUB_TOKEN. changesets/action needs
+# contents:write + pull-requests:write to open/update the "Version Packages" PR
+# (though that PR is actually created via the App token below). id-token:write
+# enables npm Trusted Publishing (OIDC): once a package registers this repo +
+# workflow as a Trusted Publisher on npmjs.com, npm exchanges this short-lived
+# OIDC token for publish auth — no NPM_TOKEN needed for that package. It is
+# harmless for packages that have not yet been registered (they keep using the
+# token). See docs/RELEASING.md.
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -54,6 +63,15 @@ jobs:
           node-version: 20
           cache: pnpm
           registry-url: https://registry.npmjs.org
+
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.0. setup-node with
+      # node 20 ships npm 10, which silently falls back to token auth and cannot
+      # use the id-token:write permission above. Upgrading the global npm CLI is
+      # the activation step for OIDC publishing. This is publish-tooling only —
+      # it does not touch pnpm or the `pnpm changeset publish` command, and is a
+      # no-op for packages still using NPM_TOKEN. See docs/RELEASING.md.
+      - name: Upgrade npm for Trusted Publishing (OIDC)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -688,6 +688,7 @@ We'll review and add it to the registry!
 - [Architecture Documentation](CLAUDE.md)
 - [Security Policy](SECURITY.md)
 - [Project Audit](PROJECT_AUDIT.md)
+- [Releasing npm Packages](docs/RELEASING.md)
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing npm Packages
+
+The monorepo's publishable packages are released with [Changesets](https://github.com/changesets/changesets) via the **Release Packages** workflow (`.github/workflows/release-packages.yml`).
+
+## How a release works
+
+1. **Add a changeset** with your PR: run `pnpm changeset`, pick the bumped packages and semver level, and commit the generated file in `.changeset/`.
+2. **Merge to `master`.** The workflow sees the pending changeset and opens (or updates) a **"Version Packages"** PR that bumps versions and updates changelogs (`pnpm changeset version`).
+3. **Merge the Version Packages PR.** With no pending changesets left, the next run publishes the new versions to npm (`pnpm changeset publish`).
+
+The "Version Packages" PR is created with a GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`) so that CI checks run on it — the default `GITHUB_TOKEN` cannot trigger workflows on its own PRs.
+
+## Manual dispatch
+
+The workflow also runs on demand:
+
+```bash
+gh workflow run release-packages.yml
+```
+
+Use this to retry a publish after fixing auth, or to publish versions that were merged while the workflow was misconfigured.
+
+## Auth: token vs. Trusted Publishing (OIDC)
+
+Publishing currently authenticates with the `NPM_TOKEN` repo secret (an npm automation token from the `thomasdavis` account). We are migrating packages to **Trusted Publishing**, where npm trades the workflow's short-lived OIDC token (`id-token: write`) for publish auth — no long-lived token required.
+
+> **Note:** OIDC requires **npm >= 11.5.0**. `actions/setup-node` (node 20) ships npm 10, so the workflow has an `npm install -g npm@latest` step that activates OIDC. This is harmless for token-based publishes.
+
+### Legacy-package gotcha (first version bump)
+
+Packages first published years ago default to **publishing access: "Require two-factor authentication or an automation token"**, which still works. But some legacy packages are set to **disallow tokens** (`Require two-factor authentication and disallow tokens`). The automation token cannot publish those, and the first bump fails with `403`.
+
+Fix it one of two ways:
+
+- **Quick flip (manual):** npmjs.com → the package → **Settings** → **Publishing access** → set to **"Require two-factor authentication or an automation token"** → publish → (optionally re-tighten after migrating to OIDC).
+- **Proper fix:** register the package for Trusted Publishing (below), which removes the token dependency entirely.
+
+### Trusted Publishing migration recipe (per package)
+
+For each package you want to move off the token:
+
+1. Go to **npmjs.com → the package → Settings → Trusted Publisher**.
+2. Choose **GitHub Actions** as the publisher.
+3. Set:
+   - **Repository:** `jsonresume/jsonresume.org`
+   - **Workflow filename:** `release-packages.yml`
+   - (Leave environment blank — the workflow does not use a GitHub Environment.)
+4. Save.
+
+Once registered, that package publishes via OIDC and no longer needs `NPM_TOKEN`. Migrate every package, then the token can be retired. Unregistered packages keep using the token, so migration can be incremental.
+
+## Files
+
+- Workflow: [`.github/workflows/release-packages.yml`](../.github/workflows/release-packages.yml)
+- Changesets config: [`.changeset/`](../.changeset/)
+- Tracking issue: [#275](https://github.com/jsonresume/jsonresume.org/issues/275)


### PR DESCRIPTION
Prep for npm Trusted Publishing (OIDC) and document the release process. Refs #275.

## Workflow (`.github/workflows/release-packages.yml`)
- Add `id-token: write` to `permissions` so packages can opt into npm Trusted Publishing once registered. Harmless for packages still on `NPM_TOKEN`.
- Add an `npm install -g npm@latest` step. OIDC requires npm >= 11.5; `setup-node` (node 20) ships npm 10, which silently falls back to token auth. This is the activation step and is publish-tooling only — `pnpm changeset publish` is **unchanged**.
- Inline comments explain both.

## Docs
- New `docs/RELEASING.md`: how releases work (changeset → Version Packages PR → merge → publish), manual dispatch (`gh workflow run release-packages.yml`), the legacy disallow-tokens publishing-access gotcha (exact npm Settings path + toggle name), and the per-package Trusted Publisher migration recipe (`jsonresume/jsonresume.org` + `release-packages.yml`).
- Linked from `CONTRIBUTING.md`.

## Verification
- Workflow YAML parses (python `yaml.safe_load`) and passes `prettier --check`.
- Markdown formatted with the repo-pinned `prettier@2.8.0`.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive release process documentation for npm packages
  * Updated contributing guidelines with release resources

* **Chores**
  * Enhanced package publishing workflow with improved security measures and npm CLI updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->