### PR TITLE
fix(jobs): normalize job.location typing across formatters and TUI

### DIFF
--- a/.changeset/fix-job-location-typing.md
+++ b/.changeset/fix-job-location-typing.md
@@ -1,0 +1,12 @@
+---
+'@jsonresume/jobs': patch
+---
+
+Fix inconsistent `job.location` typing in the job-search TUI. The registry API
+serves `location` as an object (`{ city, region, countryCode, ... }`) with
+remote status in a separate `remote` field, but the TUI remote filter treated
+`location` as a string (`/remote/i.test(j.location)`), which silently never
+matched against object locations. Added a shared `normalizeLocation()` helper
+that accepts both string and object shapes (the DB still holds some historic
+string rows) and is now used by both `formatters.js` and the TUI `useJobs`
+remote filter.

--- a/packages/job-search/src/formatters.js
+++ b/packages/job-search/src/formatters.js
@@ -4,10 +4,62 @@ export function formatSalary(salary, salaryUsd) {
   return '—';
 }
 
+/**
+ * Defensive location normalizer for job records.
+ *
+ * The registry API serves `job.location` straight from the parsed
+ * `gpt_content`, whose canonical shape is an OBJECT
+ * (`{ address, postalCode, city, region, countryCode }`, see the
+ * extraction schema in apps/registry/scripts/jobs/job-parser/jobSchema.js).
+ * Remote status is a SEPARATE field (`job.remote` → 'Full' | 'Hybrid' | 'None').
+ *
+ * Historic rows may still carry `location` as a plain string, so this
+ * normalizer accepts strings, objects, or nullish input and always returns a
+ * stable shape:
+ *   { city, region, countryCode, display, remote }
+ * where `remote` is a boolean derived from either the separate `remote`
+ * field or a "remote" hint inside a string location.
+ *
+ * @param {Object|string|null} job - a job record, or a bare location value.
+ * @returns {{city:string|null, region:string|null, countryCode:string|null, display:string|null, remote:boolean}}
+ */
+export function normalizeLocation(job) {
+  // Allow passing either a full job record or a bare location value.
+  const isJobRecord = job && typeof job === 'object' && 'location' in job;
+  const loc = isJobRecord ? job.location : job;
+  const remoteField = isJobRecord ? job.remote : undefined;
+
+  let city = null;
+  let region = null;
+  let countryCode = null;
+  let display = null;
+  let stringRemote = false;
+
+  if (typeof loc === 'string') {
+    const trimmed = loc.trim();
+    display = trimmed || null;
+    stringRemote = /remote/i.test(trimmed);
+  } else if (loc && typeof loc === 'object') {
+    city = loc.city || null;
+    region = loc.region || null;
+    countryCode = loc.countryCode || null;
+    const parts = [city, region, countryCode].filter(Boolean);
+    display = parts.length ? parts.join(', ') : null;
+  }
+
+  // Mirror the server-side remote filter (matchingHelpers.js), which treats
+  // only fully-remote roles as "remote" (j.remote === 'Full'). For historic
+  // string locations with no separate `remote` field, fall back to the
+  // "remote" hint in the location text.
+  const remote = remoteField === 'Full' || stringRemote;
+
+  return { city, region, countryCode, display, remote };
+}
+
 export function formatLocation(loc, remote) {
+  const norm = normalizeLocation(loc);
   const parts = [];
-  if (loc?.city) parts.push(loc.city);
-  if (loc?.countryCode) parts.push(loc.countryCode);
+  if (norm.display) parts.push(norm.display);
   if (remote) parts.push(`(${remote})`);
   return parts.join(', ') || '—';
 }

--- a/packages/job-search/src/formatters.test.js
+++ b/packages/job-search/src/formatters.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLocation, formatLocation } from './formatters.js';
+
+describe('normalizeLocation', () => {
+  it('normalizes the canonical object location shape', () => {
+    const job = {
+      location: { city: 'Berlin', region: 'BE', countryCode: 'DE' },
+      remote: 'None',
+    };
+    const norm = normalizeLocation(job);
+    expect(norm).toEqual({
+      city: 'Berlin',
+      region: 'BE',
+      countryCode: 'DE',
+      display: 'Berlin, BE, DE',
+      remote: false,
+    });
+  });
+
+  it('builds display from whichever object fields are present', () => {
+    expect(normalizeLocation({ location: { city: 'Seattle' } }).display).toBe(
+      'Seattle'
+    );
+    expect(normalizeLocation({ location: { countryCode: 'US' } }).display).toBe(
+      'US'
+    );
+    expect(normalizeLocation({ location: {} }).display).toBeNull();
+  });
+
+  it('handles a historic plain-string location', () => {
+    const norm = normalizeLocation({ location: 'San Francisco, CA' });
+    expect(norm.display).toBe('San Francisco, CA');
+    expect(norm.city).toBeNull();
+    expect(norm.remote).toBe(false);
+  });
+
+  it('detects "remote" inside a string location (historic rows)', () => {
+    expect(normalizeLocation({ location: 'Remote (US)' }).remote).toBe(true);
+    expect(normalizeLocation({ location: 'Fully remote' }).remote).toBe(true);
+    expect(normalizeLocation({ location: 'remote' }).remote).toBe(true);
+  });
+
+  it('uses the separate remote field for object locations', () => {
+    expect(
+      normalizeLocation({ location: { city: 'NYC' }, remote: 'Full' }).remote
+    ).toBe(true);
+    expect(
+      normalizeLocation({ location: { city: 'NYC' }, remote: 'Hybrid' }).remote
+    ).toBe(false);
+    expect(
+      normalizeLocation({ location: { city: 'NYC' }, remote: 'None' }).remote
+    ).toBe(false);
+  });
+
+  it('does NOT match remote on an object location (regression guard)', () => {
+    // The old `/remote/i.test(j.location || '')` stringified objects to
+    // "[object Object]" and never matched — but an object whose city happened
+    // to contain "remote" should not flip the flag either.
+    const job = { location: { city: 'Remoteville' }, remote: 'None' };
+    expect(normalizeLocation(job).remote).toBe(false);
+  });
+
+  it('handles null / undefined / empty location', () => {
+    expect(normalizeLocation({ location: null })).toEqual({
+      city: null,
+      region: null,
+      countryCode: null,
+      display: null,
+      remote: false,
+    });
+    expect(normalizeLocation({ location: undefined }).display).toBeNull();
+    expect(normalizeLocation({ location: '' }).display).toBeNull();
+    expect(normalizeLocation(null).display).toBeNull();
+    expect(normalizeLocation(undefined).remote).toBe(false);
+  });
+
+  it('accepts a bare location value (not wrapped in a job)', () => {
+    expect(
+      normalizeLocation({ city: 'Austin', countryCode: 'US' }).display
+    ).toBe('Austin, US');
+    expect(normalizeLocation('Remote').remote).toBe(true);
+  });
+
+  it('trims whitespace from string locations', () => {
+    expect(normalizeLocation({ location: '  London  ' }).display).toBe(
+      'London'
+    );
+    expect(normalizeLocation({ location: '   ' }).display).toBeNull();
+  });
+});
+
+describe('formatLocation', () => {
+  it('formats object locations with an explicit remote suffix', () => {
+    expect(formatLocation({ city: 'Berlin', countryCode: 'DE' }, 'Full')).toBe(
+      'Berlin, DE, (Full)'
+    );
+  });
+
+  it('formats string locations', () => {
+    expect(formatLocation('San Francisco, CA')).toBe('San Francisco, CA');
+  });
+
+  it('falls back to an em dash when empty', () => {
+    expect(formatLocation(null)).toBe('—');
+    expect(formatLocation({})).toBe('—');
+  });
+});

--- a/packages/job-search/src/tui/useJobs.js
+++ b/packages/job-search/src/tui/useJobs.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { getCached, setCache, updateCachedJob } from '../cache.js';
+import { normalizeLocation } from '../formatters.js';
 
 export function useJobs(api, activeFilters, tab, searchId, getDossierStatus) {
   const [allJobs, setAllJobs] = useState([]);
@@ -119,9 +120,11 @@ export function useJobs(api, activeFilters, tab, searchId, getDossierStatus) {
 
     for (const f of activeFilters || []) {
       if (f.type === 'remote') {
-        filtered = filtered.filter(
-          (j) => j.remote === 'Full' || /remote/i.test(j.location || '')
-        );
+        // location may be an object {city,region,countryCode} (canonical wire
+        // shape) or a historic string; normalizeLocation handles both and also
+        // folds in the separate `remote` field. The old `/remote/i.test(...)`
+        // silently failed on object locations (it tested "[object Object]").
+        filtered = filtered.filter((j) => normalizeLocation(j).remote);
       }
       if (f.type === 'globalRemote') {
         filtered = filtered.filter((j) => j.global_remote === true);


### PR DESCRIPTION
## Problem

Found during RFC #353 analysis: `@jsonresume/jobs` (packages/job-search) handles `job.location` inconsistently.

- `src/formatters.js` `formatLocation()` treats `location` as an **object** (`loc.city`, `loc.countryCode`).
- `src/tui/useJobs.js` (remote filter) treated it as a **string**: `/remote/i.test(j.location || '')`.

## Ground truth (file evidence)

The registry API serves `location` straight from the parsed `gpt_content`, and the canonical extraction shape is an **object**:

- `apps/registry/scripts/jobs/job-parser/jobSchema.js` — `location` is `type: 'object'` with `address/postalCode/city/region/countryCode`; `remote` is a **separate** enum string (`Full | Hybrid | None`).
- `apps/registry/app/api/v1/jobs/matchingHelpers.js:226` (list) and `apps/registry/app/api/v1/jobs/[id]/route.js:231` (detail) both emit `parsed.location` verbatim.
- The TUI consumes the **list** endpoint via `src/api.js#fetchJobs` -> `src/tui/useJobs.js`.
- Sibling consumers agree on the object shape: web `app/jobs/ClientJobBoardModule/utils/jobParser.js#getLocationString` reads `location.city/.region/.countryCode`; TUI `src/tui/jobFilters.js` reads `j.location?.city`.

So `useJobs.js` was the wrong side: against an object, `j.location || ''` is the object, and `/remote/i.test(object)` tests `"[object Object]"`, which never matches — the remote-location filter silently did nothing. The real remote signal is the separate `remote` field.

## Fix

- Add a defensive `normalizeLocation(job)` in `src/formatters.js` returning `{ city, region, countryCode, display, remote }`. Handles **string** and **object** inputs (the DB still holds historic string rows) and folds in the separate `remote` field. The derived `remote` boolean mirrors the server filter (`remote === 'Full'`), with a fallback to a "remote" hint for historic string locations.
- `formatLocation()` now delegates to it (behavior preserved).
- `useJobs.js` remote filter now uses `normalizeLocation(j).remote` instead of the broken string test.

## Tests

- New `src/formatters.test.js` (12 tests) covering string, object, null/undefined/empty, remote-flag variants, bare-value input, and a regression guard for object locations.
- Full package suite: 74 passed. TUI smoke `node bin/cli.js --help` exits 0. `turbo run test --filter=@jsonresume/jobs` green.

## Release

Changeset added: patch for `@jsonresume/jobs`.

Refs #275, #353

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the remote job filter in the search interface was not functioning correctly due to inconsistent handling of location data. The filter now reliably matches remote jobs regardless of data format variations.

* **Tests**
  * Added comprehensive test coverage for location formatting and data normalization to ensure consistent behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->