### PR TITLE
docs: refresh CLAUDE.md for post-consolidation reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,15 @@
 
 - **Org/Repo:** `jsonresume/jsonresume.org` — ALWAYS use `owner: "jsonresume"`
 - **Stack:** Next.js monorepo (Turborepo + pnpm), Vercel deployment, Supabase DB (`registry`)
-- **AI SDK:** Use Vercel AI SDK v6 (`ai` + `@ai-sdk/openai`), never vendor SDKs directly
+- **AI SDK:** Use Vercel AI SDK (`ai@^6` + `@ai-sdk/openai@^3`), never vendor SDKs directly
+- **Post-consolidation:** This monorepo now absorbs the former standalone repos. The old `resume-schema`, `resume-cli`, `rust-json-resume` repos are **archived** — never link them as live (tracking: #275).
+
+## Packages (publishable)
+
+- `packages/schema` (`@jsonresume/schema`) — THE JSON Resume spec. Consumed internally via `workspace:*`.
+- `packages/cli` (`resume-cli`) — Node 18+, Ajv (draft-07, `strict:false` + `ajv-formats`) validation.
+- `packages/core-rust` (`json-resume-serde`) — Cargo crate, NOT a pnpm package; excluded from JS tooling.
+- `packages/resume-core` (`@jsonresume/core`) — shared theme components. UI: `packages/ui` (`@repo/ui`).
 
 ## Code Standards
 
@@ -25,32 +33,51 @@
 
 - **Circular imports:** When file and directory share a name, use explicit path: `'./Component/index.js'`
 - **Logger exports:** Triple export pattern (CommonJS default + ES6 default + named)
-- **Themes:** Must use ES6 imports (no `fs.readFileSync`), must render ALL JSON Resume sections, must load Google Fonts via CDN, must use `@resume/core` components, must use `ServerStyleSheet` for styled-components SSR
+- **Themes:** Must use ES6 imports (no `fs.readFileSync`), must render ALL JSON Resume sections, must load Google Fonts via CDN, must use `@jsonresume/core` components, must use `ServerStyleSheet` for styled-components SSR
 - **Theme registration:** Add to `apps/registry/lib/formatters/template/themeConfig.js`
 - Search codebase before creating new utils — check `apps/registry/app/utils/`, `apps/registry/lib/`, `packages/`
 
 ## CI/CD
 
+- **`ci.yml`** runs on `push(master)` + `pull_request` + `merge_group`; fork PRs supported.
+- **Required checks:** `Lint + Typecheck`, `build`, `test` (e2e), `unit-test`, `dev-script`.
 - Unit tests: `pnpm --filter registry test -- --run` (bypass turbo for selective tests)
-- E2E tests: `pnpm test:e2e` (Playwright)
+- E2E: `pnpm turbo test:e2e` (Playwright) — covers registry + homepage2 + docs
 - turbo.json must have task entries for any `pnpm turbo <task>` command
 - All env vars used must be declared in turbo.json `globalEnv`
-- Security patches: Use `pnpm.overrides` in root package.json
+- **LINT GOTCHA:** `eslint-config-next` is PINNED to `^15` in `@repo/eslint-config-custom` via `require.resolve`. v16 ships an ESLint-9 flat-config ARRAY that crashes ESLint 8 with a circular-structure error — and turbo's remote cache can MASK the failure. Never bump it to 16 without migrating to flat config; verify lint changes with `turbo lint --force`.
 
-## Issue Management
+## Releases (Changesets)
+
+- See `docs/RELEASING.md`. Add a changeset with your PR: `pnpm changeset`.
+- Merge to `master` → workflow opens/updates a **"Version Packages"** PR → merge it → auto-publish to npm.
+- Manual dispatch: `gh workflow run release-packages.yml`. npm maintenance: `gh workflow run npm-maintenance.yml`.
+
+## Security & Deps
+
+- Security patches: `pnpm.overrides` in root `package.json` (~79 entries live there now).
+- Dependabot runs weekly, grouped.
+- `.prettierignore` excludes `packages/cli`, `packages/core-rust`, package READMEs, and generated/CSS files — keep them out of prettier runs.
+
+## Issue & Community Management
 
 - Track all work via GitHub issues. Label: critical/bug/enhancement/refactor/testing
+- `CONTRIBUTING.md`, `docs/RELEASING.md`, and issue forms exist — point contributors there.
+- Schema is now in-repo (`packages/schema`) — handle schema issues HERE, not an external repo.
 - Be skeptical of external user issues — verify before implementing
-- Close schema-related issues → direct to schema repo
 - Never deprecate themes/features without maintainer approval
+- **Comments policy:** terse, no emoji; sign agent-authored comments `— AI` on its own line.
 - Discord webhook: only post when explicitly asked
+
+## Schema Gotcha
+
+- `schema.json` has `additionalProperties: true` — unknown fields are VALID. Invalid-case test fixtures must use **type violations**, not unknown keys.
 
 ## Key Paths
 
 - Theme screenshots: `apps/homepage2/public/img/themes/`
 - Screenshot generator: `apps/registry/scripts/generate-theme-screenshots-auto.js`
-- Retry utility: `apps/registry/app/lib/retry.js`
-- UI components: `packages/ui` (@repo/ui — Button, Input, Textarea with variants)
+- Retry utility: `apps/registry/lib/retry.js`
 - Theme ideas: `packages/themes/ideas.md`
 - Theme dev guide: `docs/AGENT_THEME_DEVELOPMENT.md`
 


### PR DESCRIPTION
Refreshes the agent/contributor instructions (`CLAUDE.md`) to match the consolidated monorepo. Per #275, the standalone `resume-schema`, `resume-cli`, and `rust-json-resume` repos are archived and their code now lives here — the instructions had drifted.

Every retained rule was re-verified against the tree; stale assertions were dropped.

## Fixed (stale)

- AI SDK: `v5` -> `ai@^6` / `@ai-sdk/openai@^3` (verified in `apps/registry/package.json`).
- Theme component import: `@resume/core` -> `@jsonresume/core` (package renamed; verified in theme `src`/`package.json`).
- Retry util path: `apps/registry/app/lib/retry.js` -> `apps/registry/lib/retry.js`.
- E2E command: `pnpm test:e2e` -> `pnpm turbo test:e2e` (now spans registry + homepage2 + docs).
- Schema issues: no longer "direct to schema repo" — schema is in-repo at `packages/schema`.

## Added (learnings)

- **Packages** section: `@jsonresume/schema` (the spec, `workspace:*`), `resume-cli` (Node 18+, Ajv draft-07), `core-rust` (Cargo crate, not a pnpm package).
- **Releases (Changesets)**: `docs/RELEASING.md` flow + `gh workflow run release-packages.yml` / `npm-maintenance.yml`.
- **CI**: `ci.yml` triggers (`push`/`pull_request`/`merge_group`) and required checks (Lint + Typecheck, build, test, unit-test, dev-script).
- **LINT GOTCHA**: `eslint-config-next` pinned `^15` via `require.resolve`; v16's ESLint-9 flat-config crashes ESLint 8 and turbo's remote cache masks it. Verify lint with `turbo lint --force`.
- **Schema gotcha**: `additionalProperties: true` — invalid-case fixtures must use type violations, not unknown keys.
- Security: `pnpm.overrides` (~79 entries), grouped weekly dependabot, `.prettierignore` coverage.
- Community: `CONTRIBUTING.md` / `docs/RELEASING.md` / issue forms; comments policy (terse, no emoji, sign `— AI`).
- Note that the legacy standalone repos are archived — never link them as live.

## Verification

- `prettier --check CLAUDE.md` passes (repo-local prettier 3.8.4).
- 97 lines (kept under ~120).
- All referenced paths/workflows confirmed present in the tree.

Refs #275

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development documentation with revised AI SDK requirements and monorepo structure guidance.
  * Clarified CI/CD testing procedures and key system paths.
  * Updated component references and theme configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->