### PR TITLE
fix(themes): visual QA batch 3 (creative-confidence)

### DIFF
--- a/packages/themes/jsonresume-theme-creative-confidence/index.js
+++ b/packages/themes/jsonresume-theme-creative-confidence/index.js
@@ -73,8 +73,7 @@ html, body {
 .right-panel .compact-sub li {
   font-size: 9.15pt;
 }
-.photo,
-.photo-empty {
+.photo {
   width: 100%;
   height: 100%;
 }
@@ -87,15 +86,6 @@ html, body {
 .photo {
   object-fit: cover;
   display: block;
-}
-.photo-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  font-size: 8.4pt;
-  color: #1d4ed8;
-  padding: 6px;
 }
 .section {
   margin-top: 7px;
@@ -720,10 +710,12 @@ export function render(resume = {}) {
     : '';
   const footerText = [basics.name, basics.label].filter(Boolean).join(': ');
   const photo = basics.image
-    ? `<img class="photo" src="${escapeHtml(basics.image)}" alt="${escapeHtml(
+    ? `<div class="photo-wrap" aria-label="Profile image">
+        <img class="photo" src="${escapeHtml(basics.image)}" alt="${escapeHtml(
         name
-      )} profile photo" />`
-    : `<div class="photo-empty">Profile Photo</div>`;
+      )} profile photo" />
+      </div>`
+    : '';
 
   const leftColumn = [
     renderSummary(basics),
@@ -759,9 +751,7 @@ export function render(resume = {}) {
         <h1 class="name">${escapeHtml(name)}</h1>
         ${label}
       </div>
-      <div class="photo-wrap" aria-label="Profile image">
-        ${photo}
-      </div>
+      ${photo}
     </header>
     <div class="layout">
       <div>${leftColumn}</div>


### PR DESCRIPTION
Visual QA of Wave 6 section additions — **batch 3 of 4** (13 themes, alphabetical index %4==2). Each theme was rendered with a complete fixture (the test-fixtures sample extended with `volunteer` / `certificates` / `publications`) to HTML, screenshotted full-page at 1280px with Playwright, and reviewed by eye. The new sections were compared against each theme's established sections.

Refs #275, #360.

## Per-theme verdict

| Theme | Verdict |
|---|---|
| asymmetric-timeline | clean — vol/cert/pub reuse the SimpleSection card idiom (Lora titles, gray cards, blue underline); consistent |
| claude | clean — vol/awards/cert/pub follow title + linked subtitle + right-aligned date; refs in callout boxes |
| creative-confidence | **fixed** — see below |
| diagonal-accent-bar | clean — vol/awards/pub use red-underline headings + red org names + triangle bullets matching Work |
| flat | clean — new sections faithfully reuse the label-gutter + `.strike-through` idiom (long-title/date overlap is pre-existing upstream behavior across all sections, not a regression) |
| investor-brief | clean — cert/pub render as two-column cards with blue-underline headings, matching the brief style |
| lucide | clean — external published package (not in monorepo, out of Wave 6 scope); renders all sections in its sidebar layout |
| minimalist-grid | clean — cert/pub in a tidy two-column grid under thin blue underlines |
| new-york-editorial | clean — cert/pub/vol/awards in the serif editorial idiom (linked titles, italic issuer • date) |
| paper-plus-plus | clean for what it renders — external published package (out of scope); does not surface cert/pub (upstream gap) |
| reference | clean — vol/awards/pub/cert under blue-underline headers; skill-tag pills consistent |
| sidebar-photo-strip | clean — new sections in main column alongside dark sidebar; photo renders correctly and degrades gracefully when absent |
| typewriter-modern | clean — cert/pub in the left date-gutter, monospace issuer/publisher, bold sans titles |

## Fix: creative-confidence — missing-photo handling

When `basics.image` was absent, the dark header rendered a literal **"Profile Photo"** placeholder box. Real resumes without a photo should not show a labeled placeholder.

- Photo block is now omitted entirely when there is no image (the pattern used by every other theme).
- The avatar still renders unchanged when an image is present.
- Removed the now-dead `.photo-empty` CSS.

One file changed; rendered before/after to confirm both the no-image and with-image cases.

## Gates
- `pnpm turbo lint` — exit 0 (14/14)
- `pnpm turbo typecheck` — exit 0 (3/3)
- `pnpm prettier` — exit 0 (all files)
- `pnpm --filter registry test -- --run` — exit 0 (1318 passed, 24 pre-existing skips)

— AI