### PR TITLE
chore(ci): npm maintenance workflow to deprecate legacy packages

### DIFF
--- a/.github/workflows/npm-maintenance.yml
+++ b/.github/workflows/npm-maintenance.yml
@@ -1,0 +1,70 @@
+# Permanent npm maintenance tool (manual dispatch only).
+#
+# Runs npm administrative commands (currently: deprecating legacy packages)
+# against the npm registry using the NPM_TOKEN repo secret. Local machines are
+# generally not authenticated to npm, so this workflow is the canonical way to
+# perform npm account maintenance for the org.
+#
+# This is deprecate-only — it NEVER unpublishes. Deprecation leaves packages
+# installable (so existing dependents keep working) while surfacing a warning
+# that points users at the maintained replacements.
+#
+# Every package below was verified to include `thomasdavis` as a maintainer
+# (npm view <pkg> maintainers) before being added here. See PR referencing
+# the org-consolidation tracking issue #275.
+#
+# Usage: Actions tab -> "npm maintenance" -> Run workflow.
+
+name: npm maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Maintenance action to run'
+        required: true
+        default: 'deprecate-legacy'
+        type: choice
+        options:
+          - deprecate-legacy
+
+jobs:
+  maintenance:
+    name: ${{ inputs.action }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Deprecate legacy packages
+        if: ${{ inputs.action == 'deprecate-legacy' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -u
+
+          # deprecate <pkg> "<message>": echo the command, run it with `|| true`
+          # so a single failure does not abort the rest, and capture the output.
+          deprecate() {
+            pkg="$1"
+            msg="$2"
+            echo "::group::npm deprecate $pkg"
+            echo "+ npm deprecate \"$pkg\" \"$msg\""
+            npm deprecate "$pkg" "$msg" 2>&1 || true
+            echo "::endgroup::"
+          }
+
+          THEME_MSG="Deprecated and unmaintained. Maintained themes: https://github.com/jsonresume/jsonresume.org (packages/themes)."
+          RESUME_TO_MSG="Deprecated — superseded by the JSON Resume registry (https://registry.jsonresume.org). See https://github.com/jsonresume/jsonresume.org."
+          SCHEMA_MSG="Schema moved to @jsonresume/schema (current spec). This legacy package stays published for compatibility."
+
+          deprecate "jsonresume-theme-boilerplate" "$THEME_MSG"
+          deprecate "jsonresume-theme-business-card" "$THEME_MSG"
+          deprecate "resume-to-markdown" "$RESUME_TO_MSG"
+          deprecate "resume-to-pdf" "$RESUME_TO_MSG"
+          deprecate "resume-to-text" "$RESUME_TO_MSG"
+          deprecate "resume-schema" "$SCHEMA_MSG"
+
+          echo "Done. Review the per-package groups above for any failures."


### PR DESCRIPTION
## What

Adds `.github/workflows/npm-maintenance.yml` — a permanent, manually-dispatched maintenance tool for npm administrative tasks. Its first action (`deprecate-legacy`) deprecates long-pending legacy npm packages.

Local machines are not authenticated to npm; this workflow uses the all-access `NPM_TOKEN` repo secret to run the commands in CI.

## Why

Part of the org consolidation effort (refs #275). Several legacy packages owned by `thomasdavis` should be deprecated to steer users toward the maintained replacements, without breaking existing dependents.

## Behavior

- **Deprecate-only — NEVER unpublishes.** Packages stay installable; npm just surfaces a warning.
- Echoes each command before running, runs each with `|| true` so one failure does not abort the rest, and wraps each in a log group to capture output.
- `workflow_dispatch` only (manual), with an `action` input defaulting to `deprecate-legacy`.

## Packages deprecated (all verified `thomasdavis` is a maintainer)

| Package | Version | Message |
|---|---|---|
| jsonresume-theme-boilerplate | 0.1.2 | Deprecated and unmaintained → packages/themes |
| jsonresume-theme-business-card | 0.0.2 | Deprecated and unmaintained → packages/themes |
| resume-to-markdown | 0.0.14 | Superseded by the JSON Resume registry |
| resume-to-pdf | 0.2.7 | Superseded by the JSON Resume registry |
| resume-to-text | 0.0.15 | Superseded by the JSON Resume registry |
| resume-schema (legacy unscoped) | 1.0.1 | Moved to @jsonresume/schema; stays published for compat |

## Skipped (not deprecated)

- **jsonresume-themeutils** — `thomasdavis` is a maintainer, but the external "elegant" theme depends on it. Intentionally left published.
- **modern / polymer** — maintained by rolandnsharp.
- **full** — maintained by jackkeller.
- **theme-manager** — maintained by lesktr.

## Notes

- Do NOT merge yet — orchestrator will merge and dispatch.
- This is just a workflow file (prettier-formatted, YAML-validated).

— AI