### PR TITLE
fix(a11y): mechanical accessibility fixes + homepage axe smoke

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,6 +1,15 @@
 import './global.css';
 import { RootProvider } from 'fumadocs-ui/provider/next';
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'JSON Resume Docs',
+    template: '%s | JSON Resume Docs',
+  },
+  description: 'Documentation for the JSON Resume standard, CLI, and themes.',
+};
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/apps/homepage2/app/layout.js
+++ b/apps/homepage2/app/layout.js
@@ -82,7 +82,7 @@ export default async function Layout({ children }) {
             <Sidebar />
             <div className="inner">
               <TopNav />
-              {children}
+              <main id="content">{children}</main>
               <Footer />
             </div>
           </div>

--- a/apps/homepage2/app/themes/components/ThemesInfo.jsx
+++ b/apps/homepage2/app/themes/components/ThemesInfo.jsx
@@ -2,7 +2,7 @@ export function ThemesInfo() {
   return (
     <div className="row">
       <div className="col-md-6">
-        <h3>Browse</h3>
+        <h2>Browse</h2>
 
         <p>
           There are over{' '}
@@ -27,7 +27,7 @@ export function ThemesInfo() {
         </p>
       </div>
       <div className="col-md-6">
-        <h3>Want to develop your own?</h3>
+        <h2>Want to develop your own?</h2>
         <p>
           Read the <a href="/theme-development">theme development guide</a>{' '}
         </p>

--- a/apps/homepage2/package.json
+++ b/apps/homepage2/package.json
@@ -54,6 +54,8 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "^1.55.1",
     "@types/node": "^20.10.0",
     "caniuse-lite": "^1.0.30001566",
     "eslint": "^8.55.0",

--- a/apps/homepage2/tests/a11y.spec.js
+++ b/apps/homepage2/tests/a11y.spec.js
@@ -1,0 +1,36 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+/**
+ * Accessibility smoke test.
+ *
+ * Runs axe-core against the homepage and fails the build only on CRITICAL
+ * violations, so genuine regressions (e.g. an unlabelled control or a broken
+ * landmark) are caught without blocking on the per-theme color-contrast and
+ * design-level findings tracked separately in the a11y audit.
+ *
+ * Scope is intentionally narrow (home page, critical-only) — widen it as more
+ * surfaces are remediated.
+ */
+test('homepage has no critical accessibility violations', async ({ page }) => {
+  await page.goto('/');
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+    .analyze();
+
+  const critical = results.violations.filter((v) => v.impact === 'critical');
+
+  // Helpful output when something fails in CI.
+  if (critical.length > 0) {
+    console.error(
+      'Critical a11y violations:\n' +
+        critical
+          .map((v) => `  - ${v.id} (${v.nodes.length}): ${v.help}`)
+          .join('\n')
+    );
+  }
+
+  expect(critical).toEqual([]);
+});

--- a/packages/themes/jsonresume-theme-flat/templates/head.js
+++ b/packages/themes/jsonresume-theme-flat/templates/head.js
@@ -1,9 +1,9 @@
 export default `<!doctype html>
-<html>
+<html lang="en">
 	<head>
-	
+
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, user-scalable=no, minimal-ui">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	
 	<title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
 	

--- a/packages/themes/jsonresume-theme-modern-classic/dist/index.js
+++ b/packages/themes/jsonresume-theme-modern-classic/dist/index.js
@@ -6153,7 +6153,7 @@ const SkillCategory = dt.div`
   border-radius: 6px;
   border-left: 3px solid #0066cc;
 `;
-const SkillName = dt.h4`
+const SkillName = dt.h3`
   font-size: 15px;
   font-weight: 600;
   color: #111827;
@@ -6179,7 +6179,7 @@ function Resume({ resume }) {
     interests = [],
     references = []
   } = resume;
-  return /* @__PURE__ */ jsxs(Layout, { children: [
+  return /* @__PURE__ */ jsxs(Layout, { as: "main", children: [
     /* @__PURE__ */ jsxs(Header, { children: [
       /* @__PURE__ */ jsx(Name, { children: basics.name }),
       basics.label && /* @__PURE__ */ jsx(Label, { children: basics.label }),

--- a/packages/themes/jsonresume-theme-modern-classic/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-modern-classic/src/Resume.jsx
@@ -168,7 +168,7 @@ const SkillCategory = styled.div`
   border-left: 3px solid #0066cc;
 `;
 
-const SkillName = styled.h4`
+const SkillName = styled.h3`
   font-size: 15px;
   font-weight: 600;
   color: #111827;
@@ -198,7 +198,7 @@ function Resume({ resume }) {
   } = resume;
 
   return (
-    <Layout>
+    <Layout as="main">
       <Header>
         <Name>{basics.name}</Name>
         {basics.label && <Label>{basics.label}</Label>}

--- a/packages/themes/jsonresume-theme-operations-precision/dist/index.js
+++ b/packages/themes/jsonresume-theme-operations-precision/dist/index.js
@@ -6250,7 +6250,7 @@ function Resume({ resume }) {
     interests = [],
     references = []
   } = resume;
-  return /* @__PURE__ */ jsxs(Layout, { children: [
+  return /* @__PURE__ */ jsxs(Layout, { as: "main", children: [
     /* @__PURE__ */ jsxs(Header, { children: [
       /* @__PURE__ */ jsx(Name, { children: basics.name }),
       basics.label && /* @__PURE__ */ jsx(Label, { children: basics.label }),

--- a/packages/themes/jsonresume-theme-operations-precision/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-operations-precision/src/Resume.jsx
@@ -276,7 +276,7 @@ function Resume({ resume }) {
   } = resume;
 
   return (
-    <Layout>
+    <Layout as="main">
       <Header>
         <Name>{basics.name}</Name>
         {basics.label && <Label>{basics.label}</Label>}

--- a/packages/themes/jsonresume-theme-professional/dist/index.mjs
+++ b/packages/themes/jsonresume-theme-professional/dist/index.mjs
@@ -1,4 +1,4 @@
-import { jsxs, jsx, Fragment } from "react/jsx-runtime";
+import { jsxs, Fragment, jsx } from "react/jsx-runtime";
 import { renderToString } from "react-dom/server";
 import o, { useState, useMemo, useEffect, useContext, useDebugValue, createElement, useRef } from "react";
 import { marked } from "marked";
@@ -1690,7 +1690,7 @@ const render = (resume) => {
   const sheet = new gt();
   const html = renderToString(sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume })));
   const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><head>
+  return `<!DOCTYPE html><html lang="en"><head>
   <title>${resume.basics.name} - Resume</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -1776,7 +1776,7 @@ const render = (resume) => {
 
 
   </style>
-  ${styles}</head><body>${html}</body></html>`;
+  ${styles}</head><body><main>${html}</main></body></html>`;
 };
 export {
   Resume,

--- a/packages/themes/jsonresume-theme-professional/src/index.jsx
+++ b/packages/themes/jsonresume-theme-professional/src/index.jsx
@@ -6,7 +6,7 @@ export const render = (resume) => {
   const sheet = new ServerStyleSheet();
   const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
   const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><head>
+  return `<!DOCTYPE html><html lang="en"><head>
   <title>${resume.basics.name} - Resume</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -92,7 +92,7 @@ export const render = (resume) => {
 
 
   </style>
-  ${styles}</head><body>${html}</body></html>`;
+  ${styles}</head><body><main>${html}</main></body></html>`;
 };
 
 export { Resume };

--- a/packages/themes/jsonresume-theme-reference/dist/index.js
+++ b/packages/themes/jsonresume-theme-reference/dist/index.js
@@ -6103,7 +6103,7 @@ function Resume({ resume }) {
     references = [],
     projects = []
   } = resume;
-  return /* @__PURE__ */ jsxs(Layout, { children: [
+  return /* @__PURE__ */ jsxs(Layout, { as: "main", children: [
     basics && /* @__PURE__ */ jsxs(Header, { children: [
       /* @__PURE__ */ jsx(Name, { children: basics.name }),
       basics.label && /* @__PURE__ */ jsx(Label, { children: basics.label }),

--- a/packages/themes/jsonresume-theme-reference/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-reference/src/Resume.jsx
@@ -103,7 +103,7 @@ function Resume({ resume }) {
   } = resume;
 
   return (
-    <Layout>
+    <Layout as="main">
       {/* Hero Section - Name, Title, Contact */}
       {basics && (
         <Header>

--- a/packages/themes/stackoverflow/src/Resume.tsx
+++ b/packages/themes/stackoverflow/src/Resume.tsx
@@ -14,7 +14,7 @@ import { Skills } from './Skills';
 import { Work } from './Work';
 
 export const Resume: React.FC<ResumeProps> = (resume) => (
-  <div id="resume">
+  <main id="resume">
     <Basics {...resume.basics} />
     {resume.skills && <Skills skills={resume.skills} />}
     {resume.work && <Work work={resume.work} />}
@@ -27,5 +27,5 @@ export const Resume: React.FC<ResumeProps> = (resume) => (
     {resume.languages && <Languages languages={resume.languages} />}
     {resume.interests && <Interests interests={resume.interests} />}
     {resume.references && <References references={resume.references} />}
-  </div>
+  </main>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,12 @@ importers:
         specifier: ^11.1.1
         version: 11.1.1
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.56.1)
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.56.1
       '@repo/eslint-config-custom':
         specifier: workspace:*
         version: link:../../packages/eslint-config-custom
@@ -2521,6 +2527,15 @@ packages:
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
     dev: false
+
+  /@axe-core/playwright@4.11.3(playwright-core@1.56.1):
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.56.1
+    dev: true
 
   /@babel/cli@7.29.7(@babel/core@7.28.5):
     resolution: {integrity: sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==}
@@ -13119,6 +13134,11 @@ packages:
   /axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
+
+  /axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+    dev: true
 
   /axios@1.17.0(debug@4.3.2):
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}


### PR DESCRIPTION
## Summary

First accessibility sweep of the org's **own** surfaces. `jsonresume-theme-class` runs pa11y in CI, but homepage2, docs, and our in-repo themes had never been audited. I audited with **axe-core via Playwright** (WCAG 2.0/2.1 A & AA + best-practice):

- homepage2 `/` and `/themes` (live dev server)
- docs landing (live dev server)
- rendered HTML of 8 representative themes, using the canonical `resume-schema` full fixture: stackoverflow, professional, modern-classic, flat, colophon, reference, elegant, operations-precision

This PR fixes the **clear mechanical wins** (missing `lang`, heading-order jumps, `<main>`/landmark issues, missing document title, zoom-disabling viewport). It **skips color-contrast** and link-distinguishability — those are per-theme design calls, reported below.

Refs #275

## Before / after (axe violation counts, color-contrast excluded from "fixed")

| Surface | Violation | Before | After |
|---|---|---:|---:|
| homepage `/` | landmark-one-main | 1 | **0** |
| homepage `/` | region | 1 | **0** |
| homepage `/themes` | heading-order (h1→h3) | 1 | **0** |
| homepage `/themes` | landmark-one-main | 1 | **0** |
| homepage `/themes` | region | 1 | **0** |
| docs landing | document-title | 1 | **0** |
| theme **flat** | html-has-lang | 1 | **0** |
| theme **flat** | meta-viewport (zoom disabled) | 1 | **0** |
| theme **professional** | html-has-lang | 1 | **0** |
| theme **professional** | landmark-one-main | 1 | **0** |
| theme **professional** | region | 17 | **0** |
| theme **modern-classic** | heading-order | 3 | **0** |
| theme **modern-classic** | landmark-one-main | 1 | **0** |
| theme **modern-classic** | region | 10 | **0** |
| theme **reference** | landmark-one-main | 1 | **0** |
| theme **reference** | region | 10 | **0** |
| theme **operations-precision** | landmark-one-main | 1 | **0** |
| theme **operations-precision** | region | 10 | **0** |
| theme **stackoverflow** | landmark-one-main | 1 | **0** |
| theme **stackoverflow** | region | 11 | **0** |

Net per-surface totals (excl. color-contrast): homepage 2→0, /themes 3→0 (link-in-text-block design item remains), docs 1→0, flat 2→0 (landmark remains, see below), professional 3→0 (+ heading-1 remains), modern-classic 4→0, reference/operations-precision 2→0, stackoverflow 2→0.

### What changed
- **homepage2 layout** — wrap children in `<main id=\"content\">` (one main landmark, content in a region) on every page.
- **homepage2 /themes** — `ThemesInfo` `<h3>` → `<h2>` (no h1→h3 jump).
- **docs** — add root `metadata` title (`JSON Resume Docs`), so every docs page emits a `<title>`.
- **theme flat** — `<html lang=\"en\">`; viewport `user-scalable=no, minimal-ui` → `initial-scale=1` (re-enable zoom).
- **theme professional** — output now wrapped in `<html lang=\"en\">…<main>…</main>` (was a malformed doc with no `<html>` element).
- **theme modern-classic** — `SkillName` `h4`→`h3` (matches the item-level heading used elsewhere); `Layout` rendered `as=\"main\"`.
- **themes reference / operations-precision** — `Layout` rendered `as=\"main\"`.
- **theme stackoverflow** — root `<div id=\"resume\">` → `<main id=\"resume\">`.
- Rebuilt the tracked `dist/` for the styled-components themes (modern-classic, reference, operations-precision, professional); stackoverflow rebuilds from source on install.

## Durable regression guard
- `apps/homepage2/tests/a11y.spec.js` — Playwright + axe-core smoke on `/`, **fails only on `critical` violations** (so we catch genuine regressions without blocking on the design-level contrast findings). Scope is intentionally narrow; widen as surfaces are remediated.
- Added `@axe-core/playwright` + `@playwright/test` devDeps to homepage2. Runs via the existing `test:e2e` script.

## Reported, NOT fixed (design / out-of-scope)
- **color-contrast** (serious) — per-theme palette decisions, not mechanical: flat (19), elegant (19), modern-classic (4), stackoverflow (9), homepage `/` (4), `/themes` (56). Each needs a per-theme design pass.
- **link-in-text-block** (serious) — links distinguishable only by color; needs a CSS underline/decoration decision: `/themes` (2), elegant (1).
- **theme professional — page-has-heading-one** (moderate): the candidate name renders in a `<div>`, not an `<h1>`. Promoting it touches the styled-components component tree (not purely mechanical).
- **theme elegant — link-name (3), heading-order, page-has-heading-one, region** — elegant is an **external npm package** (`jsonresume-theme-elegant@1.16.1`), not in this repo. Empty social-icon links (`<a><i class=\"icon-twitter\"/></a>`) need `aria-label`s upstream.
- **theme colophon** — external package; clean (0 violations), no action.
- **theme flat — landmark-one-main / region (1 each)**: wrapping `#content` in `<main>` was attempted but the theme uses `<aside>` per section-column, which then triggers `landmark-complementary-is-top-level` (a worse net result). The real fix is reworking the misused `<aside>` columns — a larger refactor, left for a follow-up.
- **homepage2 layout — `charset` / `http-equiv` invalid DOM props**: React warns (`charSet`/`httpEquiv`); not an axe violation, left out to keep this PR a11y-scoped.

## Verification
- `pnpm --filter homepage2 test:e2e` — 3 passed (incl. new a11y smoke)
- `pnpm --filter homepage2 build`, `pnpm --filter docs build` — green
- `pnpm --filter homepage2 lint`, `pnpm --filter docs lint` / `typecheck` — green
- `pnpm --filter registry test -- --run lib/formatters/template` — 17 passed (theme rendering intact)
- husky pre-commit (lint-staged: eslint --fix, prettier, turbo typecheck) — passed

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced semantic HTML structure across themes with proper main elements and heading hierarchy for better document structure and accessibility.

* **Tests**
  * Added accessibility smoke test for the homepage to catch critical WCAG violations.

* **Chores**
  * Added testing dependencies for accessibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->