### PR TITLE
refactor(registry): centralize supabase config (was hardcoded 114x)

### DIFF
--- a/apps/registry/.env.example
+++ b/apps/registry/.env.example
@@ -26,6 +26,10 @@ AUTH_URL=http://localhost:3000
 
 # Supabase Project URL and Keys
 # Get from: https://app.supabase.com/project/_/settings/api
+# These are read centrally in apps/registry/lib/supabaseConfig.js
+#   - NEXT_PUBLIC_SUPABASE_URL: public project URL (client + server)
+#   - NEXT_PUBLIC_SUPABASE_ANON_KEY: public anon key for browser-safe reads
+#   - SUPABASE_KEY: service-role key, server-only, never exposed to the client
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_KEY=your_supabase_service_role_key

--- a/apps/registry/app/api/decisions/decision/route.js
+++ b/apps/registry/app/api/decisions/decision/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 /**
  * POST /api/decisions/decision

--- a/apps/registry/app/api/decisions/jobs/route.js
+++ b/apps/registry/app/api/decisions/jobs/route.js
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 /**
  * Remove embedding fields from job objects before sending to client

--- a/apps/registry/app/api/decisions/preferences/route.js
+++ b/apps/registry/app/api/decisions/preferences/route.js
@@ -1,7 +1,8 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 /**
  * GET - Fetch user's job evaluation preferences

--- a/apps/registry/app/api/job-similarity/route.js
+++ b/apps/registry/app/api/job-similarity/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 // This ensures the route is always dynamic
 export const dynamic = 'force-dynamic';

--- a/apps/registry/app/api/job-states/batch/route.js
+++ b/apps/registry/app/api/job-states/batch/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 const VALID_STATES = ['read', 'interested', 'hidden'];
 

--- a/apps/registry/app/api/job-states/migrate/route.js
+++ b/apps/registry/app/api/job-states/migrate/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 /**
  * POST /api/job-states/migrate

--- a/apps/registry/app/api/job-states/route.js
+++ b/apps/registry/app/api/job-states/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 const VALID_STATES = ['read', 'interested', 'hidden'];
 

--- a/apps/registry/app/api/jobs/[uuid]/route.js
+++ b/apps/registry/app/api/jobs/[uuid]/route.js
@@ -1,8 +1,9 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 // This ensures the route is always dynamic
 export const dynamic = 'force-dynamic';

--- a/apps/registry/app/api/my-jobs/mark/route.js
+++ b/apps/registry/app/api/my-jobs/mark/route.js
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getServiceSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/my-jobs/route.js
+++ b/apps/registry/app/api/my-jobs/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { embed } from 'ai';
@@ -8,7 +9,7 @@ import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getServiceSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/pathways/jobs/pathways-pipeline.integration.test.js
+++ b/apps/registry/app/api/pathways/jobs/pathways-pipeline.integration.test.js
@@ -20,6 +20,7 @@ import { matchJobs, buildJobInfoMap } from './jobMatcher';
 import { buildGraphData } from './graphBuilder';
 import { VPTree } from './vpTree';
 import { dotProduct, normalizeInPlace } from './vectorOps';
+import { SUPABASE_URL } from '../../../../lib/supabaseConfig';
 
 vi.mock('@/lib/logger', () => ({
   logger: {
@@ -36,7 +37,6 @@ vi.mock('@/lib/retry', () => ({
   createRetryFetch: () => fetch,
 }));
 
-const SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
 const SUPABASE_KEY = process.env.SUPABASE_KEY;
 const HAS_DB = Boolean(SUPABASE_KEY);
 

--- a/apps/registry/app/api/pathways/supabase.js
+++ b/apps/registry/app/api/pathways/supabase.js
@@ -1,8 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-
-const SUPABASE_URL =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  'https://itxuhvvwryeuzuyihpkp.supabase.co';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 
 export function getSupabase() {
   if (!process.env.SUPABASE_KEY) {

--- a/apps/registry/app/api/privacy/delete-cache/route.ts
+++ b/apps/registry/app/api/privacy/delete-cache/route.ts
@@ -3,7 +3,6 @@ import { createClient } from '@supabase/supabase-js';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import logger from '@/lib/logger';
-// @ts-expect-error - JS config module (triple-export CommonJS)
 import { SUPABASE_URL } from '@/lib/supabaseConfig';
 
 /**

--- a/apps/registry/app/api/privacy/delete-cache/route.ts
+++ b/apps/registry/app/api/privacy/delete-cache/route.ts
@@ -3,8 +3,8 @@ import { createClient } from '@supabase/supabase-js';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import logger from '@/lib/logger';
-
-const SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+// @ts-expect-error - JS config module (triple-export CommonJS)
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 
 /**
  * DELETE /api/privacy/delete-cache

--- a/apps/registry/app/api/resumes/utils/supabaseClient.js
+++ b/apps/registry/app/api/resumes/utils/supabaseClient.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../../../lib/supabaseConfig');
 
 export const createSupabaseClient = () => {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/resumes/utils/supabaseClient.test.js
+++ b/apps/registry/app/api/resumes/utils/supabaseClient.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createSupabaseClient } from './supabaseClient';
+import { SUPABASE_URL } from '../../../../lib/supabaseConfig';
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn((url, key) => ({
@@ -33,7 +34,7 @@ describe('createSupabaseClient', () => {
 
     const client = createSupabaseClient();
 
-    expect(client.url).toBe('https://itxuhvvwryeuzuyihpkp.supabase.co');
+    expect(client.url).toBe(SUPABASE_URL);
   });
 
   it('returns client object', () => {

--- a/apps/registry/app/api/similarity/utils/createSupabase.js
+++ b/apps/registry/app/api/similarity/utils/createSupabase.js
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../../../lib/supabaseConfig');
 
 export const createSupabase = () => {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/similarity/utils/createSupabase.test.js
+++ b/apps/registry/app/api/similarity/utils/createSupabase.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createSupabase } from './createSupabase';
+import { SUPABASE_URL } from '../../../../lib/supabaseConfig';
 
 vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn((url, key) => ({
@@ -33,7 +34,7 @@ describe('createSupabase', () => {
 
     const client = createSupabase();
 
-    expect(client.url).toBe('https://itxuhvvwryeuzuyihpkp.supabase.co');
+    expect(client.url).toBe(SUPABASE_URL);
   });
 
   it('returns client object', () => {

--- a/apps/registry/app/api/v1/jobs/[id]/dossier/route.js
+++ b/apps/registry/app/api/v1/jobs/[id]/dossier/route.js
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { authenticate } from '../../../auth';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/v1/jobs/[id]/route.js
+++ b/apps/registry/app/api/v1/jobs/[id]/route.js
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { authenticate } from '../../auth';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/v1/jobs/matchingHelpers.js
+++ b/apps/registry/app/api/v1/jobs/matchingHelpers.js
@@ -1,9 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { embed, generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { logger } from '@/lib/logger';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 const RERANK_BATCH_SIZE = 5;
 
 export function getSupabase() {

--- a/apps/registry/app/api/v1/report/[username]/helpers.js
+++ b/apps/registry/app/api/v1/report/[username]/helpers.js
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 export function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/v1/resume/route.js
+++ b/apps/registry/app/api/v1/resume/route.js
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { authenticate } from '../auth';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/v1/searches/[id]/route.js
+++ b/apps/registry/app/api/v1/searches/[id]/route.js
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { authenticate } from '../../auth';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);

--- a/apps/registry/app/api/v1/searches/route.js
+++ b/apps/registry/app/api/v1/searches/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import { embed, generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { authenticate } from '../auth';
@@ -7,7 +8,7 @@ import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 const PROMPT_WEIGHT = 0.65;
 
 function getSupabase() {

--- a/apps/registry/app/explore/ExploreModule/constants/index.js
+++ b/apps/registry/app/explore/ExploreModule/constants/index.js
@@ -1,4 +1,4 @@
-export const SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+export { SUPABASE_URL } from '@/lib/supabaseConfig';
 export const ITEMS_PER_PAGE = 100;
 
 export const METADATA = {

--- a/apps/registry/app/jobs/page.js
+++ b/apps/registry/app/jobs/page.js
@@ -1,9 +1,10 @@
 import { Suspense } from 'react';
 import { logger } from '@/lib/logger';
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL } from '@/lib/supabaseConfig';
 import ClientJobBoard from './ClientJobBoard';
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const supabaseUrl = SUPABASE_URL;
 
 // Force dynamic rendering - Next.js route config
 export const dynamicParams = true;

--- a/apps/registry/app/lib/supabase.test.ts
+++ b/apps/registry/app/lib/supabase.test.ts
@@ -17,8 +17,10 @@ describe('supabase client', () => {
 
   it('creates client with correct URL', async () => {
     const { supabase } = await import('./supabase');
+    // @ts-expect-error - JS config module (triple-export CommonJS)
+    const { SUPABASE_URL } = await import('../../lib/supabaseConfig');
 
-    expect(supabase.url).toBe('https://itxuhvvwryeuzuyihpkp.supabase.co');
+    expect(supabase.url).toBe(SUPABASE_URL);
   });
 
   it('creates client with anon key', async () => {

--- a/apps/registry/app/lib/supabase.ts
+++ b/apps/registry/app/lib/supabase.ts
@@ -1,5 +1,4 @@
 import { createClient } from '@supabase/supabase-js';
-// @ts-expect-error - JS config module (triple-export CommonJS)
 import { SUPABASE_URL } from '../../lib/supabaseConfig';
 
 // Anon key is browser-safe (public). Prefer env var, fall back to the

--- a/apps/registry/app/lib/supabase.ts
+++ b/apps/registry/app/lib/supabase.ts
@@ -1,9 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+// @ts-expect-error - JS config module (triple-export CommonJS)
+import { SUPABASE_URL } from '../../lib/supabaseConfig';
 
-// const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-// const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+// Anon key is browser-safe (public). Prefer env var, fall back to the
+// documented public anon key so the client keeps working if unset.
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0eHVodnZ3cnlldXp1eWlocGtwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MDc5OTA4NjQsImV4cCI6MjAyMzU2Njg2NH0.oEs0H2aumAHsiLn6i9ic1-iwWDo3bJkFkC7NCeUrIfA';
 
-export const supabase = createClient(
-  'https://itxuhvvwryeuzuyihpkp.supabase.co',
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0eHVodnZ3cnlldXp1eWlocGtwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MDc5OTA4NjQsImV4cCI6MjAyMzU2Njg2NH0.oEs0H2aumAHsiLn6i9ic1-iwWDo3bJkFkC7NCeUrIfA'
-);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/apps/registry/lib/generateResume/cacheResume.js
+++ b/apps/registry/lib/generateResume/cacheResume.js
@@ -11,7 +11,7 @@ export const cacheResume = async (username, resume) => {
   try {
     // Lazy load Supabase client only when needed
     const { createClient } = require('@supabase/supabase-js');
-    const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+    const { SUPABASE_URL: supabaseUrl } = require('../supabaseConfig');
     const supabase = createClient(supabaseUrl, supabaseKey);
 
     await supabase

--- a/apps/registry/lib/supabaseConfig.js
+++ b/apps/registry/lib/supabaseConfig.js
@@ -1,0 +1,66 @@
+/**
+ * Centralized Supabase configuration.
+ *
+ * Single source of truth for the Supabase project URL and client factories.
+ * Previously the project URL was hardcoded in ~57 files across the registry app;
+ * this module replaces all of those literals.
+ *
+ * Env vars (see apps/registry/.env.example):
+ *   - NEXT_PUBLIC_SUPABASE_URL       Public project URL (client + server)
+ *   - NEXT_PUBLIC_SUPABASE_ANON_KEY  Public anon key (browser-safe reads)
+ *   - SUPABASE_KEY                   Service-role key (server-only, never exposed)
+ *
+ * The hardcoded URL below is a documented fallback so the app keeps working if
+ * the env var is unset. The project ref persists across pause/restore, so this
+ * value is stable.
+ *
+ * Uses the triple-export CommonJS pattern so it works from both ESM
+ * (`import { SUPABASE_URL } from '...'`) and CommonJS (`require`) callers.
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+
+/** Documented fallback URL — project ref is stable across pause/restore. */
+const DEFAULT_SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+
+/** Public Supabase project URL. */
+const SUPABASE_URL =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || DEFAULT_SUPABASE_URL;
+
+/**
+ * Create a Supabase client with the service-role key (server-only).
+ * Throws if SUPABASE_KEY is not configured.
+ * @returns {import('@supabase/supabase-js').SupabaseClient}
+ */
+function createServiceClient() {
+  if (!process.env.SUPABASE_KEY) {
+    throw new Error('SUPABASE_KEY environment variable is required');
+  }
+  return createClient(SUPABASE_URL, process.env.SUPABASE_KEY);
+}
+
+/**
+ * Create a Supabase client with the public anon key (browser-safe).
+ * @returns {import('@supabase/supabase-js').SupabaseClient}
+ */
+function createAnonClient() {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!anonKey) {
+    throw new Error(
+      'NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable is required'
+    );
+  }
+  return createClient(SUPABASE_URL, anonKey);
+}
+
+module.exports = {
+  SUPABASE_URL,
+  DEFAULT_SUPABASE_URL,
+  createServiceClient,
+  createAnonClient,
+};
+module.exports.SUPABASE_URL = SUPABASE_URL;
+module.exports.DEFAULT_SUPABASE_URL = DEFAULT_SUPABASE_URL;
+module.exports.createServiceClient = createServiceClient;
+module.exports.createAnonClient = createAnonClient;
+module.exports.default = module.exports;

--- a/apps/registry/lib/trackView.js
+++ b/apps/registry/lib/trackView.js
@@ -10,7 +10,7 @@ const trackView = async (username) => {
 
   // Lazy load Supabase client only when needed
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('./supabaseConfig');
 
   // insert a view record into the database
   try {

--- a/apps/registry/pages/api/[username]/jobs.js
+++ b/apps/registry/pages/api/[username]/jobs.js
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/pages/api/candidates/supabaseClient.js
+++ b/apps/registry/pages/api/candidates/supabaseClient.js
@@ -1,5 +1,5 @@
 export const createSupabaseClient = () => {
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);
 };

--- a/apps/registry/pages/api/export.js
+++ b/apps/registry/pages/api/export.js
@@ -2,7 +2,7 @@ const { embed, generateText } = require('ai');
 const { openai } = require('@ai-sdk/openai');
 const { createClient } = require('@supabase/supabase-js');
 
-const SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL } = require('../../lib/supabaseConfig');
 
 export default async function handler(req, res) {
   if (!process.env.OPENAI_API_KEY || !process.env.SUPABASE_KEY) {

--- a/apps/registry/pages/api/interview.js
+++ b/apps/registry/pages/api/interview.js
@@ -29,7 +29,7 @@ export default async function handler(req) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/pages/api/jobs-graph/fetchResumeData.js
+++ b/apps/registry/pages/api/jobs-graph/fetchResumeData.js
@@ -5,7 +5,7 @@
  */
 export async function fetchResumeData(username) {
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/pages/api/jobs-graph/matchJobs.js
+++ b/apps/registry/pages/api/jobs-graph/matchJobs.js
@@ -5,7 +5,7 @@
  */
 export async function matchJobs(embedding) {
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   // Match jobs using vector similarity

--- a/apps/registry/pages/api/jobs.js
+++ b/apps/registry/pages/api/jobs.js
@@ -10,7 +10,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data, error: dbError } = await supabase

--- a/apps/registry/pages/api/jobs/all.js
+++ b/apps/registry/pages/api/jobs/all.js
@@ -1,6 +1,6 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
 
 export const config = {
   runtime: 'edge',

--- a/apps/registry/pages/api/letter.js
+++ b/apps/registry/pages/api/letter.js
@@ -12,7 +12,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   // pull from the cache

--- a/apps/registry/pages/api/relevant-jobs.js
+++ b/apps/registry/pages/api/relevant-jobs.js
@@ -27,7 +27,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/pages/api/suggestions-beta.js
+++ b/apps/registry/pages/api/suggestions-beta.js
@@ -26,7 +26,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/pages/api/suggestions.js
+++ b/apps/registry/pages/api/suggestions.js
@@ -7,7 +7,7 @@ export default async function handler(req, res) {
 
   // Lazy load Supabase
   const { createClient } = require('@supabase/supabase-js');
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
   const supabase = createClient(supabaseUrl, process.env.SUPABASE_KEY);
 
   const { data } = await supabase

--- a/apps/registry/scripts/cleanup-deleted-gists.js
+++ b/apps/registry/scripts/cleanup-deleted-gists.js
@@ -18,8 +18,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 import logger from '../lib/logger.js';
+import { SUPABASE_URL } from '../lib/supabaseConfig.js';
 
-const SUPABASE_URL = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
 const GITHUB_GIST_URL = 'https://gist.githubusercontent.com';
 
 // Parse command line arguments

--- a/apps/registry/scripts/companies/enrich-resume-companies.js
+++ b/apps/registry/scripts/companies/enrich-resume-companies.js
@@ -24,7 +24,7 @@ const { createClient } = require('@supabase/supabase-js');
 const async = require('async');
 const { enrichCompany } = require('./enrichCompany');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const perplexityApiKey = process.env.PERPLEXITY_API_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);

--- a/apps/registry/scripts/companies/extract-companies-from-resumes.js
+++ b/apps/registry/scripts/companies/extract-companies-from-resumes.js
@@ -22,7 +22,7 @@ for (const envPath of envPaths) {
 const { createClient } = require('@supabase/supabase-js');
 const { normalizeCompanyName } = require('./enrichCompany');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/analyze-salaries.js
+++ b/apps/registry/scripts/jobs/analyze-salaries.js
@@ -5,7 +5,7 @@
 require('dotenv').config({ path: '../../.env.local' });
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 
 if (!supabaseKey) {

--- a/apps/registry/scripts/jobs/checkJobsCount.js
+++ b/apps/registry/scripts/jobs/checkJobsCount.js
@@ -6,7 +6,7 @@ require('dotenv').config({ path: __dirname + '/./../../.env' });
 
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 
 if (!supabaseUrl || !supabaseKey) {

--- a/apps/registry/scripts/jobs/checkJobsDates.js
+++ b/apps/registry/scripts/jobs/checkJobsDates.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: __dirname + '/./../../.env' });
 
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/checkOctoberJobs.js
+++ b/apps/registry/scripts/jobs/checkOctoberJobs.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: __dirname + '/./../../.env' });
 
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/embeddings/supabase.js
+++ b/apps/registry/scripts/jobs/embeddings/supabase.js
@@ -1,6 +1,6 @@
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
 
 function createSupabaseClient() {
   const supabaseKey = process.env.SUPABASE_KEY;

--- a/apps/registry/scripts/jobs/enrich-companies.js
+++ b/apps/registry/scripts/jobs/enrich-companies.js
@@ -1,7 +1,7 @@
 require('dotenv').config({ path: __dirname + '/./../../.env' });
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/generate-embeddings-resumes.js
+++ b/apps/registry/scripts/jobs/generate-embeddings-resumes.js
@@ -10,7 +10,7 @@ const { createClient } = require('@supabase/supabase-js');
 const { embed } = require('ai');
 const { openai } = require('@ai-sdk/openai');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/import-hn-job.js
+++ b/apps/registry/scripts/jobs/import-hn-job.js
@@ -8,7 +8,7 @@ const axios = require('axios');
 const async = require('async');
 const { createClient } = require('@supabase/supabase-js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/import-hn-latest-thread.js
+++ b/apps/registry/scripts/jobs/import-hn-latest-thread.js
@@ -12,7 +12,7 @@ const path = require('path');
 const { createClient } = require('@supabase/supabase-js');
 const { notifyFeatureUsage } = require('../../lib/discord/notifiers.js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/apps/registry/scripts/jobs/job-parser/database/initializeSupabase.js
+++ b/apps/registry/scripts/jobs/job-parser/database/initializeSupabase.js
@@ -4,7 +4,9 @@ const { createClient } = require('@supabase/supabase-js');
  * Initialize Supabase client with fallback for missing credentials
  */
 function initializeSupabase() {
-  const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+  const {
+    SUPABASE_URL: supabaseUrl,
+  } = require('../../../../lib/supabaseConfig');
   const supabaseKey =
     process.env.SUPABASE_KEY || 'MISSING_KEY_USING_FILE_ONLY_MODE';
 

--- a/apps/registry/scripts/jobs/salary-normalizer/run-migration.js
+++ b/apps/registry/scripts/jobs/salary-normalizer/run-migration.js
@@ -9,7 +9,7 @@ require('dotenv').config({
 const { createClient } = require('@supabase/supabase-js');
 const { normalizeSalary } = require('./index.js');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 
 if (!supabaseKey) {

--- a/apps/registry/scripts/jobs/search.js
+++ b/apps/registry/scripts/jobs/search.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: __dirname + '/./../../.env' });
 const { createClient } = require('@supabase/supabase-js');
 const OpenAI = require('openai');
 
-const supabaseUrl = 'https://itxuhvvwryeuzuyihpkp.supabase.co';
+const { SUPABASE_URL: supabaseUrl } = require('../../lib/supabaseConfig');
 const supabaseKey = process.env.SUPABASE_KEY;
 const supabase = createClient(supabaseUrl, supabaseKey);
 const openai = new OpenAI({


### PR DESCRIPTION
## Summary

The Supabase project URL (\`itxuhvvwryeuzuyihpkp.supabase.co\`) was hardcoded in **57 files** across \`apps/registry\` — in \`app/\`, \`pages/\`, \`lib/\`, and \`scripts/\`, in both ESM and CommonJS styles. This made the project ref impossible to rotate and brittle if the URL ever changed.

This PR introduces a **single source of truth**: \`apps/registry/lib/supabaseConfig.js\`.

### What it exports
- \`SUPABASE_URL\` = \`process.env.NEXT_PUBLIC_SUPABASE_URL || <known project URL>\` (documented fallback — the project ref is stable across pause/restore)
- \`createServiceClient()\` — server-only, uses \`SUPABASE_KEY\` (service role)
- \`createAnonClient()\` — browser-safe, uses \`NEXT_PUBLIC_SUPABASE_ANON_KEY\`

It uses the repo's triple-export CommonJS pattern (matching \`lib/logger.js\`) so both \`import { SUPABASE_URL }\` (ESM / Next bundler) and \`require()\` (CJS scripts) consumers work.

### Changes
- All 57 hardcoded literal occurrences now import \`SUPABASE_URL\` from the central module.
- The **server-side service-role (\`SUPABASE_KEY\`) vs browser anon-key split is preserved** — no factory was collapsed across that boundary.
- App-router files import via the \`@/lib/supabaseConfig\` alias; \`pages/\`, \`lib/\`, and \`scripts/\` use relative paths; CJS lazy-require sites use \`require()\`.
- Tests that asserted the literal URL now assert via the config module.
- \`.env.example\` documents \`NEXT_PUBLIC_SUPABASE_URL\`, \`NEXT_PUBLIC_SUPABASE_ANON_KEY\`, \`SUPABASE_KEY\`.

### Why now / safety
The Supabase project is currently **INACTIVE** behind an unpaid invoice (#332). Restore is owner-blocked, but the URL is **identical after restore** (refs persist), so this refactor is fully safe to land now and de-risks the eventual restore.

### Verification
- \`pnpm --filter registry build\` — green (exit 0)
- \`pnpm --filter registry test -- --run\` — green (1359 passed, 24 skipped)
- \`pnpm --filter registry lint\` — green (\`--max-warnings=0\`)
- \`pnpm --filter registry typecheck\` — green (0 errors)
- \`grep\` confirms **zero** remaining hardcoded refs in source outside the single config module + \`.env.example\`

Refs #275, #332

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized Supabase configuration across the app to use a single shared configuration, improving consistency and maintainability without changing any user-facing behavior.
* **Tests**
  * Updated tests to rely on the centralized Supabase configuration (no functional test behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->