### PR TITLE
test(e2e): smoke coverage for homepage2 and docs

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -1,0 +1,5 @@
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
-    "typecheck": "fumadocs-mdx && tsc --noEmit"
+    "typecheck": "fumadocs-mdx && tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "fumadocs-core": "^16.0.0",

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * homepage2 and docs both default to port 3002, so this app is pinned to
+ * 3103 to avoid a port clash when turbo runs every app's e2e suite together.
+ */
+const PORT = 3103;
+
+export default defineConfig({
+  webServer: {
+    command: `pnpm exec next dev --port ${PORT}`,
+    url: `http://localhost:${PORT}/docs`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/docs/tests/smoke.spec.ts
+++ b/apps/docs/tests/smoke.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('docs landing renders the Fumadocs shell and a heading', async ({
+  page,
+}) => {
+  await page.goto('/docs');
+
+  // Fumadocs nav renders the configured site title as a home link.
+  await expect(
+    page.getByRole('link', { name: 'Docwright' }).first()
+  ).toBeVisible();
+
+  await expect(
+    page.getByRole('heading', { name: 'Documentation' }).first()
+  ).toBeVisible();
+});
+
+test('deep doc page loads its content heading', async ({ page }) => {
+  await page.goto('/docs/001-overview');
+
+  await expect(
+    page.getByRole('heading', { name: 'Overview' }).first()
+  ).toBeVisible();
+});

--- a/apps/homepage2/package.json
+++ b/apps/homepage2/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint --max-warnings=0",
     "typecheck": "tsc --noEmit --incremental --tsBuildInfoFile node_modules/.cache/tsbuildinfo",
     "postinstall": "prisma generate --data-proxy",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/apps/homepage2/playwright.config.js
+++ b/apps/homepage2/playwright.config.js
@@ -1,0 +1,42 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * homepage2 and docs both default to port 3002, so this app is pinned to
+ * 3102 to avoid a port clash when turbo runs every app's e2e suite together.
+ */
+const PORT = 3102;
+
+module.exports = defineConfig({
+  webServer: {
+    command: `pnpm exec next dev --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env['CI'],
+    timeout: 120 * 1000,
+  },
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env['CI'],
+  /* Retry on CI only */
+  retries: process.env['CI'] ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env['CI'] ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/homepage2/tests/smoke.spec.js
+++ b/apps/homepage2/tests/smoke.spec.js
@@ -1,0 +1,24 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test('home page loads with title and hero', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page).toHaveTitle('JSON Resume');
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'JSON Resume' })
+  ).toBeVisible();
+});
+
+test('themes gallery renders at least one theme card', async ({ page }) => {
+  await page.goto('/themes');
+
+  await expect(
+    page.getByRole('heading', { level: 1, name: 'Themes' })
+  ).toBeVisible();
+
+  // Each theme card renders a "Preview theme" link.
+  await expect(
+    page.getByRole('link', { name: 'Preview theme' }).first()
+  ).toBeVisible();
+});


### PR DESCRIPTION
## What

Adds minimal Playwright e2e smoke coverage for the two previously untested apps. `registry` already had Playwright e2e; `homepage2` and `docs` had none.

Matches the existing `registry` conventions exactly: each app gets its own `playwright.config` with a dev-mode `webServer` entry and a `test:e2e` script. No new top-level tooling.

## Specs (kept minimal, ~18s total added CI time locally)

**homepage2** (`apps/homepage2/tests/smoke.spec.js`, port 3102):
- `/` loads with `<title>JSON Resume</title>` and the visible hero `<h1>JSON Resume</h1>`.
- `/themes` renders the gallery heading and at least one theme card (asserts a visible "Preview theme" link).

**docs** (`apps/docs/tests/smoke.spec.ts`, port 3103):
- `/docs` renders the Fumadocs shell (the "Docwright" nav home link) and the `Documentation` heading.
- A deep doc page `/docs/001-overview` loads its content heading.

## CI wiring

No workflow change needed. The existing `test` job runs `pnpm turbo test:e2e --concurrency 1000`, which previously only matched `registry`. Adding a `test:e2e` script to each app means turbo now discovers all three (confirmed via `turbo test:e2e --dry-run`). The Playwright browser cache installed in the `apps/registry` step is shared (`~/.cache/ms-playwright`), so no extra install is required.

## Ports

`homepage2` and `docs` both default to port 3002 (per their READMEs), so each playwright config pins a distinct port (3102 / 3103) to avoid a clash when turbo runs every app's suite concurrently.

## Verified locally

- `homepage2` e2e: 2 passed (CI mode, retries on).
- `docs` e2e: 2 passed (CI mode, retries on).
- `pnpm turbo lint typecheck prettier`: green.

Refs #275

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test infrastructure using Playwright across multiple apps
  * Added smoke tests for the documentation app covering landing page and content pages
  * Added smoke tests for the homepage app covering home and themes pages
  * Added `test:e2e` npm scripts to run the tests

* **Chores**
  * Added Playwright configuration for docs and homepage apps
  * Updated git ignore rules for test artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->