### PR TITLE
ci: guard scheduled workflows against the known supabase outage + cron health fixes

### DIFF
--- a/.github/workflows/enrich_resume_companies.yml
+++ b/.github/workflows/enrich_resume_companies.yml
@@ -10,8 +10,37 @@ env:
   PNPM_VERSION: '8.15.9'
 
 jobs:
+  # Lightweight guard: the registry Supabase project is currently unreachable
+  # (see issue #332). When it is down, skip the pipeline cleanly instead of
+  # burning Actions minutes (and Perplexity quota) on a run that enriches 0
+  # companies. This job self-heals: once Supabase resolves again, supabase_up
+  # flips to 'true' and the pipeline runs as normal.
+  preflight:
+    name: Supabase preflight (#332)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      supabase_up: ${{ steps.check.outputs.supabase_up }}
+    steps:
+      - name: Check Supabase reachability
+        id: check
+        run: |
+          URL="https://itxuhvvwryeuzuyihpkp.supabase.co/rest/v1/"
+          # A live Supabase project answers with an HTTP status (e.g. 401
+          # without an apikey). 000 means DNS/connect failure => project down.
+          CODE=$(curl -s -o /dev/null -m 15 -w "%{http_code}" "$URL" || echo "000")
+          echo "Supabase health probe returned HTTP $CODE"
+          if [ "$CODE" = "000" ]; then
+            echo "supabase_up=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Supabase project is unreachable (see issue #332). Skipping the company enrichment pipeline with a neutral status. This job will self-heal once the project is restored."
+          else
+            echo "supabase_up=true" >> "$GITHUB_OUTPUT"
+          fi
+
   enrich_companies:
     name: Enrich Resume Companies Pipeline
+    needs: preflight
+    if: needs.preflight.outputs.supabase_up == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
 

--- a/.github/workflows/process_hn_jobs.yml
+++ b/.github/workflows/process_hn_jobs.yml
@@ -10,8 +10,37 @@ env:
   PNPM_VERSION: '8.15.9'
 
 jobs:
+  # Lightweight guard: the registry Supabase project is currently unreachable
+  # (see issue #332). When it is down, skip the pipeline cleanly instead of
+  # burning ~60 min of Actions minutes on a run that silently inserts 0 rows.
+  # This job self-heals: once Supabase resolves again, supabase_up flips to
+  # 'true' and the pipeline runs as normal.
+  preflight:
+    name: Supabase preflight (#332)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      supabase_up: ${{ steps.check.outputs.supabase_up }}
+    steps:
+      - name: Check Supabase reachability
+        id: check
+        run: |
+          URL="https://itxuhvvwryeuzuyihpkp.supabase.co/rest/v1/"
+          # A live Supabase project answers with an HTTP status (e.g. 401
+          # without an apikey). 000 means DNS/connect failure => project down.
+          CODE=$(curl -s -o /dev/null -m 15 -w "%{http_code}" "$URL" || echo "000")
+          echo "Supabase health probe returned HTTP $CODE"
+          if [ "$CODE" = "000" ]; then
+            echo "supabase_up=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Supabase project is unreachable (see issue #332). Skipping the HN jobs pipeline with a neutral status. This job will self-heal once the project is restored."
+          else
+            echo "supabase_up=true" >> "$GITHUB_OUTPUT"
+          fi
+
   process_jobs:
     name: Process HN Jobs Pipeline
+    needs: preflight
+    if: needs.preflight.outputs.supabase_up == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Scheduled workflow health audit

Audited all scheduled (`schedule:`/cron) workflows in `.github/workflows`. There are exactly **three** — `update-docs.yml`/`deploy-docs.yml` are push-triggered, not scheduled.

The surprise: the two Supabase-backed crons are **green but doing nothing**. The registry Supabase project `itxuhvvwryeuzuyihpkp.supabase.co` no longer resolves (DNS failure) per #332, so writes silently fail and the scripts still exit 0. Example: the 2026-06-12 HN run logged `Found 316 job postings` then `0 jobs imported`. Green status masks the outage and burns Actions minutes (+ Perplexity quota on the enrichment run).

### Per-workflow health table

| Workflow | Cron | Last 10 runs | Classification | Action taken |
|---|---|---|---|---|
| `process_hn_jobs.yml` | `30 0 * * *` (daily) | 10/10 "success" — but inserting 0 rows (Supabase writes silently no-op) | **failing-because-supabase-down (#332)** — green-but-no-op | Added `preflight` job: probe Supabase REST health; if unreachable, emit `::notice::` referencing #332 and skip the 60-min pipeline via job-level `if` (neutral, not red). Self-heals when project restores. |
| `enrich_resume_companies.yml` | `0 2 * * 0` (weekly) | 10/10 "success" — last real run enriched `0/0` | **failing-because-supabase-down (#332)** — green-but-no-op | Same `preflight` guard. Avoids burning up to 120 min + Perplexity quota while DB is down. |
| `vercel_error_monitor.yml` | `*/10 * * * *` | 9/10 success, 1 failure (run 27426988057) | **failing-for-other-reason (now resolved)** — the single failure was a transient `pnpm not found` from an older revision; current `master` uses `checkout@v6`/`setup-node@v6` with no pnpm step, and the latest 3 runs are green. Supabase-independent. | **None.** Healthy on current master; no change needed. |

### Guard design

The `preflight` job curls `https://itxuhvvwryeuzuyihpkp.supabase.co/rest/v1/`. A live Supabase project answers with an HTTP status (e.g. 401 without an apikey); `000` means DNS/connect failure → project down. On down, it sets `supabase_up=false`, prints a `#332` notice, and the main job is skipped (neutral status). No deletions — this self-heals automatically once Supabase is restored.

### Verification

- YAML parses (`yaml.safe_load`) for both changed files.
- `prettier --check` passes for both.
- Confirmed only 3 scheduled workflows exist; Vercel monitor intentionally untouched.

No obsolete workflows found, so nothing proposed for disabling.

Refs #275, #332

— AI
