### PR TITLE
fix(themes): render missing sections (batch 1: academic-cv-lite, bold-header-statement, creative-confidence, diagonal-accent-bar, government-standard, marketing-narrative, modern-classic, operations-precision, sidebar-photo-strip, university-first)

### DIFF
--- a/packages/themes/jsonresume-theme-academic-cv-lite/dist/index.js
+++ b/packages/themes/jsonresume-theme-academic-cv-lite/dist/index.js
@@ -6222,6 +6222,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6263,6 +6264,14 @@ function Resume({ resume }) {
           ")"
         ] }),
         pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(AwardItem, { children: [
+        /* @__PURE__ */ jsx(AwardTitle, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsx(AwardAwarder, { children: cert.issuer }),
+        cert.date && /* @__PURE__ */ jsx(AwardDate, { children: cert.date })
       ] }, index))
     ] }),
     awards?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-academic-cv-lite/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-academic-cv-lite/src/Resume.jsx
@@ -248,6 +248,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -294,6 +295,19 @@ function Resume({ resume }) {
               )}
               {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
             </PublicationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <AwardItem key={index}>
+              <AwardTitle>{cert.name}</AwardTitle>
+              {cert.issuer && <AwardAwarder>{cert.issuer}</AwardAwarder>}
+              {cert.date && <AwardDate>{cert.date}</AwardDate>}
+            </AwardItem>
           ))}
         </Section>
       )}

--- a/packages/themes/jsonresume-theme-bold-header-statement/dist/index.js
+++ b/packages/themes/jsonresume-theme-bold-header-statement/dist/index.js
@@ -6287,13 +6287,98 @@ function ProjectsSection({ projects }) {
     ] }, index))
   ] });
 }
+function VolunteerSection({ volunteer }) {
+  if (!volunteer?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Volunteer" }),
+    volunteer.map((vol, index) => /* @__PURE__ */ jsxs(ContentBlock, { children: [
+      /* @__PURE__ */ jsxs(WorkHeader, { children: [
+        /* @__PURE__ */ jsx(Position, { children: vol.position }),
+        vol.organization && /* @__PURE__ */ jsx(Company, { children: vol.organization }),
+        (vol.startDate || vol.endDate) && /* @__PURE__ */ jsx(DateText, { children: /* @__PURE__ */ jsx(DateRange, { startDate: vol.startDate, endDate: vol.endDate }) })
+      ] }),
+      vol.summary && /* @__PURE__ */ jsx(WorkSummary, { children: vol.summary }),
+      vol.highlights?.length > 0 && /* @__PURE__ */ jsx(Highlights, { children: vol.highlights.map((highlight, i) => /* @__PURE__ */ jsx("li", { children: highlight }, i)) })
+    ] }, index))
+  ] });
+}
+function AwardsSection({ awards }) {
+  if (!awards?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Awards" }),
+    awards.map((award, index) => /* @__PURE__ */ jsxs(ContentBlock, { children: [
+      /* @__PURE__ */ jsx(Institution, { children: award.title }),
+      award.awarder && /* @__PURE__ */ jsxs(Degree, { children: [
+        "Awarded by ",
+        award.awarder
+      ] }),
+      award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
+      award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+    ] }, index))
+  ] });
+}
+function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+    certificates.map((cert, index) => /* @__PURE__ */ jsxs(ContentBlock, { children: [
+      /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+      cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+        "Issued by ",
+        cert.issuer
+      ] }),
+      cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
+    ] }, index))
+  ] });
+}
+function PublicationsSection({ publications }) {
+  if (!publications?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Publications" }),
+    publications.map((pub, index) => /* @__PURE__ */ jsxs(ContentBlock, { children: [
+      /* @__PURE__ */ jsx(Institution, { children: pub.name }),
+      pub.publisher && /* @__PURE__ */ jsxs(Degree, { children: [
+        "Published by ",
+        pub.publisher
+      ] }),
+      pub.releaseDate && /* @__PURE__ */ jsx(EducationDate, { children: pub.releaseDate }),
+      pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+    ] }, index))
+  ] });
+}
+function LanguagesSection({ languages }) {
+  if (!languages?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Languages" }),
+    /* @__PURE__ */ jsx(SkillsGrid, { children: languages.map((lang, index) => /* @__PURE__ */ jsxs(SkillCategory, { children: [
+      /* @__PURE__ */ jsx(SkillName, { children: lang.language }),
+      lang.fluency && /* @__PURE__ */ jsx(SkillTags, { children: lang.fluency })
+    ] }, index)) })
+  ] });
+}
+function ReferencesSection({ references }) {
+  if (!references?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "References" }),
+    references.map((ref, index) => /* @__PURE__ */ jsxs(ContentBlock, { children: [
+      /* @__PURE__ */ jsx(Institution, { children: ref.name }),
+      ref.reference && /* @__PURE__ */ jsx(WorkSummary, { children: ref.reference })
+    ] }, index))
+  ] });
+}
 function Resume({ resume }) {
   const {
     basics = {},
     work = [],
     education = [],
     skills = [],
-    projects = []
+    projects = [],
+    volunteer = [],
+    awards = [],
+    certificates = [],
+    publications = [],
+    languages = [],
+    references = []
   } = resume;
   return /* @__PURE__ */ jsxs(Layout, { children: [
     /* @__PURE__ */ jsx(Header, { basics }),
@@ -6302,7 +6387,13 @@ function Resume({ resume }) {
       /* @__PURE__ */ jsx(WorkSection, { work }),
       /* @__PURE__ */ jsx(SkillsSection, { skills }),
       /* @__PURE__ */ jsx(EducationSection, { education }),
-      /* @__PURE__ */ jsx(ProjectsSection, { projects })
+      /* @__PURE__ */ jsx(ProjectsSection, { projects }),
+      /* @__PURE__ */ jsx(VolunteerSection, { volunteer }),
+      /* @__PURE__ */ jsx(AwardsSection, { awards }),
+      /* @__PURE__ */ jsx(CertificatesSection, { certificates }),
+      /* @__PURE__ */ jsx(PublicationsSection, { publications }),
+      /* @__PURE__ */ jsx(LanguagesSection, { languages }),
+      /* @__PURE__ */ jsx(ReferencesSection, { references })
     ] })
   ] });
 }

--- a/packages/themes/jsonresume-theme-bold-header-statement/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-bold-header-statement/src/Resume.jsx
@@ -358,6 +358,124 @@ function ProjectsSection({ projects }) {
   );
 }
 
+function VolunteerSection({ volunteer }) {
+  if (!volunteer?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Volunteer</StyledSectionTitle>
+      {volunteer.map((vol, index) => (
+        <ContentBlock key={index}>
+          <WorkHeader>
+            <Position>{vol.position}</Position>
+            {vol.organization && <Company>{vol.organization}</Company>}
+            {(vol.startDate || vol.endDate) && (
+              <DateText>
+                <DateRange startDate={vol.startDate} endDate={vol.endDate} />
+              </DateText>
+            )}
+          </WorkHeader>
+          {vol.summary && <WorkSummary>{vol.summary}</WorkSummary>}
+          {vol.highlights?.length > 0 && (
+            <Highlights>
+              {vol.highlights.map((highlight, i) => (
+                <li key={i}>{highlight}</li>
+              ))}
+            </Highlights>
+          )}
+        </ContentBlock>
+      ))}
+    </Section>
+  );
+}
+
+function AwardsSection({ awards }) {
+  if (!awards?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Awards</StyledSectionTitle>
+      {awards.map((award, index) => (
+        <ContentBlock key={index}>
+          <Institution>{award.title}</Institution>
+          {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
+          {award.date && <EducationDate>{award.date}</EducationDate>}
+          {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+        </ContentBlock>
+      ))}
+    </Section>
+  );
+}
+
+function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Certificates</StyledSectionTitle>
+      {certificates.map((cert, index) => (
+        <ContentBlock key={index}>
+          <Institution>{cert.name}</Institution>
+          {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+          {cert.date && <EducationDate>{cert.date}</EducationDate>}
+        </ContentBlock>
+      ))}
+    </Section>
+  );
+}
+
+function PublicationsSection({ publications }) {
+  if (!publications?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Publications</StyledSectionTitle>
+      {publications.map((pub, index) => (
+        <ContentBlock key={index}>
+          <Institution>{pub.name}</Institution>
+          {pub.publisher && <Degree>Published by {pub.publisher}</Degree>}
+          {pub.releaseDate && <EducationDate>{pub.releaseDate}</EducationDate>}
+          {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+        </ContentBlock>
+      ))}
+    </Section>
+  );
+}
+
+function LanguagesSection({ languages }) {
+  if (!languages?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Languages</StyledSectionTitle>
+      <SkillsGrid>
+        {languages.map((lang, index) => (
+          <SkillCategory key={index}>
+            <SkillName>{lang.language}</SkillName>
+            {lang.fluency && <SkillTags>{lang.fluency}</SkillTags>}
+          </SkillCategory>
+        ))}
+      </SkillsGrid>
+    </Section>
+  );
+}
+
+function ReferencesSection({ references }) {
+  if (!references?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>References</StyledSectionTitle>
+      {references.map((ref, index) => (
+        <ContentBlock key={index}>
+          <Institution>{ref.name}</Institution>
+          {ref.reference && <WorkSummary>{ref.reference}</WorkSummary>}
+        </ContentBlock>
+      ))}
+    </Section>
+  );
+}
+
 // Main component
 function Resume({ resume }) {
   const {
@@ -366,6 +484,12 @@ function Resume({ resume }) {
     education = [],
     skills = [],
     projects = [],
+    volunteer = [],
+    awards = [],
+    certificates = [],
+    publications = [],
+    languages = [],
+    references = [],
   } = resume;
 
   return (
@@ -377,6 +501,12 @@ function Resume({ resume }) {
         <SkillsSection skills={skills} />
         <EducationSection education={education} />
         <ProjectsSection projects={projects} />
+        <VolunteerSection volunteer={volunteer} />
+        <AwardsSection awards={awards} />
+        <CertificatesSection certificates={certificates} />
+        <PublicationsSection publications={publications} />
+        <LanguagesSection languages={languages} />
+        <ReferencesSection references={references} />
       </ContentWrapper>
     </Layout>
   );

--- a/packages/themes/jsonresume-theme-creative-confidence/index.js
+++ b/packages/themes/jsonresume-theme-creative-confidence/index.js
@@ -554,6 +554,145 @@ function renderCertificates(certificates = []) {
   );
 }
 
+function renderItemList(title, items, className) {
+  if (!items.length) return '';
+  const body = items
+    .map((entry) => {
+      const org = entry.org
+        ? `<p class="item-org">${escapeHtml(entry.org)}</p>`
+        : '';
+      const dates = entry.dates
+        ? `<div class="item-dates">${escapeHtml(entry.dates)}</div>`
+        : '';
+      const summary = entry.summary
+        ? `<p class="item-summary">${escapeHtml(entry.summary)}</p>`
+        : '';
+      const bullets =
+        Array.isArray(entry.highlights) && entry.highlights.length
+          ? `<ul class="bullets">${entry.highlights
+              .map(
+                (h) => `<li>${escapeHtml(String(h).replace(/^\*\s*/, ''))}</li>`
+              )
+              .join('')}</ul>`
+          : '';
+      return `
+      <div class="work-item-keep">
+        <article class="item">
+          <div class="item-head">
+            <div>
+              <h3 class="item-role">${escapeHtml(entry.title || '')}</h3>
+              ${org}
+            </div>
+            ${dates}
+          </div>
+          ${summary}${bullets}
+        </article>
+      </div>
+    `;
+    })
+    .join('');
+  return section(title, body, className);
+}
+
+function renderVolunteer(volunteer = []) {
+  return renderItemList(
+    'Volunteer',
+    volunteer.map((vol) => ({
+      title: vol.position,
+      org: vol.organization,
+      dates: dateRange(vol.startDate, vol.endDate),
+      summary: vol.summary,
+      highlights: vol.highlights,
+    })),
+    'work-section'
+  );
+}
+
+function renderProjects(projects = []) {
+  return renderItemList(
+    'Projects',
+    projects.map((project) => ({
+      title: project.name,
+      summary: project.description,
+      highlights: project.highlights,
+    })),
+    'work-section'
+  );
+}
+
+function renderAwards(awards = []) {
+  return renderItemList(
+    'Awards',
+    awards.map((award) => ({
+      title: award.title,
+      org: award.awarder ? `Awarded by ${award.awarder}` : '',
+      dates: award.date ? formatDate(award.date) : '',
+      summary: award.summary,
+    })),
+    'work-section'
+  );
+}
+
+function renderPublications(publications = []) {
+  return renderItemList(
+    'Publications',
+    publications.map((pub) => ({
+      title: pub.name,
+      org: pub.publisher ? `Published by ${pub.publisher}` : '',
+      dates: pub.releaseDate ? formatDate(pub.releaseDate) : '',
+      summary: pub.summary,
+    })),
+    'work-section'
+  );
+}
+
+function renderReferences(references = []) {
+  if (!references.length) return '';
+  const items = references
+    .map((ref) => {
+      const name = ref.name ? `<strong>${escapeHtml(ref.name)}</strong>` : '';
+      const quote = ref.reference
+        ? `<div class="item-summary">${escapeHtml(ref.reference)}</div>`
+        : '';
+      return `<li>${name}${quote}</li>`;
+    })
+    .join('');
+  return section('References', `<ul class="compact-list">${items}</ul>`);
+}
+
+function renderLanguages(languages = []) {
+  if (!languages.length) return '';
+  const blocks = languages
+    .map(
+      (lang) => `
+      <div class="skill-group">
+        <span class="skill-name">${escapeHtml(lang.language)}:</span>
+        <span>${escapeHtml(lang.fluency || '')}</span>
+      </div>
+    `
+    )
+    .join('');
+  return section('Languages', `<div>${blocks}</div>`);
+}
+
+function renderInterests(interests = []) {
+  if (!interests.length) return '';
+  const blocks = interests
+    .map((interest) => {
+      const keywords = Array.isArray(interest.keywords)
+        ? interest.keywords.join(', ')
+        : '';
+      return `
+      <div class="skill-group">
+        <span class="skill-name">${escapeHtml(interest.name)}</span>
+        ${keywords ? `<span>: ${escapeHtml(keywords)}</span>` : ''}
+      </div>
+    `;
+    })
+    .join('');
+  return section('Interests', `<div>${blocks}</div>`);
+}
+
 function renderSkills(skills = []) {
   if (!skills.length) return '';
   const blocks = skills
@@ -589,6 +728,10 @@ export function render(resume = {}) {
   const leftColumn = [
     renderSummary(basics),
     renderProfessionalExperience(resume.work || []),
+    renderProjects(resume.projects || []),
+    renderVolunteer(resume.volunteer || []),
+    renderAwards(resume.awards || []),
+    renderPublications(resume.publications || []),
   ].join('');
 
   const rightColumn = [
@@ -596,6 +739,9 @@ export function render(resume = {}) {
     renderEducation(resume.education || []),
     renderCertificates(resume.certificates || []),
     renderSkills(resume.skills || []),
+    renderLanguages(resume.languages || []),
+    renderInterests(resume.interests || []),
+    renderReferences(resume.references || []),
   ].join('');
 
   return `<!doctype html>

--- a/packages/themes/jsonresume-theme-diagonal-accent-bar/dist/index.js
+++ b/packages/themes/jsonresume-theme-diagonal-accent-bar/dist/index.js
@@ -6257,6 +6257,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6352,6 +6353,17 @@ function Resume({ resume }) {
         ] }),
         pub.releaseDate && /* @__PURE__ */ jsx(EducationDate, { children: pub.releaseDate }),
         pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     languages?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-diagonal-accent-bar/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-diagonal-accent-bar/src/Resume.jsx
@@ -274,6 +274,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -427,6 +428,19 @@ function Resume({ resume }) {
                 <EducationDate>{pub.releaseDate}</EducationDate>
               )}
               {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-government-standard/dist/index.js
+++ b/packages/themes/jsonresume-theme-government-standard/dist/index.js
@@ -6119,6 +6119,23 @@ function PublicationsSection({ publications }) {
     ] }, index))
   ] });
 }
+function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certifications" }),
+    certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleList, { children: [
+      /* @__PURE__ */ jsx(ListItemTitle, { children: cert.name }),
+      cert.issuer && /* @__PURE__ */ jsxs(ListItemText, { children: [
+        "Issuer: ",
+        cert.issuer
+      ] }),
+      cert.date && /* @__PURE__ */ jsxs(ListItemText, { children: [
+        "Date: ",
+        cert.date
+      ] })
+    ] }, index))
+  ] });
+}
 function LanguagesSection({ languages }) {
   if (!languages?.length) return null;
   return /* @__PURE__ */ jsxs(Section, { children: [
@@ -6352,6 +6369,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6373,6 +6391,7 @@ function Resume({ resume }) {
     /* @__PURE__ */ jsx(VolunteerSection, { volunteer }),
     /* @__PURE__ */ jsx(AwardsSection, { awards }),
     /* @__PURE__ */ jsx(PublicationsSection, { publications }),
+    /* @__PURE__ */ jsx(CertificatesSection, { certificates }),
     /* @__PURE__ */ jsx(LanguagesSection, { languages }),
     /* @__PURE__ */ jsx(InterestsSection, { interests }),
     /* @__PURE__ */ jsx(ReferencesSection, { references })

--- a/packages/themes/jsonresume-theme-government-standard/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-government-standard/src/Resume.jsx
@@ -9,6 +9,7 @@ import {
   VolunteerSection,
   AwardsSection,
   PublicationsSection,
+  CertificatesSection,
   LanguagesSection,
   InterestsSection,
   ReferencesSection,
@@ -257,6 +258,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -284,6 +286,7 @@ function Resume({ resume }) {
       <VolunteerSection volunteer={volunteer} />
       <AwardsSection awards={awards} />
       <PublicationsSection publications={publications} />
+      <CertificatesSection certificates={certificates} />
       <LanguagesSection languages={languages} />
       <InterestsSection interests={interests} />
       <ReferencesSection references={references} />

--- a/packages/themes/jsonresume-theme-government-standard/src/components/OtherSections.jsx
+++ b/packages/themes/jsonresume-theme-government-standard/src/components/OtherSections.jsx
@@ -115,6 +115,23 @@ export function PublicationsSection({ publications }) {
   );
 }
 
+export function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Certifications</StyledSectionTitle>
+      {certificates.map((cert, index) => (
+        <SimpleList key={index}>
+          <ListItemTitle>{cert.name}</ListItemTitle>
+          {cert.issuer && <ListItemText>Issuer: {cert.issuer}</ListItemText>}
+          {cert.date && <ListItemText>Date: {cert.date}</ListItemText>}
+        </SimpleList>
+      ))}
+    </Section>
+  );
+}
+
 export function LanguagesSection({ languages }) {
   if (!languages?.length) return null;
 

--- a/packages/themes/jsonresume-theme-marketing-narrative/dist/index.js
+++ b/packages/themes/jsonresume-theme-marketing-narrative/dist/index.js
@@ -6113,6 +6113,20 @@ function PublicationsSection({ publications }) {
     ] }, index))
   ] });
 }
+function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Credentials" }),
+    certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+      /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+      cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+        "Issued by ",
+        cert.issuer
+      ] }),
+      cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
+    ] }, index))
+  ] });
+}
 function LanguagesSection({ languages }) {
   if (!languages?.length) return null;
   return /* @__PURE__ */ jsxs(Section, { children: [
@@ -6355,6 +6369,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6373,6 +6388,7 @@ function Resume({ resume }) {
     /* @__PURE__ */ jsx(VolunteerSection, { volunteer }),
     /* @__PURE__ */ jsx(AwardsSection, { awards }),
     /* @__PURE__ */ jsx(PublicationsSection, { publications }),
+    /* @__PURE__ */ jsx(CertificatesSection, { certificates }),
     /* @__PURE__ */ jsx(LanguagesSection, { languages }),
     /* @__PURE__ */ jsx(InterestsSection, { interests }),
     /* @__PURE__ */ jsx(ReferencesSection, { references })

--- a/packages/themes/jsonresume-theme-marketing-narrative/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-marketing-narrative/src/Resume.jsx
@@ -9,6 +9,7 @@ import {
   VolunteerSection,
   AwardsSection,
   PublicationsSection,
+  CertificatesSection,
   LanguagesSection,
   InterestsSection,
   ReferencesSection,
@@ -248,6 +249,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -269,6 +271,7 @@ function Resume({ resume }) {
       <VolunteerSection volunteer={volunteer} />
       <AwardsSection awards={awards} />
       <PublicationsSection publications={publications} />
+      <CertificatesSection certificates={certificates} />
       <LanguagesSection languages={languages} />
       <InterestsSection interests={interests} />
       <ReferencesSection references={references} />

--- a/packages/themes/jsonresume-theme-marketing-narrative/src/sections/OtherSections.jsx
+++ b/packages/themes/jsonresume-theme-marketing-narrative/src/sections/OtherSections.jsx
@@ -91,6 +91,23 @@ export function PublicationsSection({ publications }) {
   );
 }
 
+export function CertificatesSection({ certificates }) {
+  if (!certificates?.length) return null;
+
+  return (
+    <Section>
+      <StyledSectionTitle>Credentials</StyledSectionTitle>
+      {certificates.map((cert, index) => (
+        <EducationItem key={index}>
+          <Institution>{cert.name}</Institution>
+          {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+          {cert.date && <EducationDate>{cert.date}</EducationDate>}
+        </EducationItem>
+      ))}
+    </Section>
+  );
+}
+
 export function LanguagesSection({ languages }) {
   if (!languages?.length) return null;
 

--- a/packages/themes/jsonresume-theme-modern-classic/dist/index.js
+++ b/packages/themes/jsonresume-theme-modern-classic/dist/index.js
@@ -6174,6 +6174,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6269,6 +6270,17 @@ function Resume({ resume }) {
         ] }),
         pub.releaseDate && /* @__PURE__ */ jsx(EducationDate, { children: pub.releaseDate }),
         pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     languages?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-modern-classic/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-modern-classic/src/Resume.jsx
@@ -191,6 +191,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -344,6 +345,19 @@ function Resume({ resume }) {
                 <EducationDate>{pub.releaseDate}</EducationDate>
               )}
               {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-operations-precision/dist/index.js
+++ b/packages/themes/jsonresume-theme-operations-precision/dist/index.js
@@ -6019,11 +6019,7 @@ const Layout = dt.div`
   margin: 0 auto;
   padding: 40px 35px;
   background: white;
-  font-family:
-    'Inter',
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   color: #1f2937;
   font-size: 15px;
@@ -6249,6 +6245,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6423,6 +6420,17 @@ function Resume({ resume }) {
             }
           }
         )
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certifications" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     languages?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-operations-precision/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-operations-precision/src/Resume.jsx
@@ -269,6 +269,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -487,6 +488,19 @@ function Resume({ resume }) {
                   }}
                 />
               )}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certifications</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-sidebar-photo-strip/dist/index.js
+++ b/packages/themes/jsonresume-theme-sidebar-photo-strip/dist/index.js
@@ -6134,6 +6134,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6277,6 +6278,17 @@ function Resume({ resume }) {
           ] }),
           pub.releaseDate && /* @__PURE__ */ jsx(EducationDate, { children: pub.releaseDate }),
           pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+        ] }, index))
+      ] }),
+      certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+        certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+          /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+          cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+            "Issued by ",
+            cert.issuer
+          ] }),
+          cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
         ] }, index))
       ] }),
       references?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-sidebar-photo-strip/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-sidebar-photo-strip/src/Resume.jsx
@@ -235,6 +235,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -475,6 +476,19 @@ function Resume({ resume }) {
                   <EducationDate>{pub.releaseDate}</EducationDate>
                 )}
                 {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+              </EducationItem>
+            ))}
+          </Section>
+        )}
+
+        {certificates?.length > 0 && (
+          <Section>
+            <StyledSectionTitle>Certificates</StyledSectionTitle>
+            {certificates.map((cert, index) => (
+              <EducationItem key={index}>
+                <Institution>{cert.name}</Institution>
+                {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+                {cert.date && <EducationDate>{cert.date}</EducationDate>}
               </EducationItem>
             ))}
           </Section>

--- a/packages/themes/jsonresume-theme-university-first/dist/index.js
+++ b/packages/themes/jsonresume-theme-university-first/dist/index.js
@@ -6300,6 +6300,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = []
@@ -6436,6 +6437,17 @@ function Resume({ resume }) {
           ] }),
           pub.releaseDate && /* @__PURE__ */ jsx(DateText, { children: pub.releaseDate }),
           pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+        ] }, index))
+      ] }),
+      certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certifications" }),
+        certificates.map((cert, index) => /* @__PURE__ */ jsxs(AwardItem, { children: [
+          /* @__PURE__ */ jsx(AwardTitle, { children: cert.name }),
+          cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+            "Issued by ",
+            cert.issuer
+          ] }),
+          cert.date && /* @__PURE__ */ jsx(DateText, { children: cert.date })
         ] }, index))
       ] }),
       languages?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-university-first/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-university-first/src/Resume.jsx
@@ -327,6 +327,7 @@ function Resume({ resume }) {
     volunteer = [],
     awards = [],
     publications = [],
+    certificates = [],
     languages = [],
     interests = [],
     references = [],
@@ -513,6 +514,19 @@ function Resume({ resume }) {
                 {pub.publisher && <Degree>Published by {pub.publisher}</Degree>}
                 {pub.releaseDate && <DateText>{pub.releaseDate}</DateText>}
                 {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+              </AwardItem>
+            ))}
+          </Section>
+        )}
+
+        {certificates?.length > 0 && (
+          <Section>
+            <StyledSectionTitle>Certifications</StyledSectionTitle>
+            {certificates.map((cert, index) => (
+              <AwardItem key={index}>
+                <AwardTitle>{cert.name}</AwardTitle>
+                {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+                {cert.date && <DateText>{cert.date}</DateText>}
               </AwardItem>
             ))}
           </Section>


### PR DESCRIPTION
Section-coverage fixes from the QA matrix in #360. Batch 1 of 4.

Each theme now renders its previously-omitted JSON Resume sections, in that theme's own visual idiom — reusing the theme's existing section components / styled blocks (no redesign, sections added in-place). Built `dist/` is committed alongside `src/` per the repo convention for these themes.

## Per-theme (before → after)

| theme | sections added |
|---|---|
| `academic-cv-lite` | certificates |
| `diagonal-accent-bar` | certificates |
| `government-standard` | certificates |
| `marketing-narrative` | certificates |
| `modern-classic` | certificates |
| `operations-precision` | certificates |
| `sidebar-photo-strip` | certificates |
| `university-first` | certificates |
| `bold-header-statement` | volunteer, awards, certificates, publications, languages, references |
| `creative-confidence` | volunteer, awards, publications, languages, interests, references, projects |

`bold-header-statement` previously rendered only basics/work/skills/education/projects; the six listed sections were never wired into its render tree. `creative-confidence` is a string-template (non-JSX) theme; the seven listed sections were added as render helpers reusing its existing CSS classes and slotted into its two-column layout (substantial narrative sections left, compact sections right).

## Scope notes
- `kendall` and `pumpkin` also fell in this batch's alphabetical slice but are **external npm packages** (`require('jsonresume-theme-kendall')` / `-pumpkin`), not editable in this monorepo — left for the upstream theme repos.
- No `Date`-named styled components introduced (the crash cause fixed in #359 is avoided).

## Verification
- Rendered every touched theme with a complete fixture (extended `packages/test-fixtures/resume-sample.json` with volunteer/certificates/publications, as the QA harness did). Asserted: each newly-added section's sentinel string now appears in the HTML, AND every previously-rendering section still appears. All 10 pass.
- Repo gates green: `pnpm turbo lint typecheck prettier` (18/18 tasks) and `pnpm --filter registry test -- --run` (1318 passed, 24 pre-existing skips).

Refs #275, #360

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added certificates/certifications section to resume themes
  * Users can now include certificates with optional issuer and date information
  * Additional resume sections now available: volunteer experience, awards, publications, languages, and references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->