### PR TITLE
chore: changesets to publish wave 5-7 theme improvements

### DIFF
--- a/.changeset/ship-wave-5-7-theme-improvements.md
+++ b/.changeset/ship-wave-5-7-theme-improvements.md
@@ -1,0 +1,67 @@
+---
+'jsonresume-theme-academic-cv-lite': minor
+'jsonresume-theme-architects-portfolio': minor
+'jsonresume-theme-asymmetric-timeline': minor
+'jsonresume-theme-berlin-grid': minor
+'jsonresume-theme-bold-header-statement': minor
+'jsonresume-theme-californian-warm': minor
+'jsonresume-theme-coastal-creative': minor
+'@jsonresume/jsonresume-theme-creative-studio': minor
+'jsonresume-theme-data-driven': minor
+'jsonresume-theme-developer-mono': minor
+'jsonresume-theme-diagonal-accent-bar': minor
+'jsonresume-theme-executive-slate': minor
+'jsonresume-theme-french-atelier': minor
+'jsonresume-theme-government-standard': minor
+'jsonresume-theme-graph-paper-grid': minor
+'jsonresume-theme-investor-brief': minor
+'jsonresume-theme-london-bureau': minor
+'jsonresume-theme-marketing-narrative': minor
+'jsonresume-theme-mid-century-resume': minor
+'jsonresume-theme-minimalist-grid': minor
+'jsonresume-theme-modern-classic': minor
+'jsonresume-theme-monochrome-noir': minor
+'jsonresume-theme-new-york-editorial': minor
+'jsonresume-theme-nordic-minimal': minor
+'jsonresume-theme-operations-precision': minor
+'jsonresume-theme-pacific-horizon': minor
+'jsonresume-theme-product-manager-canvas': minor
+'jsonresume-theme-reference': minor
+'jsonresume-theme-sales-hunter': minor
+'jsonresume-theme-sidebar': minor
+'jsonresume-theme-sidebar-photo-strip': minor
+'jsonresume-theme-two-column-modernist': minor
+'jsonresume-theme-typewriter-modern': minor
+'jsonresume-theme-university-first': minor
+'jsonresume-theme-urban-techno': minor
+'jsonresume-theme-writers-portfolio': minor
+'@jsonresume/jsonresume-theme-consultant-polished': patch
+'@jsonresume/jsonresume-theme-tokyo-modernist': patch
+'@jsonresume/theme-stackoverflow': patch
+'jsonresume-theme-community-garden': patch
+'jsonresume-theme-desert-modern': patch
+'jsonresume-theme-elegant-pink': patch
+---
+
+Add missing JSON Resume sections (certificates/volunteer/publications); visual and crash fixes.
+
+Publishes the wave 5-7 theme improvements that currently exist only in git (refs #275). The
+published npm versions are stale: most themes never rendered certificates/volunteer/publications,
+and all carried the `@resume/core` import (renamed to `@jsonresume/core`) plus the Date-shadow
+rendering crash.
+
+Minor (gained rendered sections via the "render missing sections" batches #363-#366 and the
+operations-precision a11y/markdown work): all themes listed above as `minor` now render the
+previously-missing certificates/volunteer/publications (and related) sections.
+
+Patch (no new sections; visual, crash and dependency-rename fixes only):
+
+- consultant-polished: stop crash when certificates/publications present (#359).
+- tokyo-modernist: exports/CI fixes; styled-components moved to dependencies.
+- @jsonresume/theme-stackoverflow: consistent date formatting (#259) + a11y fixes (the
+  Yarn-Berry lockfile removal did not change source and does not drive this bump).
+- community-garden, desert-modern, elegant-pink: `@resume/core` -> `@jsonresume/core` import
+  fix and visual polish; sections were already rendered.
+
+Excludes `@jsonresume/jsonresume-theme-professional` (already current on npm) and the private
+themes (claude, creative-confidence, flat, tailwind).


### PR DESCRIPTION
## What

Adds **one** changeset that publishes the wave 5-7 theme improvements which currently exist only in git. npm users still install the stale versions: most themes never rendered `certificates`/`volunteer`/`publications`, every theme shipped the renamed `@resume/core` import (now `@jsonresume/core`, 404 on the registry), and several carried the Date-shadow rendering crash.

Refs #275 (org consolidation / theme publishing).

## How packages were selected

For every **non-private** `packages/themes/*` package I compared the current source against its **published npm tarball** (`npm pack <name>@<version>`):

- The "render missing sections" batches (#363, #364, #365, #366) and the operations-precision a11y/markdown work added section render branches that are absent from npm → **minor**.
- Themes whose only unpublished delta is the `@resume/core` -> `@jsonresume/core` import, a crash fix, or visual polish (no new section) → **patch**.
- `@jsonresume/jsonresume-theme-professional` had no change since its last publish → **excluded**.
- Private themes (`claude`, `creative-confidence`, `flat`, `tailwind`) → **excluded**.
- `@jsonresume/theme-stackoverflow`: included (date-formatting #259 + a11y changed source). The vestigial Yarn-Berry lockfile removal (#358) did **not** change source and does not drive the bump.

`pnpm changeset status` reports 36 minor + 6 patch (plus the private `registry` app, auto-bumped as an internal dependent — it is `private` and will not publish).

## Bump table

| Package | Bump | Why |
| --- | --- | --- |
| jsonresume-theme-academic-cv-lite | minor | renders certificates (batch #363) |
| jsonresume-theme-architects-portfolio | minor | renders certificates (batch #366) |
| jsonresume-theme-asymmetric-timeline | minor | renders certificates (batch #365) |
| jsonresume-theme-berlin-grid | minor | renders missing sections (batch #364) |
| jsonresume-theme-bold-header-statement | minor | renders 6 missing sections (batch #363) |
| jsonresume-theme-californian-warm | minor | renders certificates (batch #366) |
| jsonresume-theme-coastal-creative | minor | renders certificates (batch #364) |
| @jsonresume/jsonresume-theme-creative-studio | minor | renders certificates (batch #366) |
| jsonresume-theme-data-driven | minor | renders 4 missing sections (batch #365) |
| jsonresume-theme-developer-mono | minor | renders certificates (batch #364) |
| jsonresume-theme-diagonal-accent-bar | minor | renders certificates (batch #363) |
| jsonresume-theme-executive-slate | minor | renders certificates (batch #366) |
| jsonresume-theme-french-atelier | minor | renders certificates (batch #364) |
| jsonresume-theme-government-standard | minor | renders certificates (batch #363) |
| jsonresume-theme-graph-paper-grid | minor | renders certificates + SingleDate crash fix (batch #366) |
| jsonresume-theme-investor-brief | minor | renders certificates (batch #365) |
| jsonresume-theme-london-bureau | minor | renders certificates (batch #366) |
| jsonresume-theme-marketing-narrative | minor | renders certificates (batch #363) |
| jsonresume-theme-mid-century-resume | minor | renders certificates (batch #366) |
| jsonresume-theme-minimalist-grid | minor | renders certificates (batch #365) |
| jsonresume-theme-modern-classic | minor | renders certificates (batch #363) |
| jsonresume-theme-monochrome-noir | minor | renders certificates (batch #366) |
| jsonresume-theme-new-york-editorial | minor | renders certificates (batch #365) |
| jsonresume-theme-nordic-minimal | minor | renders 4 missing sections (batch #364) |
| jsonresume-theme-operations-precision | minor | renders certificates + a11y/markdown (batch #363) |
| jsonresume-theme-pacific-horizon | minor | renders certificates (batch #366) |
| jsonresume-theme-product-manager-canvas | minor | renders certificates (batch #364) |
| jsonresume-theme-reference | minor | renders certificates (batch #366) |
| jsonresume-theme-sales-hunter | minor | renders certificates (batch #365) |
| jsonresume-theme-sidebar | minor | renders 3 missing sections (batch #364) |
| jsonresume-theme-sidebar-photo-strip | minor | renders certificates (batch #363) |
| jsonresume-theme-two-column-modernist | minor | renders certificates (batch #365) |
| jsonresume-theme-typewriter-modern | minor | renders certificates (batch #364) |
| jsonresume-theme-university-first | minor | renders certificates (batch #363) |
| jsonresume-theme-urban-techno | minor | renders 5 missing sections (batch #366) |
| jsonresume-theme-writers-portfolio | minor | renders certificates (batch #365) |
| @jsonresume/jsonresume-theme-consultant-polished | patch | crash fix when certificates/publications present (#359); no new section |
| @jsonresume/jsonresume-theme-tokyo-modernist | patch | exports/CI fixes, styled-components moved to deps; no new section |
| @jsonresume/theme-stackoverflow | patch | consistent date formatting (#259) + a11y; no new section |
| jsonresume-theme-community-garden | patch | `@resume/core` -> `@jsonresume/core` + polish; sections already rendered |
| jsonresume-theme-desert-modern | patch | `@resume/core` -> `@jsonresume/core` + polish; sections already rendered |
| jsonresume-theme-elegant-pink | patch | `@resume/core` -> `@jsonresume/core` + polish; sections already rendered |

## Publish note: legacy unscoped packages may 403

The unscoped `jsonresume-theme-*` packages were published **pre-2026 by token-less flows**, so the Changesets release job may **403** on `npm publish` until each package's npm **Publishing access** toggle is flipped (require an automation/granular token, or grant the CI token write access) — the same fix applied to `jsonresume-theme-operations-precision` before it could publish `0.2.0`.

Packages likely to need the toggle flipped (every unscoped name in this changeset):

`jsonresume-theme-academic-cv-lite`, `architects-portfolio`, `asymmetric-timeline`, `berlin-grid`, `bold-header-statement`, `californian-warm`, `coastal-creative`, `community-garden`, `data-driven`, `desert-modern`, `developer-mono`, `diagonal-accent-bar`, `elegant-pink`, `executive-slate`, `french-atelier`, `government-standard`, `graph-paper-grid`, `investor-brief`, `london-bureau`, `marketing-narrative`, `mid-century-resume`, `minimalist-grid`, `modern-classic`, `monochrome-noir`, `new-york-editorial`, `nordic-minimal`, `operations-precision`, `pacific-horizon`, `product-manager-canvas`, `reference`, `sales-hunter`, `sidebar`, `sidebar-photo-strip`, `two-column-modernist`, `typewriter-modern`, `university-first`, `urban-techno`, `writers-portfolio`.

The scoped `@jsonresume/*` packages (`creative-studio`, `consultant-polished`, `tokyo-modernist`, `theme-stackoverflow`) use the newer scoped-publish flow and are less likely to be affected.

## Verification

- `pnpm install --frozen-lockfile` — exit 0
- `pnpm changeset status` — exit 0, lists 36 minor + 6 patch (+ private `registry` dependent)
- `prettier -c .` (CI format gate) — clean
- `turbo run build` on a theme — green

— AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certificates, volunteer work, and publications resume sections now display properly in all themes.

* **Bug Fixes**
  * Fixed crashes that occurred when certain resume sections were present.
  * Corrected date formatting inconsistencies across themes.
  * Resolved export and continuous integration issues.
  * Improved accessibility support throughout themes.
  * Enhanced overall visual design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->