### PR TITLE
fix(themes): render missing sections (batch 2: architects-portfolio, californian-warm, creative-studio, executive-slate, graph-paper-grid, london-bureau, mid-century-resume, monochrome-noir, pacific-horizon, reference, urban-techno)

### DIFF
--- a/packages/themes/jsonresume-theme-architects-portfolio/dist/index.js
+++ b/packages/themes/jsonresume-theme-architects-portfolio/dist/index.js
@@ -6204,6 +6204,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6243,6 +6244,93 @@ function Resume({ resume }) {
         edu.institution && /* @__PURE__ */ jsx(Institution, { children: edu.institution }),
         (edu.studyType || edu.area) && /* @__PURE__ */ jsx(Degree, { children: edu.studyType && edu.area ? `${edu.studyType} in ${edu.area}` : edu.studyType || edu.area }),
         (edu.startDate || edu.endDate) && /* @__PURE__ */ jsx(EducationDate, { children: /* @__PURE__ */ jsx(DateRange, { startDate: edu.startDate, endDate: edu.endDate }) })
+      ] }, index))
+    ] }),
+    projects && projects.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Projects" }),
+      projects.map((project, index) => /* @__PURE__ */ jsxs(WorkItem, { children: [
+        /* @__PURE__ */ jsxs(WorkHeader, { children: [
+          /* @__PURE__ */ jsxs("div", { children: [
+            project.name && /* @__PURE__ */ jsx(Position, { children: project.name }),
+            project.type && /* @__PURE__ */ jsx(Company, { children: project.type })
+          ] }),
+          (project.startDate || project.endDate) && /* @__PURE__ */ jsx(DateText, { children: /* @__PURE__ */ jsx(
+            DateRange,
+            {
+              startDate: project.startDate,
+              endDate: project.endDate
+            }
+          ) })
+        ] }),
+        project.description && /* @__PURE__ */ jsx(WorkSummary, { children: project.description }),
+        project.highlights && project.highlights.length > 0 && /* @__PURE__ */ jsx(Highlights, { children: project.highlights.map((highlight, i) => /* @__PURE__ */ jsx("li", { children: highlight }, i)) })
+      ] }, index))
+    ] }),
+    volunteer && volunteer.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Volunteer" }),
+      volunteer.map((vol, index) => /* @__PURE__ */ jsxs(WorkItem, { children: [
+        /* @__PURE__ */ jsxs(WorkHeader, { children: [
+          /* @__PURE__ */ jsxs("div", { children: [
+            vol.position && /* @__PURE__ */ jsx(Position, { children: vol.position }),
+            vol.organization && /* @__PURE__ */ jsx(Company, { children: vol.organization })
+          ] }),
+          (vol.startDate || vol.endDate) && /* @__PURE__ */ jsx(DateText, { children: /* @__PURE__ */ jsx(
+            DateRange,
+            {
+              startDate: vol.startDate,
+              endDate: vol.endDate
+            }
+          ) })
+        ] }),
+        vol.summary && /* @__PURE__ */ jsx(WorkSummary, { children: vol.summary }),
+        vol.highlights && vol.highlights.length > 0 && /* @__PURE__ */ jsx(Highlights, { children: vol.highlights.map((highlight, i) => /* @__PURE__ */ jsx("li", { children: highlight }, i)) })
+      ] }, index))
+    ] }),
+    awards && awards.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Awards" }),
+      awards.map((award, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        award.title && /* @__PURE__ */ jsx(Institution, { children: award.title }),
+        award.awarder && /* @__PURE__ */ jsx(Degree, { children: award.awarder }),
+        award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
+        award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates && certificates.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        cert.name && /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsx(Degree, { children: cert.issuer }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
+      ] }, index))
+    ] }),
+    publications && publications.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Publications" }),
+      publications.map((pub, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        pub.name && /* @__PURE__ */ jsx(Institution, { children: pub.name }),
+        pub.publisher && /* @__PURE__ */ jsx(Degree, { children: pub.publisher }),
+        pub.releaseDate && /* @__PURE__ */ jsx(EducationDate, { children: pub.releaseDate }),
+        pub.summary && /* @__PURE__ */ jsx(WorkSummary, { children: pub.summary })
+      ] }, index))
+    ] }),
+    languages && languages.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Languages" }),
+      /* @__PURE__ */ jsx(SkillsGrid, { children: languages.map((lang, index) => /* @__PURE__ */ jsxs(SkillCategory, { children: [
+        lang.language && /* @__PURE__ */ jsx(SkillName, { children: lang.language }),
+        lang.fluency && /* @__PURE__ */ jsx(SkillTags, { children: lang.fluency })
+      ] }, index)) })
+    ] }),
+    interests && interests.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Interests" }),
+      /* @__PURE__ */ jsx(SkillsGrid, { children: interests.map((interest, index) => /* @__PURE__ */ jsxs(SkillCategory, { children: [
+        interest.name && /* @__PURE__ */ jsx(SkillName, { children: interest.name }),
+        interest.keywords && interest.keywords.length > 0 && /* @__PURE__ */ jsx(SkillTags, { children: interest.keywords.join(", ") })
+      ] }, index)) })
+    ] }),
+    references && references.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "References" }),
+      references.map((ref, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        ref.name && /* @__PURE__ */ jsx(Institution, { children: ref.name }),
+        ref.reference && /* @__PURE__ */ jsx(WorkSummary, { children: ref.reference })
       ] }, index))
     ] })
   ] });

--- a/packages/themes/jsonresume-theme-architects-portfolio/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-architects-portfolio/src/Resume.jsx
@@ -238,6 +238,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -314,6 +315,157 @@ function Resume({ resume }) {
                   <DateRange startDate={edu.startDate} endDate={edu.endDate} />
                 </EducationDate>
               )}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {projects && projects.length > 0 && (
+        <Section>
+          <SectionTitle>Projects</SectionTitle>
+          {projects.map((project, index) => (
+            <WorkItem key={index}>
+              <WorkHeader>
+                <div>
+                  {project.name && <Position>{project.name}</Position>}
+                  {project.type && <Company>{project.type}</Company>}
+                </div>
+                {(project.startDate || project.endDate) && (
+                  <DateText>
+                    <DateRange
+                      startDate={project.startDate}
+                      endDate={project.endDate}
+                    />
+                  </DateText>
+                )}
+              </WorkHeader>
+              {project.description && (
+                <WorkSummary>{project.description}</WorkSummary>
+              )}
+              {project.highlights && project.highlights.length > 0 && (
+                <Highlights>
+                  {project.highlights.map((highlight, i) => (
+                    <li key={i}>{highlight}</li>
+                  ))}
+                </Highlights>
+              )}
+            </WorkItem>
+          ))}
+        </Section>
+      )}
+
+      {volunteer && volunteer.length > 0 && (
+        <Section>
+          <SectionTitle>Volunteer</SectionTitle>
+          {volunteer.map((vol, index) => (
+            <WorkItem key={index}>
+              <WorkHeader>
+                <div>
+                  {vol.position && <Position>{vol.position}</Position>}
+                  {vol.organization && <Company>{vol.organization}</Company>}
+                </div>
+                {(vol.startDate || vol.endDate) && (
+                  <DateText>
+                    <DateRange
+                      startDate={vol.startDate}
+                      endDate={vol.endDate}
+                    />
+                  </DateText>
+                )}
+              </WorkHeader>
+              {vol.summary && <WorkSummary>{vol.summary}</WorkSummary>}
+              {vol.highlights && vol.highlights.length > 0 && (
+                <Highlights>
+                  {vol.highlights.map((highlight, i) => (
+                    <li key={i}>{highlight}</li>
+                  ))}
+                </Highlights>
+              )}
+            </WorkItem>
+          ))}
+        </Section>
+      )}
+
+      {awards && awards.length > 0 && (
+        <Section>
+          <SectionTitle>Awards</SectionTitle>
+          {awards.map((award, index) => (
+            <EducationItem key={index}>
+              {award.title && <Institution>{award.title}</Institution>}
+              {award.awarder && <Degree>{award.awarder}</Degree>}
+              {award.date && <EducationDate>{award.date}</EducationDate>}
+              {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates && certificates.length > 0 && (
+        <Section>
+          <SectionTitle>Certificates</SectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              {cert.name && <Institution>{cert.name}</Institution>}
+              {cert.issuer && <Degree>{cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {publications && publications.length > 0 && (
+        <Section>
+          <SectionTitle>Publications</SectionTitle>
+          {publications.map((pub, index) => (
+            <EducationItem key={index}>
+              {pub.name && <Institution>{pub.name}</Institution>}
+              {pub.publisher && <Degree>{pub.publisher}</Degree>}
+              {pub.releaseDate && (
+                <EducationDate>{pub.releaseDate}</EducationDate>
+              )}
+              {pub.summary && <WorkSummary>{pub.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {languages && languages.length > 0 && (
+        <Section>
+          <SectionTitle>Languages</SectionTitle>
+          <SkillsGrid>
+            {languages.map((lang, index) => (
+              <SkillCategory key={index}>
+                {lang.language && <SkillName>{lang.language}</SkillName>}
+                {lang.fluency && <SkillTags>{lang.fluency}</SkillTags>}
+              </SkillCategory>
+            ))}
+          </SkillsGrid>
+        </Section>
+      )}
+
+      {interests && interests.length > 0 && (
+        <Section>
+          <SectionTitle>Interests</SectionTitle>
+          <SkillsGrid>
+            {interests.map((interest, index) => (
+              <SkillCategory key={index}>
+                {interest.name && <SkillName>{interest.name}</SkillName>}
+                {interest.keywords && interest.keywords.length > 0 && (
+                  <SkillTags>{interest.keywords.join(', ')}</SkillTags>
+                )}
+              </SkillCategory>
+            ))}
+          </SkillsGrid>
+        </Section>
+      )}
+
+      {references && references.length > 0 && (
+        <Section>
+          <SectionTitle>References</SectionTitle>
+          {references.map((ref, index) => (
+            <EducationItem key={index}>
+              {ref.name && <Institution>{ref.name}</Institution>}
+              {ref.reference && <WorkSummary>{ref.reference}</WorkSummary>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-californian-warm/dist/index.js
+++ b/packages/themes/jsonresume-theme-californian-warm/dist/index.js
@@ -6327,6 +6327,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6415,6 +6416,17 @@ function Resume({ resume }) {
           award.date && `• ${award.date}`
         ] }),
         award.summary && /* @__PURE__ */ jsx("p", { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("h4", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs("p", { children: [
+          cert.issuer,
+          " ",
+          cert.date && `• ${cert.date}`
+        ] })
       ] }, index))
     ] }),
     publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-californian-warm/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-californian-warm/src/Resume.jsx
@@ -272,6 +272,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -412,6 +413,26 @@ function Resume({ resume }) {
                 {award.awarder} {award.date && `• ${award.date}`}
               </p>
               {award.summary && <p>{award.summary}</p>}
+            </SimpleCard>
+          ))}
+        </StyledSection>
+      )}
+
+      {certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <SimpleCard key={index}>
+              <h4>
+                {cert.url ? (
+                  <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                ) : (
+                  cert.name
+                )}
+              </h4>
+              <p>
+                {cert.issuer} {cert.date && `• ${cert.date}`}
+              </p>
             </SimpleCard>
           ))}
         </StyledSection>

--- a/packages/themes/jsonresume-theme-creative-studio/dist/index.js
+++ b/packages/themes/jsonresume-theme-creative-studio/dist/index.js
@@ -6219,6 +6219,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6303,6 +6304,17 @@ function Resume({ resume }) {
         ] }),
         award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
         award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     publications?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-creative-studio/src/ui/Resume.jsx
+++ b/packages/themes/jsonresume-theme-creative-studio/src/ui/Resume.jsx
@@ -240,6 +240,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -378,6 +379,19 @@ function Resume({ resume }) {
               {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
               {award.date && <EducationDate>{award.date}</EducationDate>}
               {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-executive-slate/dist/index.js
+++ b/packages/themes/jsonresume-theme-executive-slate/dist/index.js
@@ -6274,6 +6274,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6379,6 +6380,17 @@ function Resume({ resume }) {
           ] }),
           award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
           award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+        ] }, index2))
+      ] }),
+      certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+        /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+        certificates.map((cert, index2) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+          /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+          cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+            "Issued by ",
+            cert.issuer
+          ] }),
+          cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
         ] }, index2))
       ] }),
       publications?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-executive-slate/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-executive-slate/src/Resume.jsx
@@ -296,6 +296,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -454,6 +455,19 @@ function Resume({ resume }) {
                 {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
                 {award.date && <EducationDate>{award.date}</EducationDate>}
                 {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+              </EducationItem>
+            ))}
+          </Section>
+        )}
+
+        {certificates?.length > 0 && (
+          <Section>
+            <StyledSectionTitle>Certificates</StyledSectionTitle>
+            {certificates.map((cert, index) => (
+              <EducationItem key={index}>
+                <Institution>{cert.name}</Institution>
+                {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+                {cert.date && <EducationDate>{cert.date}</EducationDate>}
               </EducationItem>
             ))}
           </Section>

--- a/packages/themes/jsonresume-theme-graph-paper-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-graph-paper-grid/dist/index.js
@@ -6327,6 +6327,7 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
@@ -6435,6 +6436,22 @@ function Resume({ resume }) {
         award.awarder && /* @__PURE__ */ jsx(Awarder, { children: award.awarder }),
         award.date && /* @__PURE__ */ jsx(SingleDate, { children: formatDateRange({ startDate: award.date }) }),
         award.summary && /* @__PURE__ */ jsx(Description, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates && certificates.length > 0 && /* @__PURE__ */ jsxs(ContentSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(AwardItem, { children: [
+        cert.name && /* @__PURE__ */ jsx(AwardTitle, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsx(Awarder, { children: cert.issuer }),
+        cert.date && /* @__PURE__ */ jsx(SingleDate, { children: formatDateRange({ startDate: cert.date }) }),
+        cert.url && /* @__PURE__ */ jsx(ProjectUrl, { children: /* @__PURE__ */ jsx(
+          Link,
+          {
+            href: safeUrl(cert.url),
+            target: isExternalUrl(cert.url) ? "_blank" : void 0,
+            children: cert.url.replace(/^https?:\/\//, "")
+          }
+        ) })
       ] }, index))
     ] }),
     publications && publications.length > 0 && /* @__PURE__ */ jsxs(ContentSection, { children: [

--- a/packages/themes/jsonresume-theme-graph-paper-grid/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-graph-paper-grid/src/Resume.jsx
@@ -333,6 +333,7 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
@@ -498,6 +499,34 @@ function Resume({ resume }) {
                 </SingleDate>
               )}
               {award.summary && <Description>{award.summary}</Description>}
+            </AwardItem>
+          ))}
+        </ContentSection>
+      )}
+
+      {/* Certificates */}
+      {certificates && certificates.length > 0 && (
+        <ContentSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <AwardItem key={index}>
+              {cert.name && <AwardTitle>{cert.name}</AwardTitle>}
+              {cert.issuer && <Awarder>{cert.issuer}</Awarder>}
+              {cert.date && (
+                <SingleDate>
+                  {formatDateRange({ startDate: cert.date })}
+                </SingleDate>
+              )}
+              {cert.url && (
+                <ProjectUrl>
+                  <Link
+                    href={safeUrl(cert.url)}
+                    target={isExternalUrl(cert.url) ? '_blank' : undefined}
+                  >
+                    {cert.url.replace(/^https?:\/\//, '')}
+                  </Link>
+                </ProjectUrl>
+              )}
             </AwardItem>
           ))}
         </ContentSection>

--- a/packages/themes/jsonresume-theme-london-bureau/dist/index.js
+++ b/packages/themes/jsonresume-theme-london-bureau/dist/index.js
@@ -6303,6 +6303,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6391,6 +6392,17 @@ function Resume({ resume }) {
           award.date && `• ${award.date}`
         ] }),
         award.summary && /* @__PURE__ */ jsx("p", { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("h4", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs("p", { children: [
+          cert.issuer,
+          " ",
+          cert.date && `• ${cert.date}`
+        ] })
       ] }, index))
     ] }),
     publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-london-bureau/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-london-bureau/src/Resume.jsx
@@ -248,6 +248,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -390,6 +391,26 @@ function Resume({ resume }) {
                 {award.awarder} {award.date && `• ${award.date}`}
               </p>
               {award.summary && <p>{award.summary}</p>}
+            </SimpleCard>
+          ))}
+        </StyledSection>
+      )}
+
+      {certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <SimpleCard key={index}>
+              <h4>
+                {cert.url ? (
+                  <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                ) : (
+                  cert.name
+                )}
+              </h4>
+              <p>
+                {cert.issuer} {cert.date && `• ${cert.date}`}
+              </p>
             </SimpleCard>
           ))}
         </StyledSection>

--- a/packages/themes/jsonresume-theme-mid-century-resume/dist/index.js
+++ b/packages/themes/jsonresume-theme-mid-century-resume/dist/index.js
@@ -6264,6 +6264,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6350,6 +6351,17 @@ function Resume({ resume }) {
         ] }),
         award.date && /* @__PURE__ */ jsx(EducationDate, { children: award.date }),
         award.summary && /* @__PURE__ */ jsx(WorkSummary, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(EducationItem, { children: [
+        /* @__PURE__ */ jsx(Institution, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsxs(Degree, { children: [
+          "Issued by ",
+          cert.issuer
+        ] }),
+        cert.date && /* @__PURE__ */ jsx(EducationDate, { children: cert.date })
       ] }, index))
     ] }),
     publications?.length > 0 && /* @__PURE__ */ jsxs(Section, { children: [

--- a/packages/themes/jsonresume-theme-mid-century-resume/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-mid-century-resume/src/Resume.jsx
@@ -283,6 +283,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -424,6 +425,19 @@ function Resume({ resume }) {
               {award.awarder && <Degree>Awarded by {award.awarder}</Degree>}
               {award.date && <EducationDate>{award.date}</EducationDate>}
               {award.summary && <WorkSummary>{award.summary}</WorkSummary>}
+            </EducationItem>
+          ))}
+        </Section>
+      )}
+
+      {certificates?.length > 0 && (
+        <Section>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <EducationItem key={index}>
+              <Institution>{cert.name}</Institution>
+              {cert.issuer && <Degree>Issued by {cert.issuer}</Degree>}
+              {cert.date && <EducationDate>{cert.date}</EducationDate>}
             </EducationItem>
           ))}
         </Section>

--- a/packages/themes/jsonresume-theme-monochrome-noir/dist/index.js
+++ b/packages/themes/jsonresume-theme-monochrome-noir/dist/index.js
@@ -6313,6 +6313,7 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
@@ -6421,6 +6422,22 @@ function Resume({ resume }) {
         award.awarder && /* @__PURE__ */ jsx(Awarder, { children: award.awarder }),
         award.date && /* @__PURE__ */ jsx(StyledDateRange, { startDate: award.date }),
         award.summary && /* @__PURE__ */ jsx(Description, { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates && certificates.length > 0 && /* @__PURE__ */ jsxs(ContentSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(AwardItem, { children: [
+        cert.name && /* @__PURE__ */ jsx(AwardTitle, { children: cert.name }),
+        cert.issuer && /* @__PURE__ */ jsx(Awarder, { children: cert.issuer }),
+        cert.date && /* @__PURE__ */ jsx(StyledDateRange, { startDate: cert.date }),
+        cert.url && /* @__PURE__ */ jsx(ProjectUrl, { children: /* @__PURE__ */ jsx(
+          Link,
+          {
+            href: safeUrl(cert.url),
+            target: isExternalUrl(cert.url) ? "_blank" : void 0,
+            children: cert.url.replace(/^https?:\/\//, "")
+          }
+        ) })
       ] }, index))
     ] }),
     publications && publications.length > 0 && /* @__PURE__ */ jsxs(ContentSection, { children: [

--- a/packages/themes/jsonresume-theme-monochrome-noir/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-monochrome-noir/src/Resume.jsx
@@ -317,6 +317,7 @@ function Resume({ resume }) {
     skills,
     volunteer,
     awards,
+    certificates,
     publications,
     languages,
     interests,
@@ -478,6 +479,30 @@ function Resume({ resume }) {
               {award.awarder && <Awarder>{award.awarder}</Awarder>}
               {award.date && <StyledDateRange startDate={award.date} />}
               {award.summary && <Description>{award.summary}</Description>}
+            </AwardItem>
+          ))}
+        </ContentSection>
+      )}
+
+      {/* Certificates */}
+      {certificates && certificates.length > 0 && (
+        <ContentSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <AwardItem key={index}>
+              {cert.name && <AwardTitle>{cert.name}</AwardTitle>}
+              {cert.issuer && <Awarder>{cert.issuer}</Awarder>}
+              {cert.date && <StyledDateRange startDate={cert.date} />}
+              {cert.url && (
+                <ProjectUrl>
+                  <Link
+                    href={safeUrl(cert.url)}
+                    target={isExternalUrl(cert.url) ? '_blank' : undefined}
+                  >
+                    {cert.url.replace(/^https?:\/\//, '')}
+                  </Link>
+                </ProjectUrl>
+              )}
             </AwardItem>
           ))}
         </ContentSection>

--- a/packages/themes/jsonresume-theme-pacific-horizon/dist/index.js
+++ b/packages/themes/jsonresume-theme-pacific-horizon/dist/index.js
@@ -6289,6 +6289,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6377,6 +6378,17 @@ function Resume({ resume }) {
           award.date && `• ${award.date}`
         ] }),
         award.summary && /* @__PURE__ */ jsx("p", { children: award.summary })
+      ] }, index))
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [
+      /* @__PURE__ */ jsx(StyledSectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index) => /* @__PURE__ */ jsxs(SimpleCard, { children: [
+        /* @__PURE__ */ jsx("h4", { children: cert.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(cert.url), children: cert.name }) : cert.name }),
+        /* @__PURE__ */ jsxs("p", { children: [
+          cert.issuer,
+          " ",
+          cert.date && `• ${cert.date}`
+        ] })
       ] }, index))
     ] }),
     publications.length > 0 && /* @__PURE__ */ jsxs(StyledSection, { children: [

--- a/packages/themes/jsonresume-theme-pacific-horizon/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-pacific-horizon/src/Resume.jsx
@@ -234,6 +234,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -374,6 +375,26 @@ function Resume({ resume }) {
                 {award.awarder} {award.date && `• ${award.date}`}
               </p>
               {award.summary && <p>{award.summary}</p>}
+            </SimpleCard>
+          ))}
+        </StyledSection>
+      )}
+
+      {certificates.length > 0 && (
+        <StyledSection>
+          <StyledSectionTitle>Certificates</StyledSectionTitle>
+          {certificates.map((cert, index) => (
+            <SimpleCard key={index}>
+              <h4>
+                {cert.url ? (
+                  <Link href={safeUrl(cert.url)}>{cert.name}</Link>
+                ) : (
+                  cert.name
+                )}
+              </h4>
+              <p>
+                {cert.issuer} {cert.date && `• ${cert.date}`}
+              </p>
             </SimpleCard>
           ))}
         </StyledSection>

--- a/packages/themes/jsonresume-theme-reference/dist/index.js
+++ b/packages/themes/jsonresume-theme-reference/dist/index.js
@@ -6096,6 +6096,7 @@ function Resume({ resume }) {
     skills = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6277,6 +6278,27 @@ function Resume({ resume }) {
               )
             ] })
           ] })
+        },
+        index2
+      ))
+    ] }),
+    certificates.length > 0 && /* @__PURE__ */ jsxs(Section, { id: "certificates", children: [
+      /* @__PURE__ */ jsx(SectionTitle, { children: "Certificates" }),
+      certificates.map((cert, index2) => /* @__PURE__ */ jsx(
+        ListItem,
+        {
+          title: cert.name,
+          subtitle: cert.issuer,
+          dateRange: cert.date,
+          description: cert.url && safeUrl(cert.url) ? /* @__PURE__ */ jsx(
+            "a",
+            {
+              href: safeUrl(cert.url),
+              target: "_blank",
+              rel: getLinkRel(cert.url, true),
+              children: cert.url
+            }
+          ) : void 0
         },
         index2
       ))

--- a/packages/themes/jsonresume-theme-reference/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-reference/src/Resume.jsx
@@ -94,6 +94,7 @@ function Resume({ resume }) {
     skills = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -331,6 +332,32 @@ function Resume({ resume }) {
                     </>
                   )}
                 </>
+              }
+            />
+          ))}
+        </Section>
+      )}
+
+      {/* Certificates Section */}
+      {certificates.length > 0 && (
+        <Section id="certificates">
+          <SectionTitle>Certificates</SectionTitle>
+          {certificates.map((cert, index) => (
+            <ListItem
+              key={index}
+              title={cert.name}
+              subtitle={cert.issuer}
+              dateRange={cert.date}
+              description={
+                cert.url && safeUrl(cert.url) ? (
+                  <a
+                    href={safeUrl(cert.url)}
+                    target="_blank"
+                    rel={getLinkRel(cert.url, true)}
+                  >
+                    {cert.url}
+                  </a>
+                ) : undefined
               }
             />
           ))}

--- a/packages/themes/jsonresume-theme-urban-techno/dist/index.js
+++ b/packages/themes/jsonresume-theme-urban-techno/dist/index.js
@@ -6265,6 +6265,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -6385,6 +6386,66 @@ function Resume({ resume }) {
               /* @__PURE__ */ jsx(WorkTitle, { children: project.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(project.url), children: project.name }) : project.name }),
               project.description && /* @__PURE__ */ jsx(WorkDescription, { children: project.description }),
               project.highlights && project.highlights.length > 0 && /* @__PURE__ */ jsx(WorkHighlights, { children: project.highlights.map((highlight, i) => /* @__PURE__ */ jsx("li", { children: highlight }, i)) })
+            ] })
+          ] }, index))
+        ] }),
+        volunteer.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+          /* @__PURE__ */ jsx(MainSectionTitle, { children: "Volunteer" }),
+          volunteer.map((vol, index) => /* @__PURE__ */ jsxs(WorkGrid, { children: [
+            /* @__PURE__ */ jsx(DateColumn, { children: /* @__PURE__ */ jsx(
+              DateRange,
+              {
+                startDate: vol.startDate,
+                endDate: vol.endDate
+              }
+            ) }),
+            /* @__PURE__ */ jsxs(ContentColumn, { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: vol.position }),
+              vol.organization && /* @__PURE__ */ jsx(WorkCompany, { children: vol.organization }),
+              vol.summary && /* @__PURE__ */ jsx(WorkDescription, { children: vol.summary }),
+              vol.highlights && vol.highlights.length > 0 && /* @__PURE__ */ jsx(WorkHighlights, { children: vol.highlights.map((highlight, i) => /* @__PURE__ */ jsx("li", { children: highlight }, i)) })
+            ] })
+          ] }, index))
+        ] }),
+        awards.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+          /* @__PURE__ */ jsx(MainSectionTitle, { children: "Awards" }),
+          awards.map((award, index) => /* @__PURE__ */ jsxs(WorkGrid, { children: [
+            /* @__PURE__ */ jsx(DateColumn, { children: award.date }),
+            /* @__PURE__ */ jsxs(ContentColumn, { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: award.title }),
+              award.awarder && /* @__PURE__ */ jsx(WorkCompany, { children: award.awarder }),
+              award.summary && /* @__PURE__ */ jsx(WorkDescription, { children: award.summary })
+            ] })
+          ] }, index))
+        ] }),
+        certificates.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+          /* @__PURE__ */ jsx(MainSectionTitle, { children: "Certificates" }),
+          certificates.map((cert, index) => /* @__PURE__ */ jsxs(WorkGrid, { children: [
+            /* @__PURE__ */ jsx(DateColumn, { children: cert.date }),
+            /* @__PURE__ */ jsxs(ContentColumn, { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: cert.name }),
+              cert.issuer && /* @__PURE__ */ jsx(WorkCompany, { children: cert.issuer })
+            ] })
+          ] }, index))
+        ] }),
+        publications.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+          /* @__PURE__ */ jsx(MainSectionTitle, { children: "Publications" }),
+          publications.map((pub, index) => /* @__PURE__ */ jsxs(WorkGrid, { children: [
+            /* @__PURE__ */ jsx(DateColumn, { children: pub.releaseDate }),
+            /* @__PURE__ */ jsxs(ContentColumn, { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: pub.url ? /* @__PURE__ */ jsx(Link, { href: safeUrl(pub.url), children: pub.name }) : pub.name }),
+              pub.publisher && /* @__PURE__ */ jsx(WorkCompany, { children: pub.publisher }),
+              pub.summary && /* @__PURE__ */ jsx(WorkDescription, { children: pub.summary })
+            ] })
+          ] }, index))
+        ] }),
+        references.length > 0 && /* @__PURE__ */ jsxs(MainSection, { children: [
+          /* @__PURE__ */ jsx(MainSectionTitle, { children: "References" }),
+          references.map((ref, index) => /* @__PURE__ */ jsxs(WorkGrid, { children: [
+            /* @__PURE__ */ jsx(DateColumn, {}),
+            /* @__PURE__ */ jsxs(ContentColumn, { children: [
+              /* @__PURE__ */ jsx(WorkTitle, { children: ref.name }),
+              ref.reference && /* @__PURE__ */ jsx(WorkDescription, { children: ref.reference })
             ] })
           ] }, index))
         ] })

--- a/packages/themes/jsonresume-theme-urban-techno/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-urban-techno/src/Resume.jsx
@@ -271,6 +271,7 @@ function Resume({ resume }) {
     projects = [],
     volunteer = [],
     awards = [],
+    certificates = [],
     publications = [],
     languages = [],
     interests = [],
@@ -451,6 +452,116 @@ function Resume({ resume }) {
                           <li key={i}>{highlight}</li>
                         ))}
                       </WorkHighlights>
+                    )}
+                  </ContentColumn>
+                </WorkGrid>
+              ))}
+            </MainSection>
+          )}
+
+          {volunteer.length > 0 && (
+            <MainSection>
+              <MainSectionTitle>Volunteer</MainSectionTitle>
+              {volunteer.map((vol, index) => (
+                <WorkGrid key={index}>
+                  <DateColumn>
+                    <DateRange
+                      startDate={vol.startDate}
+                      endDate={vol.endDate}
+                    />
+                  </DateColumn>
+                  <ContentColumn>
+                    <WorkTitle>{vol.position}</WorkTitle>
+                    {vol.organization && (
+                      <WorkCompany>{vol.organization}</WorkCompany>
+                    )}
+                    {vol.summary && (
+                      <WorkDescription>{vol.summary}</WorkDescription>
+                    )}
+                    {vol.highlights && vol.highlights.length > 0 && (
+                      <WorkHighlights>
+                        {vol.highlights.map((highlight, i) => (
+                          <li key={i}>{highlight}</li>
+                        ))}
+                      </WorkHighlights>
+                    )}
+                  </ContentColumn>
+                </WorkGrid>
+              ))}
+            </MainSection>
+          )}
+
+          {awards.length > 0 && (
+            <MainSection>
+              <MainSectionTitle>Awards</MainSectionTitle>
+              {awards.map((award, index) => (
+                <WorkGrid key={index}>
+                  <DateColumn>{award.date}</DateColumn>
+                  <ContentColumn>
+                    <WorkTitle>{award.title}</WorkTitle>
+                    {award.awarder && (
+                      <WorkCompany>{award.awarder}</WorkCompany>
+                    )}
+                    {award.summary && (
+                      <WorkDescription>{award.summary}</WorkDescription>
+                    )}
+                  </ContentColumn>
+                </WorkGrid>
+              ))}
+            </MainSection>
+          )}
+
+          {certificates.length > 0 && (
+            <MainSection>
+              <MainSectionTitle>Certificates</MainSectionTitle>
+              {certificates.map((cert, index) => (
+                <WorkGrid key={index}>
+                  <DateColumn>{cert.date}</DateColumn>
+                  <ContentColumn>
+                    <WorkTitle>{cert.name}</WorkTitle>
+                    {cert.issuer && <WorkCompany>{cert.issuer}</WorkCompany>}
+                  </ContentColumn>
+                </WorkGrid>
+              ))}
+            </MainSection>
+          )}
+
+          {publications.length > 0 && (
+            <MainSection>
+              <MainSectionTitle>Publications</MainSectionTitle>
+              {publications.map((pub, index) => (
+                <WorkGrid key={index}>
+                  <DateColumn>{pub.releaseDate}</DateColumn>
+                  <ContentColumn>
+                    <WorkTitle>
+                      {pub.url ? (
+                        <Link href={safeUrl(pub.url)}>{pub.name}</Link>
+                      ) : (
+                        pub.name
+                      )}
+                    </WorkTitle>
+                    {pub.publisher && (
+                      <WorkCompany>{pub.publisher}</WorkCompany>
+                    )}
+                    {pub.summary && (
+                      <WorkDescription>{pub.summary}</WorkDescription>
+                    )}
+                  </ContentColumn>
+                </WorkGrid>
+              ))}
+            </MainSection>
+          )}
+
+          {references.length > 0 && (
+            <MainSection>
+              <MainSectionTitle>References</MainSectionTitle>
+              {references.map((ref, index) => (
+                <WorkGrid key={index}>
+                  <DateColumn />
+                  <ContentColumn>
+                    <WorkTitle>{ref.name}</WorkTitle>
+                    {ref.reference && (
+                      <WorkDescription>{ref.reference}</WorkDescription>
                     )}
                   </ContentColumn>
                 </WorkGrid>


### PR DESCRIPTION
## Theme section-coverage fixes — batch 2 of 4

Part of the coordinated sweep from the QA matrix in #360 (every registered theme must render ALL JSON Resume schema sections). This batch covers the alphabetical-index `% 4 == 1` slice of themes that silently dropped one or more sections. Sections were added in each theme's **own existing visual idiom** — reusing its existing styled-components / `@resume/core` primitives. No redesigns; additive only.

### Per-theme before → after (sections newly rendered)

| theme | sections added |
|---|---|
| `architects-portfolio` | volunteer, awards, certificates, publications, languages, interests, references, projects |
| `californian-warm` | certificates |
| `creative-studio` | certificates |
| `executive-slate` | certificates |
| `graph-paper-grid` | certificates |
| `london-bureau` | certificates |
| `mid-century-resume` | certificates |
| `monochrome-noir` | certificates |
| `pacific-horizon` | certificates |
| `reference` | certificates |
| `urban-techno` | volunteer, awards, certificates, publications, references |

`architects-portfolio` previously rendered only basics/work/skills/education — the remaining 8 sections are now wired in using its existing `WorkItem` / `EducationItem` / `SkillsGrid` blocks.

### Out of scope (separate upstream PR)

- `tan-responsive` was in the index slice but is an **external npm package** (`jsonresume-theme-tan-responsive@^0.0.7`), not a local monorepo package, so it cannot be fixed in this repo. Flagging for a separate upstream change.

### Verification

- Rebuilt every touched theme (`vite build`) and committed `dist/` alongside `src/` (repo convention — registry loads from `dist`).
- Rendered each theme from its **built dist** with a full fixture (`packages/test-fixtures/resume-sample.json` extended with `certificates` / `volunteer` / `publications`, mirroring the QA harness) and asserted: newly-added section sentinels now appear AND previously-rendering sections (work/education/skills) still render. 11/11 PASS.
- Repo gates green: `pnpm turbo lint typecheck prettier` exit 0; `pnpm --filter registry test -- --run` → 1318 passed, 0 failed.
- No styled-component named `Date` introduced (avoids the global-shadow crash from #359).

Refs #275, #360

— AI
