### PR TITLE
fix(themes): render missing sections (batch 3: asymmetric-timeline, claude, data-driven, flat, investor-brief, minimalist-grid, new-york-editorial, sales-hunter, two-column-modernist, writers-portfolio)

### DIFF
--- a/packages/themes/jsonresume-theme-asymmetric-timeline/dist/index.js
+++ b/packages/themes/jsonresume-theme-asymmetric-timeline/dist/index.js
@@ -6268,6 +6268,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6341,6 +6342,17 @@ function Resume({ resume }) {
         ] }),
         award.date && /* @__PURE__ */ jsx(DateText, { children: award.date }),
         award.summary && /* @__PURE__ */ jsx(ItemSummary, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(SimpleSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleItem, { children: [
+        /* @__PURE__ */ jsx(SimpleTitle, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Subtitle, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(DateText, { children: cert.date })
       ] }, index))
     ] }),
     publications?.length > 0 && /* @__PURE__ */ jsxs(SimpleSection, { children: [

--- a/packages/themes/jsonresume-theme-asymmetric-timeline/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-asymmetric-timeline/src/Resume.jsx
@@ -296,6 +296,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -436,6 +437,19 @@ function Resume({ resume }) {
               {award.awarder && <Subtitle>Awarded by {award.awarder}</Subtitle>}
               {award.date && <DateText>{award.date}</DateText>}
               {award.summary && <ItemSummary>{award.summary}</ItemSummary>}
+            </SimpleItem>
+          ))}
+        </SimpleSection>
+      )}
+
+      {certificates?.length > 0 && (
+        <SimpleSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <SimpleItem key={index}>
+              <SimpleTitle>{cert.name}</SimpleTitle>
+              {cert.issuer && <Subtitle>Issued by {cert.issuer}</Subtitle>}
+              {cert.date && <DateText>{cert.date}</DateText>}
             </SimpleItem>
           ))}
         </SimpleSection>

--- a/packages/themes/jsonresume-theme-claude/index.js
+++ b/packages/themes/jsonresume-theme-claude/index.js
@@ -60,6 +60,10 @@ export function render(resume) {
     education = [],
     skills = [],
     projects = [],
+    volunteer = [],
+    awards = [],
+    certificates = [],
+    publications = [],
     languages = [],
     references = [],
   } = resume;
@@ -581,6 +585,135 @@ export function render(resume) {
       </div>`
         )
         .join('')}
+    </section>`
+        : ''
+    }
+
+    ${
+      volunteer.length
+        ? `
+    <section class="section">
+      <div class="section-title">Volunteer</div>
+      ${volunteer
+        .map(
+          (vol) => `
+      <div class="entry">
+        <div class="entry-header">
+          <span class="entry-title">${vol.position || ''}</span>
+          <span class="entry-date">${dateRange(
+            vol.startDate,
+            vol.endDate
+          )}</span>
+        </div>
+        <div class="entry-subtitle">${vol.organization || ''}</div>
+        ${
+          vol.summary
+            ? `<div class="entry-body">${renderMarkdown(vol.summary)}</div>`
+            : ''
+        }
+      </div>`
+        )
+        .join('')}
+    </section>`
+        : ''
+    }
+
+    ${
+      awards.length
+        ? `
+    <section class="section">
+      <div class="section-title">Awards</div>
+      ${awards
+        .map(
+          (award) => `
+      <div class="entry">
+        <div class="entry-header">
+          <span class="entry-title">${award.title || ''}</span>
+          <span class="entry-date">${formatDate(award.date)}</span>
+        </div>
+        <div class="entry-subtitle">${award.awarder || ''}</div>
+        ${
+          award.summary
+            ? `<div class="entry-body">${renderMarkdown(award.summary)}</div>`
+            : ''
+        }
+      </div>`
+        )
+        .join('')}
+    </section>`
+        : ''
+    }
+
+    ${
+      certificates.length
+        ? `
+    <section class="section">
+      <div class="section-title">Certificates</div>
+      ${certificates
+        .map(
+          (cert) => `
+      <div class="entry">
+        <div class="entry-header">
+          <span class="entry-title">${
+            cert.url
+              ? `<a href="${safeUrl(cert.url)}">${cert.name || ''}</a>`
+              : cert.name || ''
+          }</span>
+          <span class="entry-date">${formatDate(cert.date)}</span>
+        </div>
+        <div class="entry-subtitle">${cert.issuer || ''}</div>
+      </div>`
+        )
+        .join('')}
+    </section>`
+        : ''
+    }
+
+    ${
+      publications.length
+        ? `
+    <section class="section">
+      <div class="section-title">Publications</div>
+      ${publications
+        .map(
+          (pub) => `
+      <div class="entry">
+        <div class="entry-header">
+          <span class="entry-title">${
+            pub.url
+              ? `<a href="${safeUrl(pub.url)}">${pub.name || ''}</a>`
+              : pub.name || ''
+          }</span>
+          <span class="entry-date">${formatDate(pub.releaseDate)}</span>
+        </div>
+        <div class="entry-subtitle">${pub.publisher || ''}</div>
+        ${
+          pub.summary
+            ? `<div class="entry-body">${renderMarkdown(pub.summary)}</div>`
+            : ''
+        }
+      </div>`
+        )
+        .join('')}
+    </section>`
+        : ''
+    }
+
+    ${
+      languages.length
+        ? `
+    <section class="section">
+      <div class="section-title">Languages</div>
+      <div class="skill-tags">
+        ${languages
+          .map(
+            (lang) =>
+              `<span class="skill-tag">${lang.language || ''}${
+                lang.fluency ? ` — ${lang.fluency}` : ''
+              }</span>`
+          )
+          .join('')}
+      </div>
     </section>`
         : ''
     }

--- a/packages/themes/jsonresume-theme-data-driven/dist/index.js
+++ b/packages/themes/jsonresume-theme-data-driven/dist/index.js
@@ -6092,7 +6092,11 @@ function Resume({ resume }) {
     skills = [],
     projects = [],
     volunteer = [],
-    awards = []
+    awards = [],
+    certificates = [],
+    publications = [],
+    languages = [],
+    references = []
   } = resume;
   return /* @__PURE__ */ jsxs(Fragment, { children: [
     /* @__PURE__ */ jsx(GlobalStyle, {}),
@@ -6266,6 +6270,44 @@ function Resume({ resume }) {
               }
             }
           )
+        ] }, i))
+      ] }),
+      certificates.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(SectionTitle, { children: "Certifications" }),
+        certificates.map((cert, i) => /* @__PURE__ */ jsxs(Item, { children: [
+          /* @__PURE__ */ jsx(ItemHeader, { children: /* @__PURE__ */ jsx(ItemTitle, { children: cert.name }) }),
+          cert.issuer && /* @__PURE__ */ jsx(ItemSubtitle, { children: cert.issuer }),
+          cert.date && /* @__PURE__ */ jsx(ItemMeta, { children: /* @__PURE__ */ jsx("span", { children: cert.date }) })
+        ] }, i))
+      ] }),
+      publications.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(SectionTitle, { children: "Publications" }),
+        publications.map((pub, i) => /* @__PURE__ */ jsxs(Item, { children: [
+          /* @__PURE__ */ jsx(ItemHeader, { children: /* @__PURE__ */ jsx(ItemTitle, { children: pub.name }) }),
+          pub.publisher && /* @__PURE__ */ jsx(ItemSubtitle, { children: pub.publisher }),
+          pub.releaseDate && /* @__PURE__ */ jsx(ItemMeta, { children: /* @__PURE__ */ jsx("span", { children: pub.releaseDate }) }),
+          pub.summary && /* @__PURE__ */ jsx(
+            Description,
+            {
+              dangerouslySetInnerHTML: {
+                __html: boldNumbers(pub.summary)
+              }
+            }
+          )
+        ] }, i))
+      ] }),
+      languages.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(SectionTitle, { children: "Languages" }),
+        /* @__PURE__ */ jsx(BadgeList, { children: languages.map((lang, i) => /* @__PURE__ */ jsxs(Badge, { children: [
+          lang.language,
+          lang.fluency && ` — ${lang.fluency}`
+        ] }, i)) })
+      ] }),
+      references.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(SectionTitle, { children: "References" }),
+        references.map((ref, i) => /* @__PURE__ */ jsxs(Item, { children: [
+          /* @__PURE__ */ jsx(ItemHeader, { children: /* @__PURE__ */ jsx(ItemTitle, { children: ref.name }) }),
+          ref.reference && /* @__PURE__ */ jsx(Description, { children: ref.reference })
         ] }, i))
       ] })
     ] })

--- a/packages/themes/jsonresume-theme-data-driven/src/ui/Resume.jsx
+++ b/packages/themes/jsonresume-theme-data-driven/src/ui/Resume.jsx
@@ -258,6 +258,10 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
+    publications = [],
+    languages = [],
+    references = [],
   } = resume;
 
   return (
@@ -550,6 +554,83 @@ function Resume({ resume }) {
                     }}
                   />
                 )}
+              </Item>
+            ))}
+          </Section>
+        )}
+
+        {/* Certificates */}
+        {certificates.length > 0 && (
+          <Section>
+            <SectionTitle>Certifications</SectionTitle>
+            {certificates.map((cert, i) => (
+              <Item key={i}>
+                <ItemHeader>
+                  <ItemTitle>{cert.name}</ItemTitle>
+                </ItemHeader>
+                {cert.issuer && <ItemSubtitle>{cert.issuer}</ItemSubtitle>}
+                {cert.date && (
+                  <ItemMeta>
+                    <span>{cert.date}</span>
+                  </ItemMeta>
+                )}
+              </Item>
+            ))}
+          </Section>
+        )}
+
+        {/* Publications */}
+        {publications.length > 0 && (
+          <Section>
+            <SectionTitle>Publications</SectionTitle>
+            {publications.map((pub, i) => (
+              <Item key={i}>
+                <ItemHeader>
+                  <ItemTitle>{pub.name}</ItemTitle>
+                </ItemHeader>
+                {pub.publisher && <ItemSubtitle>{pub.publisher}</ItemSubtitle>}
+                {pub.releaseDate && (
+                  <ItemMeta>
+                    <span>{pub.releaseDate}</span>
+                  </ItemMeta>
+                )}
+                {pub.summary && (
+                  <Description
+                    dangerouslySetInnerHTML={{
+                      __html: boldNumbers(pub.summary),
+                    }}
+                  />
+                )}
+              </Item>
+            ))}
+          </Section>
+        )}
+
+        {/* Languages */}
+        {languages.length > 0 && (
+          <Section>
+            <SectionTitle>Languages</SectionTitle>
+            <BadgeList>
+              {languages.map((lang, i) => (
+                <Badge key={i}>
+                  {lang.language}
+                  {lang.fluency && ` — ${lang.fluency}`}
+                </Badge>
+              ))}
+            </BadgeList>
+          </Section>
+        )}
+
+        {/* References */}
+        {references.length > 0 && (
+          <Section>
+            <SectionTitle>References</SectionTitle>
+            {references.map((ref, i) => (
+              <Item key={i}>
+                <ItemHeader>
+                  <ItemTitle>{ref.name}</ItemTitle>
+                </ItemHeader>
+                {ref.reference && <Description>{ref.reference}</Description>}
               </Item>
             ))}
           </Section>

--- a/packages/themes/jsonresume-theme-flat/resume.js
+++ b/packages/themes/jsonresume-theme-flat/resume.js
@@ -5,7 +5,9 @@ import work from './templates/work.js';
 import volunteer from './templates/volunteer.js';
 import education from './templates/education.js';
 import awards from './templates/awards.js';
+import certificates from './templates/certificates.js';
 import publications from './templates/publications.js';
+import projects from './templates/projects.js';
 import skills from './templates/skills.js';
 import languages from './templates/languages.js';
 import interests from './templates/interests.js';
@@ -18,7 +20,9 @@ export default head +
   volunteer +
   education +
   awards +
+  certificates +
   publications +
+  projects +
   skills +
   languages +
   interests +

--- a/packages/themes/jsonresume-theme-flat/templates/awards.js
+++ b/packages/themes/jsonresume-theme-flat/templates/awards.js
@@ -33,4 +33,4 @@ export default `	<section id="awards" class="row">
 	</section>
 	{{/if}}
 	
-	{{#if resume.publications.length}}`;
+	{{#if resume.certificates.length}}`;

--- a/packages/themes/jsonresume-theme-flat/templates/certificates.js
+++ b/packages/themes/jsonresume-theme-flat/templates/certificates.js
@@ -1,0 +1,35 @@
+export default `	<section id="certificates" class="row">
+		<aside class="col-sm-3">
+			<h3>Certificates</h3>
+		</aside>
+		<div class="col-sm-9">
+			<div class="row">
+			{{#each resume.certificates}}
+			<div class="col-sm-12">
+				<h4 class="strike-through">
+					<span>{{name}}</span>
+					{{#date}}
+					<span class="date">
+						{{.}}
+					</span>
+					{{/date}}
+				</h4>
+				{{#url}}
+				<div class="website pull-right">
+					<a href="{{.}}">{{.}}</a>
+				</div>
+				{{/url}}
+				{{#issuer}}
+				<div class="issuer">
+					<em>Issued by</em>
+					<strong>{{.}}</strong>
+				</div>
+				{{/issuer}}
+			</div>
+			{{/each}}
+			</div>
+		</div>
+	</section>
+	{{/if}}
+
+	{{#if resume.publications.length}}`;

--- a/packages/themes/jsonresume-theme-flat/templates/projects.js
+++ b/packages/themes/jsonresume-theme-flat/templates/projects.js
@@ -1,0 +1,41 @@
+export default `	<section id="projects" class="row">
+		<aside class="col-sm-3">
+			<h3>Projects</h3>
+		</aside>
+		<div class="col-sm-9">
+			<div class="row">
+			{{#each resume.projects}}
+			<div class="col-sm-12">
+				<h4 class="strike-through">
+					<span>{{name}}</span>
+					{{#if startDate}}
+					<span class="date">
+						{{startDate}} — {{endDate}}
+					</span>
+					{{/if}}
+				</h4>
+				{{#url}}
+				<div class="website pull-right">
+					<a href="{{.}}">{{.}}</a>
+				</div>
+				{{/url}}
+				{{#description}}
+				<div class="summary">
+					<p>{{.}}</p>
+				</div>
+				{{/description}}
+				{{#if highlights.length}}
+				<ul class="highlights">
+					{{#highlights}}
+					<li class="bullet">{{.}}</li>
+					{{/highlights}}
+				</ul>
+				{{/if}}
+			</div>
+			{{/each}}
+			</div>
+		</div>
+	</section>
+	{{/if}}
+
+	{{#if resume.skills.length}}`;

--- a/packages/themes/jsonresume-theme-flat/templates/publications.js
+++ b/packages/themes/jsonresume-theme-flat/templates/publications.js
@@ -35,4 +35,4 @@ export default `	<section id="publications" class="row">
 	</section>
 	{{/if}}
 	
-	{{#if resume.skills.length}}`;
+	{{#if resume.projects.length}}`;

--- a/packages/themes/jsonresume-theme-investor-brief/dist/index.js
+++ b/packages/themes/jsonresume-theme-investor-brief/dist/index.js
@@ -6252,6 +6252,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6394,6 +6395,24 @@ function Resume({ resume }) {
               marginTop: "4px"
             },
             children: award.date
+          }
+        )
+      ] }, index)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+      /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("strong", { children: cert.name }),
+        cert.issuer && ` — ${cert.issuer}`,
+        cert.date && /* @__PURE__ */ jsx(
+          "div",
+          {
+            style: {
+              fontSize: "13px",
+              color: "#9ca3af",
+              marginTop: "4px"
+            },
+            children: cert.date
           }
         )
       ] }, index)) })

--- a/packages/themes/jsonresume-theme-investor-brief/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-investor-brief/src/Resume.jsx
@@ -234,6 +234,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -477,6 +478,31 @@ function Resume({ resume }) {
                     }}
                   >
                     {award.date}
+                  </div>
+                )}
+              </SimpleCard>
+            ))}
+          </SimpleList>
+        </MainSection>
+      )}
+
+      {certificates.length > 0 && (
+        <MainSection>
+          <MainSectionTitle>Certificates</MainSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleCard key={index}>
+                <strong>{cert.name}</strong>
+                {cert.issuer && ` — ${cert.issuer}`}
+                {cert.date && (
+                  <div
+                    style={{
+                      fontSize: '13px',
+                      color: '#9ca3af',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {cert.date}
                   </div>
                 )}
               </SimpleCard>

--- a/packages/themes/jsonresume-theme-minimalist-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-minimalist-grid/dist/index.js
@@ -6289,6 +6289,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6391,6 +6392,24 @@ function Resume({ resume }) {
               marginTop: "4px"
             },
             children: award.date
+          }
+        )
+      ] }, index)) })
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+      /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleItem, { children: [
+        /* @__PURE__ */ jsx("strong", { children: cert.name }),
+        cert.issuer && ` — ${cert.issuer}`,
+        cert.date && /* @__PURE__ */ jsx(
+          "div",
+          {
+            style: {
+              fontSize: "12px",
+              color: "#9ca3af",
+              marginTop: "4px"
+            },
+            children: cert.date
           }
         )
       ] }, index)) })

--- a/packages/themes/jsonresume-theme-minimalist-grid/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-minimalist-grid/src/Resume.jsx
@@ -234,6 +234,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -420,6 +421,31 @@ function Resume({ resume }) {
                     }}
                   >
                     {award.date}
+                  </div>
+                )}
+              </SimpleItem>
+            ))}
+          </SimpleList>
+        </MainSection>
+      )}
+
+      {certificates.length > 0 && (
+        <MainSection>
+          <MainSectionTitle>Certificates</MainSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleItem key={index}>
+                <strong>{cert.name}</strong>
+                {cert.issuer && ` — ${cert.issuer}`}
+                {cert.date && (
+                  <div
+                    style={{
+                      fontSize: '12px',
+                      color: '#9ca3af',
+                      marginTop: '4px',
+                    }}
+                  >
+                    {cert.date}
                   </div>
                 )}
               </SimpleItem>

--- a/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
+++ b/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
@@ -6348,6 +6348,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6468,6 +6469,19 @@ function Resume({ resume }) {
           ] })
         ] }),
         award.summary && /* @__PURE__ */ jsx(ItemDescription, { children: award.summary })
+      ] }, index)) })
+    ] }),
+    certificates && certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      /* @__PURE__ */ jsx(SimpleList, { children: certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleItem, { children: [
+        /* @__PURE__ */ jsx(ItemTitle, { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: cert.url, children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs(ItemMeta, { children: [
+          cert.issuer,
+          cert.date && /* @__PURE__ */ jsxs(Fragment, { children: [
+            " • ",
+            cert.date
+          ] })
+        ] })
       ] }, index)) })
     ] }),
     languages && languages.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-new-york-editorial/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-new-york-editorial/src/Resume.jsx
@@ -338,6 +338,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -509,6 +510,29 @@ function Resume({ resume }) {
                 {award.summary && (
                   <ItemDescription>{award.summary}</ItemDescription>
                 )}
+              </SimpleItem>
+            ))}
+          </SimpleList>
+        </StyledSection>
+      )}
+
+      {certificates && certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          <SimpleList>
+            {certificates.map((cert, index) => (
+              <SimpleItem key={index}>
+                <ItemTitle>
+                  {cert.url ? (
+                    <Link href={cert.url}>{cert.name}</Link>
+                  ) : (
+                    cert.name
+                  )}
+                </ItemTitle>
+                <ItemMeta>
+                  {cert.issuer}
+                  {cert.date && <> • {cert.date}</>}
+                </ItemMeta>
               </SimpleItem>
             ))}
           </SimpleList>

--- a/packages/themes/jsonresume-theme-sales-hunter/dist/index.js
+++ b/packages/themes/jsonresume-theme-sales-hunter/dist/index.js
@@ -6211,6 +6211,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6325,6 +6326,17 @@ function Resume({ resume }) {
         ] }),
         award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
         award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     publications?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-sales-hunter/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-sales-hunter/src/Resume.jsx
@@ -228,6 +228,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -388,6 +389,19 @@ function Resume({ resume }) {
               {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
               {award.date && <EducationDate>{award.date}</EducationDate>}
               {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-two-column-modernist/dist/index.js
+++ b/packages/themes/jsonresume-theme-two-column-modernist/dist/index.js
@@ -6325,6 +6325,30 @@ function AwardsSection({ awards }) {
     ] }, i))
   ] });
 }
+function CertificatesSection({ certificates }) {
+  if (!certificates || certificates.length === 0) return null;
+  return /* @__PURE__ */ jsxs(Section, { children: [
+    /* @__PURE__ */ jsx(SectionTitle, { children: "Certificates" }),
+    certificates.map((cert, i) => /* @__PURE__ */ jsxs(Entry, { children: [
+      /* @__PURE__ */ jsxs(EntryHeader, { children: [
+        cert.name && /* @__PURE__ */ jsx(EntryTitle, { children: cert.name }),
+        /* @__PURE__ */ jsxs(EntryMeta, { children: [
+          cert.issuer && /* @__PURE__ */ jsx(EntryOrganization, { children: cert.issuer }),
+          cert.date && /* @__PURE__ */ jsx(EntryDate, { children: cert.date })
+        ] })
+      ] }),
+      cert.url && /* @__PURE__ */ jsx("div", { children: /* @__PURE__ */ jsx(
+        "a",
+        {
+          href: safeUrl(cert.url),
+          target: "_blank",
+          rel: "noopener noreferrer",
+          children: "View Certificate"
+        }
+      ) })
+    ] }, i))
+  ] });
+}
 function PublicationsSection({ publications }) {
   if (!publications || publications.length === 0) return null;
   return /* @__PURE__ */ jsxs(Section, { children: [
@@ -6370,6 +6394,7 @@ function Resume({ resume }) {
     projects,
     volunteer,
     awards,
+    certificates,
     publications,
     interests,
     references
@@ -6395,6 +6420,7 @@ function Resume({ resume }) {
       /* @__PURE__ */ jsx(ProjectsSection, { projects }),
       /* @__PURE__ */ jsx(VolunteerSection, { volunteer }),
       /* @__PURE__ */ jsx(AwardsSection, { awards }),
+      /* @__PURE__ */ jsx(CertificatesSection, { certificates }),
       /* @__PURE__ */ jsx(PublicationsSection, { publications }),
       /* @__PURE__ */ jsx(InterestsSection, { interests }),
       /* @__PURE__ */ jsx(ReferencesSection, { references })

--- a/packages/themes/jsonresume-theme-two-column-modernist/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-two-column-modernist/src/Resume.jsx
@@ -575,6 +575,40 @@ function AwardsSection({ awards }) {
   );
 }
 
+function CertificatesSection({ certificates }) {
+  if (!certificates || certificates.length === 0) return null;
+
+  return (
+    <Section>
+      <SectionTitle>Certificates</SectionTitle>
+      {certificates.map((cert, i) => (
+        <Entry key={i}>
+          <EntryHeader>
+            {cert.name && <EntryTitle>{cert.name}</EntryTitle>}
+            <EntryMeta>
+              {cert.issuer && (
+                <EntryOrganization>{cert.issuer}</EntryOrganization>
+              )}
+              {cert.date && <EntryDate>{cert.date}</EntryDate>}
+            </EntryMeta>
+          </EntryHeader>
+          {cert.url && (
+            <div>
+              <a
+                href={safeUrl(cert.url)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                View Certificate
+              </a>
+            </div>
+          )}
+        </Entry>
+      ))}
+    </Section>
+  );
+}
+
 function PublicationsSection({ publications }) {
   if (!publications || publications.length === 0) return null;
 
@@ -639,6 +673,7 @@ function Resume({ resume }) {
     projects,
     volunteer,
     awards,
+    certificates,
     publications,
     interests,
     references,
@@ -674,6 +709,7 @@ function Resume({ resume }) {
         <ProjectsSection projects={projects} />
         <VolunteerSection volunteer={volunteer} />
         <AwardsSection awards={awards} />
+        <CertificatesSection certificates={certificates} />
         <PublicationsSection publications={publications} />
         <InterestsSection interests={interests} />
         <ReferencesSection references={references} />

--- a/packages/themes/jsonresume-theme-writers-portfolio/dist/index.js
+++ b/packages/themes/jsonresume-theme-writers-portfolio/dist/index.js
@@ -6260,6 +6260,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6371,6 +6372,17 @@ function Resume({ resume }) {
         ] }),
         award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
         award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+      ] }, index2))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index2) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index2))
     ] }),
     languages?.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-writers-portfolio/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-writers-portfolio/src/Resume.jsx
@@ -291,6 +291,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -461,6 +462,19 @@ function Resume({ resume }) {
               {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
               {award.date && <EducationDate>{award.date}</EducationDate>}
               {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </StyledSection>
+      )}
+
+      {certificates?.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </StyledSection>


### PR DESCRIPTION
## Theme section-coverage fixes — batch 3 of 4

Closes per-theme gaps from the QA matrix in #360: themes that render fine but silently drop one or more JSON Resume sections. Each section was added in the theme's **own existing idiom** (reusing its section components / styled blocks) — additive only, no redesign.

Refs #275, #360.

### Per-theme before/after

| theme | sections before | sections added | sections after |
|---|---|---|---|
| `asymmetric-timeline` | all except certificates | certificates | full |
| `claude` | basics, work, education, skills, projects, interests, references | volunteer, awards, certificates, publications, languages | full |
| `data-driven` | basics, work, volunteer, education, awards, skills, interests, projects | certificates, publications, languages, references | full |
| `flat` | all except certificates, projects | certificates, projects | full |
| `investor-brief` | all except certificates | certificates | full |
| `minimalist-grid` | all except certificates | certificates | full |
| `new-york-editorial` | all except certificates | certificates | full |
| `sales-hunter` | all except certificates | certificates | full |
| `two-column-modernist` | all except certificates | certificates | full |
| `writers-portfolio` | all except certificates | certificates | full |

### Implementation notes
- **Vite/styled-components themes** (asymmetric-timeline, data-driven, investor-brief, minimalist-grid, new-york-editorial, sales-hunter, two-column-modernist, writers-portfolio): new sections reuse the theme's existing `Section`/`Item`/styled blocks. `dist/` rebuilt with `vite build` and committed alongside `src/` per repo convention (committed dist is the production artifact the registry loads).
- **`claude`** (HTML-string template): new sections added in the theme's `.entry` / `.skill-tag` markup idiom.
- **`flat`** (Handlebars partial chain): added `templates/certificates.js` and `templates/projects.js`, wired into the `{{#if}}` section chain in `resume.js`.
- No styled-component was named `Date` (avoids the global-shadow crash from #359). ES6 imports only; per-file changes stay small.

### Not included (out of scope for this repo)
The matrix's alphabetical batch-3 slice also nominally included `lucide` (awards) and `paper-plus-plus` (work, certificates, publications, references, projects), but those are **external npm packages** (`require('jsonresume-theme-lucide')` / `jsonresume-theme-paper-plus-plus`) resolved from `node_modules` — they have no editable source in this monorepo, so they need upstream PRs in their own repos. Flagging for a maintainer follow-up.

### Verification
- Rendered each of the 10 themes with a full fixture (sample resume extended with volunteer/certificates/publications, as the QA harness did); asserted the newly-added section sentinel strings now appear **and** previously-rendering sections still do. All 10 pass.
- `pnpm turbo lint typecheck` — 17/17 tasks successful (exit 0).
- `prettier -c .` — clean.
- `pnpm --filter registry test -- --run` — green (1318 passed, 24 pre-existing skips).
- `jsonresume-theme-data-driven` own vitest — 13/13 pass.

— AI