### PR TITLE
docs: bring docs-site content in line with the consolidated repo

### DIFF
--- a/apps/docs/content/docs/001-overview.md
+++ b/apps/docs/content/docs/001-overview.md
@@ -7,6 +7,15 @@ description: "Docwright documentation"
 
 This project implements a comprehensive platform for managing, analyzing, and visualizing professional resumes and job data. It integrates multiple subsystems including resume parsing and analysis, job matching and decision support, interactive job graph visualization, interview facilitation, and user dashboard components. The architecture is modular, with distinct UI components, hooks for state and data management, and backend API endpoints supporting AI-driven analysis and data persistence.
 
+## Repository at a Glance
+
+This is a pnpm + Turborepo monorepo. Following the 2026 org consolidation, several previously standalone repositories now live here:
+
+- **Applications (`apps/`)** — the hosted registry and product app (`apps/registry`), the marketing site at jsonresume.org (`apps/homepage2`), and this documentation site at docs.jsonresume.org (`apps/docs`).
+- **Core ecosystem packages (`packages/`)** — the canonical schema and validator (`packages/schema`, npm `@jsonresume/schema`), the revived command-line tool (`packages/cli`, npm `resume-cli`), a Rust implementation of the schema (`packages/core-rust`, `json-resume-serde`), shared resume components (`packages/resume-core`), the shared UI library (`packages/ui`), the HN job-search CLI (`packages/job-search`), ATS validation (`packages/ats-validator`), format converters (`packages/converters/*`), and ~49 resume themes (`packages/themes/*`).
+
+The subsystems described below live primarily in `apps/registry`. For the full package map and the Changesets-based release process, see the Repository Structure page. For the schema itself, see the Schema Definitions page.
+
 ## Architecture Overview
 
 ```mermaid

--- a/apps/docs/content/docs/002-repository-structure.md
+++ b/apps/docs/content/docs/002-repository-structure.md
@@ -17,6 +17,8 @@ For details on build orchestration and task execution, see the Turbo Build syste
 
 The repository is structured as a monorepo managed by pnpm and Turbo Build. It contains multiple packages under `packages/` and `packages/themes/`, as well as applications under `apps/`. Each package and app has its own `package.json` defining dependencies, scripts, and exports. TypeScript configuration is layered with base configs extended by app- or package-specific `tsconfig.json` files.
 
+The 2026 org consolidation folded several previously standalone repositories into this monorepo. Most notably, the canonical JSON Resume schema now lives at `packages/schema` (published to npm as [`@jsonresume/schema`](https://www.npmjs.com/package/@jsonresume/schema), imported with full history from `jsonresume/resume-schema`), and the command-line tool now lives at `packages/cli` (revived and published to npm as [`resume-cli`](https://www.npmjs.com/package/resume-cli)). A Rust implementation of the schema lives at `packages/core-rust` (`json-resume-serde`). Three applications live under `apps/`: the hosted registry (`apps/registry`), the marketing site (`apps/homepage2`), and this documentation site (`apps/docs`).
+
 The build and development lifecycle is orchestrated by Turbo Build (`turbo.json`), which defines tasks, caching, and environment variables for the entire monorepo. Documentation generation is configured via Docwright (`docwright.config.yaml`), which scans selected directories and outputs generated MDX content into the docs app.
 
 ```mermaid
@@ -30,10 +32,17 @@ flowchart TD
     Root --> Themes["packages/themes/*"]
 
     Apps --> Registry["apps/registry"]
+    Apps --> Homepage["apps/homepage2"]
+    Apps --> Docs["apps/docs"]
+    Packages --> Schema["packages/schema"]
+    Packages --> CLI["packages/cli"]
+    Packages --> CoreRust["packages/core-rust"]
     Packages --> Core["packages/resume-core"]
     Packages --> UI["packages/ui"]
     Packages --> ATSValidator["packages/ats-validator"]
     Packages --> JobSearch["packages/job-search"]
+    Packages --> Converters["packages/converters/*"]
+    Packages --> ThemeConfigPkg["packages/theme-config"]
     Packages --> ESLintConfig["packages/eslint-config-custom"]
     Packages --> TSConfig["packages/tsconfig"]
     Themes --> ThemePackages["packages/themes/*"]
@@ -150,6 +159,14 @@ The registry app is a Next.js application with Prisma integration, responsible f
 
 Developers interact with this app by running the scripts for development, build, linting, testing, and database client generation. The TypeScript config ensures type safety and module resolution aligned with Next.js conventions.
 
+## Application: Marketing Site (`apps/homepage2`)
+
+The `homepage2` app is the JSON Resume marketing site served at `jsonresume.org`. It is a Next.js app that introduces the project, the schema, and the ecosystem of tools and themes. Its `dev` script defaults to port 3002 (the same default as the docs app), so the two are run one at a time during development.
+
+## Application: Documentation Site (`apps/docs`)
+
+The `docs` app is this documentation site, served at `docs.jsonresume.org`. It is built with Fumadocs on top of Next.js, authoring content as MDX under `apps/docs/content/docs`. The build is a static export (`output: 'export'` in `next.config.mjs`). See the Documentation Site page for details on its toolchain and deployment.
+
 ## UI Package (`packages/ui/package.json` and `tsconfig.json`)
 
 The UI package provides shared React components and styles used across apps and themes.
@@ -222,6 +239,62 @@ This package provides utilities for validating Applicant Tracking System (ATS) c
 
 Used to validate that generated resume HTML meets ATS requirements, ensuring compatibility with job application systems.
 
+## Schema Package (`packages/schema/package.json`)
+
+This is the canonical JSON Resume schema and validator, published publicly to npm as `@jsonresume/schema`. It was imported with full history from the former standalone `jsonresume/resume-schema` repository during the 2026 consolidation.
+
+### Key Points
+
+- Named `@jsonresume/schema`; not private (published to npm).
+- Ships `schema.json` (the canonical resume schema), `job-schema.json`, `sample.resume.json`, `sample.job.json`, and a `validator.js` entry point (`main`).
+- `schema.json` is a JSON Schema **draft-07** document with `additionalProperties: true` at the root and within nested objects — extra/custom fields are allowed.
+- `validator.js` exposes a `validate(resumeJson, callback)` API backed by the `jsonschema` library, plus the raw `schema` and `jobSchema` objects.
+- `validate` script runs `ajv validate` against the draft-07 metaschema; unit tests run with `tape`.
+
+### Interaction
+
+This package is the single source of truth for the resume structure. The registry app and `resume-cli` both depend on it (`workspace:*`). The Rust crate in `packages/core-rust` mirrors it, and downstream consumers install it from npm.
+
+## CLI Package (`packages/cli/package.json`)
+
+The revived JSON Resume command-line tool, published publicly to npm as `resume-cli`. The old standalone `jsonresume/resume-cli` repository is archived; the tool now lives here and was modernized for current Node.js.
+
+### Key Points
+
+- Named `resume-cli` (binary: `resume`); version 3.x, not private.
+- Requires Node.js 18 or newer (`engines.node: ">=18"`).
+- Commands: `init`, `validate`, `export`, and `serve` (see `lib/`).
+- `validate` uses **Ajv** (`ajv` + `ajv-formats`, `strict: false`) to check a `resume.json` against the draft-07 schema resolved from `@jsonresume/schema/schema.json`.
+- Depends on `@jsonresume/schema` (`workspace:*`); built with Babel (`lib` → `build`); tested with Jest.
+- Release tooling note: the old semantic-release config that previously lived in this package has been removed — Changesets is now the single release path (see below).
+
+### Interaction
+
+End users install `resume-cli` globally to initialize, validate, export, and serve `resume.json` files. It consumes the canonical schema package for validation.
+
+## Rust Core Package (`packages/core-rust`)
+
+A Rust implementation of the JSON Resume schema, providing strongly typed structs for serialization, deserialization, and validation.
+
+### Key Points
+
+- Cargo crate `json-resume-serde` (this is a Rust crate, not a Node package — it has a `Cargo.toml`, not a `package.json`, so it is not part of the pnpm workspace graph).
+- Built on `serde` and `serde_valid`; mirrors the canonical schema in `packages/schema`.
+- Publishing to crates.io is TBD; consume via a Git or path dependency for now.
+
+### Interaction
+
+Provides a type-safe Rust path for parsing, validating, and re-serializing `resume.json`. Its structs are kept in sync with `packages/schema` by hand when the schema changes.
+
+## Converters (`packages/converters/*`)
+
+Standalone format converters for JSON Resume data.
+
+### Key Points
+
+- Currently contains `@jsonresume/jsonresume-to-rendercv`, a published CLI that converts a JSON Resume into the RenderCV YAML format.
+- Each converter is its own npm package with its own `package.json` and `bin`.
+
 ## Job Search CLI Package (`packages/job-search/package.json`)
 
 This package implements a CLI tool to search Hacker News jobs matched against a JSON Resume.
@@ -282,12 +355,23 @@ The `packages/tsconfig` package provides shared TypeScript configuration presets
 ## Summary of Key Scripts and Build Flow
 
 - Root scripts invoke Turbo Build to run tasks across packages.
-- Each package defines its own build, lint, test, and publish scripts.
+- Each package defines its own build, lint, and test scripts. npm publishing is centralized through Changesets (see Release Process below) rather than per-package publish scripts.
 - The registry app uses Prisma for database client generation and Next.js for SSR.
 - Themes use Vite for building React-based resume themes.
 - UI package uses Storybook for component development.
 - Testing is done with Vitest and Playwright for unit and end-to-end tests.
 - Docwright generates documentation from source code with AI assistance.
+
+## Release Process (Changesets)
+
+npm publishing for the monorepo's public packages (e.g. `@jsonresume/schema`, `resume-cli`) is managed by [Changesets](https://github.com/changesets/changesets), configured in `.changeset/config.json` (base branch `master`, `access: public`). This replaced the previous `release.yml` workflow and the semantic-release config that used to live in the CLI package — Changesets is now the single release path.
+
+The `.github/workflows/release-packages.yml` workflow runs on every push to `master`:
+
+1. If there are pending changesets, it opens or updates a "Version Packages" pull request (`pnpm changeset version`).
+2. When that PR is merged (no pending changesets remain), it publishes any unpublished package versions to npm (`pnpm changeset publish`).
+
+Publishing uses npm Trusted Publishing (OIDC) where a package has registered this repo+workflow as a trusted publisher, and falls back to an `NPM_TOKEN` secret otherwise. See `docs/RELEASING.md` for details.
 
 ## Key Relationships
 

--- a/apps/docs/content/docs/013-schema-definitions.md
+++ b/apps/docs/content/docs/013-schema-definitions.md
@@ -7,9 +7,23 @@ description: "Docwright documentation"
 
 This module defines the JSON schema and TypeScript types that model the structure of resumes within the system. It provides a comprehensive, strongly typed contract for all resume sections, including personal information, work history, education, skills, and metadata. These schemas enable validation, tooling, and consistent data interchange across components that consume or produce resume data.
 
+## Canonical Schema (`packages/schema`)
+
+The single source of truth for the JSON Resume structure is `packages/schema`, published to npm as [`@jsonresume/schema`](https://www.npmjs.com/package/@jsonresume/schema). It was imported with full history from the former standalone `jsonresume/resume-schema` repository during the 2026 consolidation.
+
+Key facts about the canonical schema (`packages/schema/schema.json`):
+
+- It is a JSON Schema **draft-07** document (`"$schema": "http://json-schema.org/draft-07/schema#"`).
+- `additionalProperties` is **`true`** at the root and within nested objects — custom/extension fields are explicitly permitted.
+- The package's `validator.js` (the `main` entry) exposes `validate(resumeJson, callback)` backed by the `jsonschema` library, plus the raw `schema` and `jobSchema` objects.
+
+Consumers of the canonical schema include `resume-cli` (`packages/cli`), which validates `resume.json` with **Ajv** (`ajv` + `ajv-formats`, `strict: false`) against `@jsonresume/schema/schema.json`, and the Rust crate `packages/core-rust` (`json-resume-serde`), whose structs mirror this schema.
+
+> **Note on the registry's internal schema:** The sections below document a *separate, registry-internal* copy of the schema under `apps/registry/lib/schema/*.js`. That copy is a JSON Schema **draft-04** object with `additionalProperties: false` and is used only by the registry's own `/api/schema` and `components/schema.js`. It is intentionally stricter than — and distinct from — the canonical `@jsonresume/schema` package above. When the two disagree, the canonical `packages/schema` is authoritative.
+
 ## Purpose and Scope
 
-This page documents the schema definitions and related TypeScript interfaces representing various resume sections. It covers the JSON Schema objects used for validation in the registry app (`apps/registry/lib/schema/*.js`) and the corresponding TypeScript interfaces used in the Stack Overflow theme (`packages/themes/stackoverflow/src/types.ts` and related files). It does not cover resume rendering, persistence, or transformation logic.
+This page documents the canonical schema package (`packages/schema`, above), the registry's internal JSON Schema objects (`apps/registry/lib/schema/*.js`), and the corresponding TypeScript interfaces used in the Stack Overflow theme (`packages/themes/stackoverflow/src/types.ts` and related files). It does not cover resume rendering, persistence, or transformation logic.
 
 For how these schemas integrate into the resume processing pipeline, see the Pipeline Stages page. For UI components consuming these types, see the Theme Components page.
 
@@ -31,12 +45,14 @@ Sources: `apps/registry/lib/schema.js:16-43`, `apps/registry/lib/schema/definiti
 
 ---
 
-## Main Schema Object (`schema`)
+## Registry-Internal Main Schema Object (`schema`)
 
-**Purpose:** Defines the root JSON Schema object for validating complete resume JSON documents, aggregating all section schemas and shared definitions.  
+> The remaining sections on this page describe the registry's internal draft-04 schema copy (`apps/registry/lib/schema/*.js`), not the canonical `@jsonresume/schema` package documented at the top of this page.
+
+**Purpose:** Defines the root JSON Schema object the registry uses internally to validate complete resume JSON documents, aggregating all section schemas and shared definitions.  
 **Primary file:** `apps/registry/lib/schema.js:16-43`
 
-The `schema` object is a JSON Schema Draft-04 schema describing the entire resume structure. It disallows additional properties beyond those defined, ensuring strict validation.
+The `schema` object is a JSON Schema Draft-04 schema describing the entire resume structure. It disallows additional properties beyond those defined, ensuring strict validation. (This differs from the canonical `@jsonresume/schema`, which is draft-07 with `additionalProperties: true`.)
 
 | Field            | Type           | Purpose                                                                                      |
 |------------------|----------------|----------------------------------------------------------------------------------------------|
@@ -677,7 +693,8 @@ Sources: `apps/registry/lib/schema.js:16-43`, `packages/themes/stackoverflow/src
 
 The schema definitions subsystem depends on:
 
-- JSON Schema Draft-04 specification for validation semantics.
+- The canonical `@jsonresume/schema` package (`packages/schema`) as the authoritative draft-07 contract.
+- The registry's internal draft-04 schema copy (`apps/registry/lib/schema/*.js`) for the registry's own `/api/schema` endpoint.
 - Shared definitions for common patterns like flexible ISO 8601 dates.
 - TypeScript interfaces for static typing in UI and tooling layers.
 

--- a/apps/docs/content/docs/027-docs-site.md
+++ b/apps/docs/content/docs/027-docs-site.md
@@ -5,11 +5,28 @@ description: "Docwright documentation"
 
 # Documentation Site
 
-This module composes the documentation site for the JSON Resume API, integrating multiple endpoint documentation components and data examples into a cohesive user interface. It serves as the central aggregation point for API overview, resume retrieval, job recommendations, legacy compatibility, and ATS compatibility analysis documentation.
+There are two distinct "docs" surfaces in this repository. This page covers both, but they should not be confused:
+
+1. **The standalone documentation site (`apps/docs`)** — the site you are reading now, served at [docs.jsonresume.org](https://docs.jsonresume.org). See "The `apps/docs` Site" immediately below.
+2. **The registry's in-app API documentation page (`apps/registry/app/docs`)** — a single React route inside the registry app that renders human-readable JSON Resume API reference. The bulk of this page (from "Registry In-App API Docs Page" onward) documents that route.
+
+## The `apps/docs` Site
+
+The standalone documentation site lives at `apps/docs` and is served at `docs.jsonresume.org`.
+
+- **Toolchain:** Built with [Fumadocs](https://fumadocs.dev) (`fumadocs-core`, `fumadocs-mdx`, `fumadocs-ui`) on top of Next.js. Content is authored as MDX under `apps/docs/content/docs`; `fumadocs-mdx` runs on `postinstall` and during `typecheck` to generate the docs source. This replaced the project's earlier Nextra-based setup.
+- **Build:** A static export — `next.config.mjs` sets `output: 'export'`, producing static HTML in `apps/docs/out`. Build with `pnpm --filter docs build`.
+- **Deployment:** The live production site at `docs.jsonresume.org` is served by **Vercel** (responses carry Vercel cache/`x-vercel-id` headers). The repository also retains a `.github/workflows/deploy-docs.yml` workflow that publishes the static export to GitHub Pages (writing a `docs.jsonresume.org` CNAME) on pushes touching `apps/docs/**`; the README still describes that GitHub Pages path. In other words: the repo carries a GitHub Pages workflow, but the domain currently resolves to a Vercel deployment. Treat Vercel as the source of truth for what is live and reconcile `deploy-docs.yml`/`README` if only one path should remain.
+
+For the package layout and how `apps/docs` fits into the monorepo, see the Repository Structure page.
+
+## Registry In-App API Docs Page
+
+The rest of this page documents the in-app API documentation **route inside the registry** (`apps/registry/app/docs`), which composes multiple endpoint documentation components and data examples into a cohesive user interface. It serves as the central aggregation point for API overview, resume retrieval, job recommendations, legacy compatibility, and ATS compatibility analysis documentation. It is a feature of the registry app and is unrelated to the Fumadocs site above.
 
 ## Purpose and Scope
 
-This page documents the core React components and data structures that render the JSON Resume API documentation site. It covers the composition of the main documentation page, the detailed endpoint documentation components, example data used for illustrating API responses, and the ATS compatibility scoring system. It does not cover the backend API implementations, data persistence, or AI processing logic.
+This section documents the core React components and data structures that render the registry's in-app JSON Resume API documentation route. It covers the composition of the main documentation page, the detailed endpoint documentation components, example data used for illustrating API responses, and the ATS compatibility scoring system. It does not cover the backend API implementations, data persistence, or AI processing logic.
 
 For the API backend and AI matching mechanisms, see the Job Matching Engine page. For frontend UI components unrelated to documentation, see the UI Components page.
 


### PR DESCRIPTION
## Summary

The docs-site content under `apps/docs/content/docs/` was machine-generated in April 2026, **before** the org consolidation, and described an outdated repository. This is a truth pass that brings the high-impact pages in line with the consolidated monorepo. Verified every claim against the actual tree at HEAD.

Refs #275.

## What changed (per file)

### `001-overview.md`
- Added a "Repository at a Glance" section. The overview previously described the platform as if it were only `apps/registry`. It now names all three apps (`apps/registry`, `apps/homepage2`, `apps/docs`) and the core ecosystem packages introduced/folded in by the consolidation (`packages/schema`, `packages/cli`, `packages/core-rust`, plus resume-core/ui/job-search/ats-validator/converters/themes), with pointers to the Repository Structure and Schema pages.

### `002-repository-structure.md` (full apps/packages map + release process)
- Added the missing packages to both the architecture diagram and prose: **`packages/schema`** (npm `@jsonresume/schema`), **`packages/cli`** (npm `resume-cli`, revived, Node 18+, validates with Ajv against the draft-07 schema), **`packages/core-rust`** (`json-resume-serde` Rust crate — noted it is not in the pnpm workspace), and **`packages/converters/*`** (`@jsonresume/jsonresume-to-rendercv`).
- Added the two previously undocumented apps: **`apps/homepage2`** (marketing site, jsonresume.org) and **`apps/docs`** (this docs site, docs.jsonresume.org).
- Added a **Release Process (Changesets)** section describing `.changeset/config.json` and `.github/workflows/release-packages.yml` (Version Packages PR → `changeset publish`, OIDC Trusted Publishing / `NPM_TOKEN` fallback). Corrected the stale "each package defines its own publish scripts" line.

### `013-schema-definitions.md` (canonical schema location + draft version)
- Added a **Canonical Schema (`packages/schema`)** section establishing the published `@jsonresume/schema` as the single source of truth: JSON Schema **draft-07**, **`additionalProperties: true`**, `validator.js` (jsonschema lib), consumed by `resume-cli` (Ajv) and mirrored by `packages/core-rust`.
- The page previously presented the registry-internal `apps/registry/lib/schema/*.js` copy (draft-04, `additionalProperties: false`) as THE schema. That copy is accurate for the registry's `/api/schema` route, so it is kept but clearly reframed as a *separate, stricter, registry-internal* schema, with the canonical package marked authoritative when they disagree.

### `027-docs-site.md` (what the docs site actually is + how it deploys)
- The page was titled "Documentation Site" but its entire body documented the registry's in-app API docs route (`apps/registry/app/docs`). Added a top section describing the **actual** standalone docs site (`apps/docs`): Fumadocs + Next.js, MDX content, static export (`output: 'export'`), replacing the earlier Nextra setup.
- **Deployment:** the live `docs.jsonresume.org` is served by **Vercel** (verified via response headers: `x-vercel-id` / `x-vercel-cache`). The repo still carries `deploy-docs.yml` (GitHub Pages, writes a CNAME) and a README that describes GH Pages; documented this discrepancy and flagged Vercel as the source of truth for what is live, with a note to reconcile the workflow/README.
- Reframed the existing API-docs content under a "Registry In-App API Docs Page" heading so the two surfaces are not confused.

## Files intentionally left unchanged

The deep-dive pages (`003`–`037`) describe `apps/registry` internals (hooks, routes, components) and were spot-checked against the tree — e.g. `028-api-layer.md` route handlers and the `/api/jobs` 60-day filter are accurate, and `009`/`010` schema-validation references describe the registry's runtime `validateResume` pipeline correctly. They are not consolidation-affected, so no blanket "may predate consolidation" notes were added (that would have reduced accuracy).

## Verification

- `pnpm install --frozen-lockfile` — exit 0
- `pnpm --filter docs build` — exit 0 (41 static pages, all edited pages compile and appear in the static export)
- `pnpm turbo lint typecheck prettier` — exit 0

— AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository overview guide describing project structure and main packages.
  * Updated repository documentation with expanded diagrams and detailed package descriptions.
  * Clarified distinction between canonical JSON Resume schema and registry-specific schema versions.
  * Separated documentation for standalone docs site and in-app API documentation surfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->