### PR TITLE
fix(themes): render missing sections (batch 4: berlin-grid, coastal-creative, developer-mono, french-atelier, nordic-minimal, product-manager-canvas, sidebar, typewriter-modern)

### DIFF
--- a/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
@@ -6335,6 +6335,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6430,6 +6431,17 @@ function Resume({ resume }) {
           award.date && `• ${award.date}`
         ] }),
         award.summary && /* @__PURE__ */ jsx("p", { children: award.summary })
+      ] }, index)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleItem, { children: [
+        /* @__PURE__ */ jsx("h4", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs("p", { children: [
+          cert.issuer,
+          " ",
+          cert.date && `• ${cert.date}`
+        ] })
       ] }, index)) })
     ] }),
     publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-berlin-grid/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-berlin-grid/src/Resume.jsx
@@ -283,6 +283,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -435,6 +436,28 @@ function Resume({ resume }) {
                   {award.awarder} {award.date && `• ${award.date}`}
                 </p>
                 {award.summary && <p>{award.summary}</p>}
+              </SimpleItem>
+            ))}
+          </SimpleList>
+        </StyledSection>
+      )}
+
+      {certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleItem key={index}>
+                <h4>
+                  {cert.url ? (
+                    <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                  ) : (
+                    cert.name
+                  )}
+                </h4>
+                <p>
+                  {cert.issuer} {cert.date && `• ${cert.date}`}
+                </p>
               </SimpleItem>
             ))}
           </SimpleList>

--- a/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
+++ b/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
@@ -6272,6 +6272,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6374,6 +6375,24 @@ function Resume({ resume }) {
               marginTop: "8px"
             },
             children: award.date
+          }
+        )
+      ] }, index)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+      /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("strong", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        cert.issuer && ` — ${cert.issuer}`,
+        cert.date && /* @__PURE__ */ jsx(
+          "div",
+          {
+            style: {
+              fontSize: "14px",
+              color: "#94a3b8",
+              marginTop: "8px"
+            },
+            children: cert.date
           }
         )
       ] }, index)) })

--- a/packages/themes/jsonresume-theme-coastal-creative/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-coastal-creative/src/Resume.jsx
@@ -217,6 +217,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -403,6 +404,37 @@ function Resume({ resume }) {
                     }}
                   >
                     {award.date}
+                  </div>
+                )}
+              </SimpleCard>
+            ))}
+          </SimpleList>
+        </MainSection>
+      )}
+
+      {certificates.length > 0 && (
+        <MainSection>
+          <MainSectionTitle>Certificates</MainSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleCard key={index}>
+                <strong>
+                  {cert.url ? (
+                    <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                  ) : (
+                    cert.name
+                  )}
+                </strong>
+                {cert.issuer && ` — ${cert.issuer}`}
+                {cert.date && (
+                  <div
+                    style={{
+                      fontSize: '14px',
+                      color: '#94a3b8',
+                      marginTop: '8px',
+                    }}
+                  >
+                    {cert.date}
                   </div>
                 )}
               </SimpleCard>

--- a/packages/themes/jsonresume-theme-developer-mono/dist/index.js
+++ b/packages/themes/jsonresume-theme-developer-mono/dist/index.js
@@ -6237,6 +6237,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6339,6 +6340,24 @@ function Resume({ resume }) {
               marginTop: "4px"
             },
             children: award.date
+          }
+        )
+      ] }, index)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+      /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleItem, { children: [
+        /* @__PURE__ */ jsx("strong", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        cert.issuer && ` — ${cert.issuer}`,
+        cert.date && /* @__PURE__ */ jsx(
+          "div",
+          {
+            style: {
+              fontSize: "13px",
+              color: "#6b7280",
+              marginTop: "4px"
+            },
+            children: cert.date
           }
         )
       ] }, index)) })

--- a/packages/themes/jsonresume-theme-developer-mono/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-developer-mono/src/Resume.jsx
@@ -217,6 +217,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -399,6 +400,37 @@ function Resume({ resume }) {
                     }}
                   >
                     {award.date}
+                  </div>
+                )}
+              </SimpleItem>
+            ))}
+          </SimpleList>
+        </MainSection>
+      )}
+
+      {certificates.length > 0 && (
+        <MainSection>
+          <MainSectionTitle>Certificates</MainSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleItem key={index}>
+                <strong>
+                  {cert.url ? (
+                    <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                  ) : (
+                    cert.name
+                  )}
+                </strong>
+                {cert.issuer && ` — ${cert.issuer}`}
+                {cert.date && (
+                  <div
+                    style={{
+                      fontSize: '13px',
+                      color: '#6b7280',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {cert.date}
                   </div>
                 )}
               </SimpleItem>

--- a/packages/themes/jsonresume-theme-french-atelier/dist/index.js
+++ b/packages/themes/jsonresume-theme-french-atelier/dist/index.js
@@ -6359,6 +6359,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6465,6 +6466,17 @@ function Resume({ resume }) {
           award.date && `• ${award.date}`
         ] }),
         award.summary && /* @__PURE__ */ jsx("p", { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("h4", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs("p", { children: [
+          cert.issuer,
+          " ",
+          cert.date && `• ${cert.date}`
+        ] })
       ] }, index))
     ] }),
     publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-french-atelier/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-french-atelier/src/Resume.jsx
@@ -305,6 +305,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -457,6 +458,26 @@ function Resume({ resume }) {
                 {award.awarder} {award.date && `• ${award.date}`}
               </p>
               {award.summary && <p>{award.summary}</p>}
+            </SimpleCard>
+          ))}
+        </StyledSection>
+      )}
+
+      {certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <SimpleCard key={index}>
+              <h4>
+                {cert.url ? (
+                  <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                ) : (
+                  cert.name
+                )}
+              </h4>
+              <p>
+                {cert.issuer} {cert.date && `• ${cert.date}`}
+              </p>
             </SimpleCard>
           ))}
         </StyledSection>

--- a/packages/themes/jsonresume-theme-nordic-minimal/dist/index.js
+++ b/packages/themes/jsonresume-theme-nordic-minimal/dist/index.js
@@ -6224,9 +6224,11 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
+    references,
     projects
   } = resume;
   return /* @__PURE__ */ jsxs(ResumeContainer, { children: [
@@ -6370,6 +6372,62 @@ function Resume({ resume }) {
             award.awarder && /* @__PURE__ */ jsx(Degree, { children: award.awarder }),
             award.date && /* @__PURE__ */ jsx(StyledDateRange, { startDate: award.date }),
             award.summary && /* @__PURE__ */ jsx(Description, { children: award.summary })
+          ] }, index))
+        ] }),
+        certificates && certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+          /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+          certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+            cert.name && /* @__PURE__ */ jsx(Institution, { children: cert.url ? /* @__PURE__ */ jsx(
+              Link,
+              {
+                href: safeUrl(cert.url),
+                target: isExternalUrl(cert.url) ? "_blank" : void 0,
+                children: cert.name
+              }
+            ) : cert.name }),
+            cert.issuer && /* @__PURE__ */ jsx(Degree, { children: cert.issuer }),
+            cert.date && /* @__PURE__ */ jsx(StyledDateRange, { startDate: cert.date })
+          ] }, index))
+        ] }),
+        publications && publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+          /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Publications" }),
+          publications.map((pub, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+            pub.name && /* @__PURE__ */ jsx(Institution, { children: pub.url ? /* @__PURE__ */ jsx(
+              Link,
+              {
+                href: safeUrl(pub.url),
+                target: isExternalUrl(pub.url) ? "_blank" : void 0,
+                children: pub.name
+              }
+            ) : pub.name }),
+            pub.publisher && /* @__PURE__ */ jsx(Degree, { children: pub.publisher }),
+            pub.releaseDate && /* @__PURE__ */ jsx(StyledDateRange, { startDate: pub.releaseDate }),
+            pub.summary && /* @__PURE__ */ jsx(Description, { children: pub.summary })
+          ] }, index))
+        ] }),
+        volunteer && volunteer.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+          /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Volunteer" }),
+          volunteer.map((vol, index) => /* @__PURE__ */ jsxs(ExperienceItem, { children: [
+            /* @__PURE__ */ jsxs(ExperienceHeader, { children: [
+              vol.position && /* @__PURE__ */ jsx(Position, { children: vol.position }),
+              vol.organization && /* @__PURE__ */ jsx(Company, { children: vol.organization }),
+              /* @__PURE__ */ jsx(
+                StyledDateRange,
+                {
+                  startDate: vol.startDate,
+                  endDate: vol.endDate
+                }
+              )
+            ] }),
+            vol.summary && /* @__PURE__ */ jsx(Description, { children: vol.summary }),
+            vol.highlights && vol.highlights.length > 0 && /* @__PURE__ */ jsx(Highlights, { children: vol.highlights.map((highlight, i) => /* @__PURE__ */ jsx(Highlight, { children: highlight }, i)) })
+          ] }, index))
+        ] }),
+        references && references.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+          /* @__PURE__ */ jsx(StyledSectionTitle, { children: "References" }),
+          references.map((ref, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+            ref.name && /* @__PURE__ */ jsx(Institution, { children: ref.name }),
+            ref.reference && /* @__PURE__ */ jsx(Description, { children: ref.reference })
           ] }, index))
         ] })
       ] })

--- a/packages/themes/jsonresume-theme-nordic-minimal/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-nordic-minimal/src/Resume.jsx
@@ -272,9 +272,11 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
+    references,
     projects,
   } = resume;
 
@@ -511,6 +513,107 @@ function Resume({ resume }) {
                   {award.awarder && <Degree>{award.awarder}</Degree>}
                   {award.date && <StyledDateRange startDate={award.date} />}
                   {award.summary && <Description>{award.summary}</Description>}
+                </EducationItem>
+              ))}
+            </StyledSection>
+          )}
+
+          {/* Certificates */}
+          {certificates && certificates.length > 0 && (
+            <StyledSection>
+              <StyledSectionTitle>Certificates</StyledSectionTitle>
+              {certificates.map((cert, index) => (
+                <EducationItem key={index}>
+                  {cert.name && (
+                    <Institution>
+                      {cert.url ? (
+                        <Link
+                          href={safeUrl(cert.url)}
+                          target={
+                            isExternalUrl(cert.url) ? '_blank' : undefined
+                          }
+                        >
+                          {cert.name}
+                        </Link>
+                      ) : (
+                        cert.name
+                      )}
+                    </Institution>
+                  )}
+                  {cert.issuer && <Degree>{cert.issuer}</Degree>}
+                  {cert.date && <StyledDateRange startDate={cert.date} />}
+                </EducationItem>
+              ))}
+            </StyledSection>
+          )}
+
+          {/* Publications */}
+          {publications && publications.length > 0 && (
+            <StyledSection>
+              <StyledSectionTitle>Publications</StyledSectionTitle>
+              {publications.map((pub, index) => (
+                <EducationItem key={index}>
+                  {pub.name && (
+                    <Institution>
+                      {pub.url ? (
+                        <Link
+                          href={safeUrl(pub.url)}
+                          target={isExternalUrl(pub.url) ? '_blank' : undefined}
+                        >
+                          {pub.name}
+                        </Link>
+                      ) : (
+                        pub.name
+                      )}
+                    </Institution>
+                  )}
+                  {pub.publisher && <Degree>{pub.publisher}</Degree>}
+                  {pub.releaseDate && (
+                    <StyledDateRange startDate={pub.releaseDate} />
+                  )}
+                  {pub.summary && <Description>{pub.summary}</Description>}
+                </EducationItem>
+              ))}
+            </StyledSection>
+          )}
+
+          {/* Volunteer */}
+          {volunteer && volunteer.length > 0 && (
+            <StyledSection>
+              <StyledSectionTitle>Volunteer</StyledSectionTitle>
+              {volunteer.map((vol, index) => (
+                <ExperienceItem key={index}>
+                  <ExperienceHeader>
+                    {vol.position && <Position>{vol.position}</Position>}
+                    {vol.organization && <Company>{vol.organization}</Company>}
+                    <StyledDateRange
+                      startDate={vol.startDate}
+                      endDate={vol.endDate}
+                    />
+                  </ExperienceHeader>
+
+                  {vol.summary && <Description>{vol.summary}</Description>}
+
+                  {vol.highlights && vol.highlights.length > 0 && (
+                    <Highlights>
+                      {vol.highlights.map((highlight, i) => (
+                        <Highlight key={i}>{highlight}</Highlight>
+                      ))}
+                    </Highlights>
+                  )}
+                </ExperienceItem>
+              ))}
+            </StyledSection>
+          )}
+
+          {/* References */}
+          {references && references.length > 0 && (
+            <StyledSection>
+              <StyledSectionTitle>References</StyledSectionTitle>
+              {references.map((ref, index) => (
+                <EducationItem key={index}>
+                  {ref.name && <Institution>{ref.name}</Institution>}
+                  {ref.reference && <Description>{ref.reference}</Description>}
                 </EducationItem>
               ))}
             </StyledSection>

--- a/packages/themes/jsonresume-theme-product-manager-canvas/dist/index.js
+++ b/packages/themes/jsonresume-theme-product-manager-canvas/dist/index.js
@@ -6279,6 +6279,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6393,6 +6394,24 @@ function Resume({ resume }) {
               marginTop: "4px"
             },
             children: award.date
+          }
+        )
+      ] }, index2)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+      /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index2) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("strong", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        cert.issuer && ` — ${cert.issuer}`,
+        cert.date && /* @__PURE__ */ jsx(
+          "div",
+          {
+            style: {
+              fontSize: "12px",
+              color: "#6b7280",
+              marginTop: "4px"
+            },
+            children: cert.date
           }
         )
       ] }, index2)) })

--- a/packages/themes/jsonresume-theme-product-manager-canvas/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-product-manager-canvas/src/Resume.jsx
@@ -228,6 +228,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -424,6 +425,37 @@ function Resume({ resume }) {
                     }}
                   >
                     {award.date}
+                  </div>
+                )}
+              </SimpleCard>
+            ))}
+          </SimpleList>
+        </MainSection>
+      )}
+
+      {certificates.length > 0 && (
+        <MainSection>
+          <MainSectionTitle>Certificates</MainSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleCard key={index}>
+                <strong>
+                  {cert.url ? (
+                    <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                  ) : (
+                    cert.name
+                  )}
+                </strong>
+                {cert.issuer && ` — ${cert.issuer}`}
+                {cert.date && (
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: '#6b7280',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {cert.date}
                   </div>
                 )}
               </SimpleCard>

--- a/packages/themes/jsonresume-theme-sidebar/dist/index.js
+++ b/packages/themes/jsonresume-theme-sidebar/dist/index.js
@@ -6131,6 +6131,9 @@ function Resume({ resume }) {
     references = [],
     projects = [],
     awards = [],
+    certificates = [],
+    publications = [],
+    volunteer = [],
     interests = []
   } = resume;
   const nameParts = basics.name ? basics.name.split(" ") : [];
@@ -6264,6 +6267,25 @@ function Resume({ resume }) {
           project.highlights && project.highlights.length > 0 && /* @__PURE__ */ jsx(WorkDescription, { children: project.highlights.map((highlight, idx) => /* @__PURE__ */ jsx("li", { children: highlight }, idx)) })
         ] }, index2))
       ] }),
+      volunteer.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+        /* @__PURE__ */ jsx(MainSectionTitle, { children: "VOLUNTEER" }),
+        volunteer.map((vol, index2) => /* @__PURE__ */ jsxs(WorkItem, { children: [
+          /* @__PURE__ */ jsxs(WorkHeader, { children: [
+            /* @__PURE__ */ jsxs("div", { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: vol.organization }),
+              /* @__PURE__ */ jsx(WorkCompany, { children: vol.position })
+            ] }),
+            /* @__PURE__ */ jsx(WorkDate, { children: vol.startDate && /* @__PURE__ */ jsxs(Fragment, { children: [
+              new Date(vol.startDate).getFullYear(),
+              " -",
+              " ",
+              vol.endDate ? new Date(vol.endDate).getFullYear() : "PRESENT"
+            ] }) })
+          ] }),
+          vol.summary && /* @__PURE__ */ jsx("p", { style: { marginBottom: "10px", color: "#4a4a4a" }, children: vol.summary }),
+          vol.highlights && vol.highlights.length > 0 && /* @__PURE__ */ jsx(WorkDescription, { children: vol.highlights.map((highlight, idx) => /* @__PURE__ */ jsx("li", { children: highlight }, idx)) })
+        ] }, index2))
+      ] }),
       awards.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
         /* @__PURE__ */ jsx(MainSectionTitle, { children: "AWARDS & HONORS" }),
         awards.map((award, index2) => /* @__PURE__ */ jsxs(
@@ -6277,6 +6299,59 @@ function Resume({ resume }) {
                 award.date && ` - ${new Date(award.date).toLocaleDateString()}`
               ] }),
               award.summary && /* @__PURE__ */ jsx("p", { style: { marginTop: "8px", color: "#4a4a4a" }, children: award.summary })
+            ]
+          },
+          index2
+        ))
+      ] }),
+      certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+        /* @__PURE__ */ jsx(MainSectionTitle, { children: "CERTIFICATES" }),
+        certificates.map((cert, index2) => /* @__PURE__ */ jsxs(
+          "div",
+          {
+            style: { marginBottom: "20px", paddingLeft: "25px" },
+            children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: cert.url ? /* @__PURE__ */ jsx(
+                "a",
+                {
+                  href: safeUrl(cert.url),
+                  target: "_blank",
+                  rel: getLinkRel(cert.url, true),
+                  style: { color: "#1e3a52" },
+                  children: cert.name
+                }
+              ) : cert.name }),
+              /* @__PURE__ */ jsxs(WorkCompany, { children: [
+                cert.issuer,
+                cert.date && ` - ${new Date(cert.date).toLocaleDateString()}`
+              ] })
+            ]
+          },
+          index2
+        ))
+      ] }),
+      publications.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+        /* @__PURE__ */ jsx(MainSectionTitle, { children: "PUBLICATIONS" }),
+        publications.map((pub, index2) => /* @__PURE__ */ jsxs(
+          "div",
+          {
+            style: { marginBottom: "20px", paddingLeft: "25px" },
+            children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: pub.url ? /* @__PURE__ */ jsx(
+                "a",
+                {
+                  href: safeUrl(pub.url),
+                  target: "_blank",
+                  rel: getLinkRel(pub.url, true),
+                  style: { color: "#1e3a52" },
+                  children: pub.name
+                }
+              ) : pub.name }),
+              /* @__PURE__ */ jsxs(WorkCompany, { children: [
+                pub.publisher,
+                pub.releaseDate && ` - ${new Date(pub.releaseDate).toLocaleDateString()}`
+              ] }),
+              pub.summary && /* @__PURE__ */ jsx("p", { style: { marginTop: "8px", color: "#4a4a4a" }, children: pub.summary })
             ]
           },
           index2

--- a/packages/themes/jsonresume-theme-sidebar/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-sidebar/src/Resume.jsx
@@ -315,6 +315,9 @@ function Resume({ resume }) {
     references = [],
     projects = [],
     awards = [],
+    certificates = [],
+    publications = [],
+    volunteer = [],
     interests = [],
   } = resume;
 
@@ -543,6 +546,45 @@ function Resume({ resume }) {
           </MainSection>
         )}
 
+        {/* Volunteer Section */}
+        {volunteer.length > 0 && (
+          <MainSection>
+            <MainSectionTitle>VOLUNTEER</MainSectionTitle>
+            {volunteer.map((vol, index) => (
+              <WorkItem key={index}>
+                <WorkHeader>
+                  <div>
+                    <WorkTitle>{vol.organization}</WorkTitle>
+                    <WorkCompany>{vol.position}</WorkCompany>
+                  </div>
+                  <WorkDate>
+                    {vol.startDate && (
+                      <>
+                        {new Date(vol.startDate).getFullYear()} -{' '}
+                        {vol.endDate
+                          ? new Date(vol.endDate).getFullYear()
+                          : 'PRESENT'}
+                      </>
+                    )}
+                  </WorkDate>
+                </WorkHeader>
+                {vol.summary && (
+                  <p style={{ marginBottom: '10px', color: '#4a4a4a' }}>
+                    {vol.summary}
+                  </p>
+                )}
+                {vol.highlights && vol.highlights.length > 0 && (
+                  <WorkDescription>
+                    {vol.highlights.map((highlight, idx) => (
+                      <li key={idx}>{highlight}</li>
+                    ))}
+                  </WorkDescription>
+                )}
+              </WorkItem>
+            ))}
+          </MainSection>
+        )}
+
         {/* Awards Section */}
         {awards.length > 0 && (
           <MainSection>
@@ -561,6 +603,77 @@ function Resume({ resume }) {
                 {award.summary && (
                   <p style={{ marginTop: '8px', color: '#4a4a4a' }}>
                     {award.summary}
+                  </p>
+                )}
+              </div>
+            ))}
+          </MainSection>
+        )}
+
+        {/* Certificates Section */}
+        {certificates.length > 0 && (
+          <MainSection>
+            <MainSectionTitle>CERTIFICATES</MainSectionTitle>
+            {certificates.map((cert, index) => (
+              <div
+                key={index}
+                style={{ marginBottom: '20px', paddingLeft: '25px' }}
+              >
+                <WorkTitle>
+                  {cert.url ? (
+                    <a
+                      href={safeUrl(cert.url)}
+                      target="_blank"
+                      rel={getLinkRel(cert.url, true)}
+                      style={{ color: '#1e3a52' }}
+                    >
+                      {cert.name}
+                    </a>
+                  ) : (
+                    cert.name
+                  )}
+                </WorkTitle>
+                <WorkCompany>
+                  {cert.issuer}
+                  {cert.date &&
+                    ` - ${new Date(cert.date).toLocaleDateString()}`}
+                </WorkCompany>
+              </div>
+            ))}
+          </MainSection>
+        )}
+
+        {/* Publications Section */}
+        {publications.length > 0 && (
+          <MainSection>
+            <MainSectionTitle>PUBLICATIONS</MainSectionTitle>
+            {publications.map((pub, index) => (
+              <div
+                key={index}
+                style={{ marginBottom: '20px', paddingLeft: '25px' }}
+              >
+                <WorkTitle>
+                  {pub.url ? (
+                    <a
+                      href={safeUrl(pub.url)}
+                      target="_blank"
+                      rel={getLinkRel(pub.url, true)}
+                      style={{ color: '#1e3a52' }}
+                    >
+                      {pub.name}
+                    </a>
+                  ) : (
+                    pub.name
+                  )}
+                </WorkTitle>
+                <WorkCompany>
+                  {pub.publisher}
+                  {pub.releaseDate &&
+                    ` - ${new Date(pub.releaseDate).toLocaleDateString()}`}
+                </WorkCompany>
+                {pub.summary && (
+                  <p style={{ marginTop: '8px', color: '#4a4a4a' }}>
+                    {pub.summary}
                   </p>
                 )}
               </div>

--- a/packages/themes/jsonresume-theme-typewriter-modern/dist/index.js
+++ b/packages/themes/jsonresume-theme-typewriter-modern/dist/index.js
@@ -6266,6 +6266,17 @@ function Awards({ awards = [] }) {
     award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
   ] }, index)) });
 }
+function Certificates({ certificates = [] }) {
+  if (!certificates?.length) return null;
+  return /* @__PURE__ */ jsx(Fragment, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+    /* @__PURE__ */ jsx(DateText, { children: cert.date || "" }),
+    /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+    cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+      "Issued by ",
+      cert.issuer
+    ] })
+  ] }, index)) });
+}
 function Publications({ publications = [] }) {
   if (!publications?.length) return null;
   return /* @__PURE__ */ jsx(Fragment, { children: publications.map((pub, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
@@ -6294,6 +6305,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6324,6 +6336,10 @@ function Resume({ resume }) {
     awards?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
       /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Awards" }),
       /* @__PURE__ */ jsx(Awards, { awards })
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(Certificates, { certificates })
     ] }),
     publications?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
       /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Publications" }),

--- a/packages/themes/jsonresume-theme-typewriter-modern/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-typewriter-modern/src/Resume.jsx
@@ -362,6 +362,22 @@ function Awards({ awards = [] }) {
   );
 }
 
+function Certificates({ certificates = [] }) {
+  if (!certificates?.length) return null;
+
+  return (
+    <>
+      {certificates.map((cert, index) => (
+        <EducationItem key={index}>
+          <DateText>{cert.date || ''}</DateText>
+          <Institution>{cert.name}</Institution>
+          {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+        </EducationItem>
+      ))}
+    </>
+  );
+}
+
 function Publications({ publications = [] }) {
   if (!publications?.length) return null;
 
@@ -404,6 +420,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -453,6 +470,13 @@ function Resume({ resume }) {
         <Section>
           <StyledSectionTitle>Awards</StyledSectionTitle>
           <Awards awards={awards} />
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          <Certificates certificates={certificates} />
         </Section>
       )}
 


### PR DESCRIPTION
## Theme section-coverage fixes — batch 4 of 4

Closes part of the per-theme follow-up tracked in #360 (every theme must render ALL JSON Resume sections). Refs #275.

Each theme had section data silently dropped on render. This PR adds the missing sections **in each theme's own existing visual idiom** — reusing the theme's section components/styles (e.g. its `SimpleCard`/`SimpleList`/`EducationItem` blocks, or its sub-component pattern). No redesigns, no new styled-component primitives. Committed `dist/` rebuilt alongside `src/` per repo convention.

### Per-theme before -> after

| theme | sections added |
|---|---|
| `berlin-grid` | certificates |
| `coastal-creative` | certificates |
| `developer-mono` | certificates |
| `french-atelier` | certificates |
| `nordic-minimal` | volunteer, certificates, publications, references |
| `product-manager-canvas` | certificates |
| `sidebar` | volunteer, certificates, publications |
| `typewriter-modern` | certificates |

All other sections per the #360 matrix already rendered and are unchanged.

### Verification

- Rendered each theme from its built `dist/` with a full fixture (extended `packages/test-fixtures/resume-sample.json` with `volunteer`/`certificates`/`publications`, as the QA harness did). Asserted: each newly-added section's sentinel string now appears in the HTML **and** previously-rendering sections (work, education, awards, references, languages, skills) still appear. 8/8 PASS.
- `pnpm turbo lint typecheck prettier` -> exit 0 (18/18 tasks).
- `pnpm --filter registry test -- --run` -> 1318 passed, 24 skipped, 0 failures.

### Out of scope / note

Batch 4's alphabetical slice also included `jacrys`, `macchiato`, and `minyma`. These are **external npm packages** (loaded via `require('jsonresume-theme-*')`, not vendored in this monorepo), so their source cannot be fixed here — they need PRs to their upstream repos. Flagging for a maintainer follow-up.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume themes now support displaying certificates with name, issuer, and date information
  * Certificate names become clickable links when URLs are provided
  * Select themes enhanced with additional sections for volunteer experience, publications, and references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->