### PR TITLE
test(registry): cover jobs matching + report analytics + salary normalizer

### DIFF
--- a/apps/registry/app/api/v1/jobs/matchingHelpers.test.js
+++ b/apps/registry/app/api/v1/jobs/matchingHelpers.test.js
@@ -1,0 +1,217 @@
+/**
+ * Characterization tests for the pure vector / scoring helpers exported by
+ * matchingHelpers.js. The async functions in this module (generateHydeEmbedding,
+ * rerankJobs, matchJobs, getResumeEmbedding) hit OpenAI / Supabase and are not
+ * unit-tested here — only the deterministic pure logic is covered.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  normalize,
+  interpolate,
+  subtractDirection,
+  timeDecayScore,
+  averageEmbeddings,
+} from './matchingHelpers';
+
+const mag = (v) => Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+
+describe('normalize', () => {
+  it('scales a vector to unit length', () => {
+    const out = normalize([3, 4]);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    expect(out[0]).toBeCloseTo(0.6, 10);
+    expect(out[1]).toBeCloseTo(0.8, 10);
+  });
+
+  it('already-unit vector stays unit length', () => {
+    const out = normalize([1, 0, 0]);
+    expect(out).toEqual([1, 0, 0]);
+  });
+
+  it('returns the zero vector unchanged (no divide-by-zero)', () => {
+    const zero = [0, 0, 0];
+    const out = normalize(zero);
+    expect(out).toBe(zero); // returns same reference
+    expect(out).toEqual([0, 0, 0]);
+  });
+
+  it('handles negative components and preserves direction', () => {
+    const out = normalize([-3, -4]);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    expect(out[0]).toBeLessThan(0);
+    expect(out[1]).toBeLessThan(0);
+  });
+
+  it('normalizes a single-element vector to sign-only', () => {
+    expect(normalize([5])).toEqual([1]);
+    expect(normalize([-5])).toEqual([-1]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [3, 4];
+    normalize(input);
+    expect(input).toEqual([3, 4]);
+  });
+});
+
+describe('interpolate', () => {
+  it('alpha=1 returns normalized vecA direction', () => {
+    const out = interpolate([3, 4], [0, 1], 1);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    expect(out[0]).toBeCloseTo(0.6, 10);
+    expect(out[1]).toBeCloseTo(0.8, 10);
+  });
+
+  it('alpha=0 returns normalized vecB direction', () => {
+    const out = interpolate([3, 4], [0, 5], 0);
+    expect(out).toEqual([0, 1]);
+  });
+
+  it('output is always unit length for a blend', () => {
+    const out = interpolate([1, 0], [0, 1], 0.5);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    // 0.5 of each then normalized => equal components
+    expect(out[0]).toBeCloseTo(out[1], 10);
+  });
+
+  it('blends proportionally before normalizing', () => {
+    // alpha 0.75 of [1,0] + 0.25 of [0,1] => [0.75, 0.25] normalized
+    const out = interpolate([1, 0], [0, 1], 0.75);
+    const expectedMag = Math.sqrt(0.75 * 0.75 + 0.25 * 0.25);
+    expect(out[0]).toBeCloseTo(0.75 / expectedMag, 10);
+    expect(out[1]).toBeCloseTo(0.25 / expectedMag, 10);
+  });
+
+  it('does not mutate inputs', () => {
+    const a = [1, 2];
+    const b = [3, 4];
+    interpolate(a, b, 0.5);
+    expect(a).toEqual([1, 2]);
+    expect(b).toEqual([3, 4]);
+  });
+});
+
+describe('subtractDirection', () => {
+  it('moves the vector away from the negative direction', () => {
+    // base pointing +x, subtract a +x negative direction => still +x but unit
+    const out = subtractDirection([1, 0], [1, 0], 0.15);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    expect(out[0]).toBeCloseTo(1, 10);
+  });
+
+  it('default weight is 0.15', () => {
+    const explicit = subtractDirection([1, 0], [0, 1], 0.15);
+    const defaulted = subtractDirection([1, 0], [0, 1]);
+    expect(defaulted).toEqual(explicit);
+  });
+
+  it('larger weight pushes further from the negative vector', () => {
+    const small = subtractDirection([1, 0], [0, 1], 0.1);
+    const large = subtractDirection([1, 0], [0, 1], 0.5);
+    // negative y component grows with weight
+    expect(large[1]).toBeLessThan(small[1]);
+    expect(mag(large)).toBeCloseTo(1, 10);
+  });
+
+  it('result is unit length', () => {
+    const out = subtractDirection([2, 3, 6], [1, 1, 1], 0.2);
+    expect(mag(out)).toBeCloseTo(1, 10);
+  });
+
+  it('does not mutate inputs', () => {
+    const v = [1, 0];
+    const n = [0, 1];
+    subtractDirection(v, n);
+    expect(v).toEqual([1, 0]);
+    expect(n).toEqual([0, 1]);
+  });
+});
+
+describe('timeDecayScore', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the raw similarity when postedAt is missing', () => {
+    expect(timeDecayScore(0.7, null)).toBe(0.7);
+    expect(timeDecayScore(0.42, undefined)).toBe(0.42);
+  });
+
+  it('a job posted right now gets the full recency boost', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-01-01T00:00:00Z');
+    vi.setSystemTime(now);
+    // recencyBoost = 0.5^0 = 1 => 0.85*sim + 0.15*1
+    const out = timeDecayScore(0.5, now.toISOString());
+    expect(out).toBeCloseTo(0.85 * 0.5 + 0.15 * 1, 10);
+  });
+
+  it('halves the recency boost after one half-life (14 days)', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-01-15T00:00:00Z');
+    vi.setSystemTime(now);
+    const posted = new Date('2026-01-01T00:00:00Z'); // 14 days earlier
+    const out = timeDecayScore(0.5, posted.toISOString());
+    // recencyBoost = 0.5^1 = 0.5
+    expect(out).toBeCloseTo(0.85 * 0.5 + 0.15 * 0.5, 6);
+  });
+
+  it('older jobs decay toward 0.85*similarity', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-06-01T00:00:00Z');
+    vi.setSystemTime(now);
+    const posted = new Date('2025-06-01T00:00:00Z'); // ~1 year old
+    const out = timeDecayScore(0.6, posted.toISOString());
+    expect(out).toBeGreaterThan(0.85 * 0.6 - 0.001);
+    expect(out).toBeLessThan(0.85 * 0.6 + 0.01);
+  });
+
+  it('recent jobs score higher than identical-similarity old jobs', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-06-01T00:00:00Z');
+    vi.setSystemTime(now);
+    const recent = new Date('2026-05-30T00:00:00Z').toISOString();
+    const old = new Date('2026-01-01T00:00:00Z').toISOString();
+    expect(timeDecayScore(0.5, recent)).toBeGreaterThan(
+      timeDecayScore(0.5, old)
+    );
+  });
+});
+
+describe('averageEmbeddings', () => {
+  it('returns null for an empty list', () => {
+    expect(averageEmbeddings([])).toBeNull();
+  });
+
+  it('averages then normalizes a single embedding to unit length', () => {
+    const out = averageEmbeddings([[3, 4]]);
+    expect(mag(out)).toBeCloseTo(1, 10);
+    expect(out[0]).toBeCloseTo(0.6, 10);
+  });
+
+  it('averages component-wise across multiple embeddings before normalizing', () => {
+    // average of [1,0] and [0,1] is [0.5,0.5] -> normalized equal components
+    const out = averageEmbeddings([
+      [1, 0],
+      [0, 1],
+    ]);
+    expect(out[0]).toBeCloseTo(out[1], 10);
+    expect(mag(out)).toBeCloseTo(1, 10);
+  });
+
+  it('opposing vectors average to the zero vector and stay zero', () => {
+    const out = averageEmbeddings([
+      [1, 0],
+      [-1, 0],
+    ]);
+    expect(out).toEqual([0, 0]);
+  });
+
+  it('does not mutate the input embeddings', () => {
+    const a = [1, 2];
+    const b = [3, 4];
+    averageEmbeddings([a, b]);
+    expect(a).toEqual([1, 2]);
+    expect(b).toEqual([3, 4]);
+  });
+});

--- a/apps/registry/app/api/v1/report/[username]/analytics-v2.test.js
+++ b/apps/registry/app/api/v1/report/[username]/analytics-v2.test.js
@@ -1,0 +1,274 @@
+/**
+ * Characterization tests for the v2 report analytics:
+ * anti-resume, skill adjacency, archetypes, market drift, readiness scores,
+ * and best-match similarity. All functions are pure over parsed job objects.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  computeAntiResume,
+  computeSkillAdjacency,
+  computeArchetypes,
+  computeMarketDrift,
+  computeReadinessScores,
+  computeBestMatchSimilar,
+} from './analytics-v2';
+
+const job = (overrides = {}) => ({
+  id: Math.random(),
+  title: 'Engineer',
+  company: 'Acme',
+  skills: [],
+  ...overrides,
+});
+
+describe('computeAntiResume', () => {
+  it('returns empty structure when there are no rejected jobs', () => {
+    expect(computeAntiResume([job()], [])).toEqual({
+      skills: [],
+      attributes: [],
+    });
+  });
+
+  it('flags skills over-represented in rejections as avoid skills', () => {
+    const rejected = [
+      job({ skills: [{ name: 'PHP' }] }),
+      job({ skills: [{ name: 'PHP' }] }),
+      job({ skills: [{ name: 'PHP' }] }),
+    ];
+    const interested = [job({ skills: [{ name: 'React' }] })];
+    const out = computeAntiResume(interested, rejected);
+    const php = out.skills.find((s) => s.skill === 'php');
+    expect(php).toBeDefined();
+    expect(php.rejCount).toBe(3);
+    expect(php.intCount).toBe(0);
+    expect(php.avoidScore).toBeGreaterThan(0.05);
+  });
+
+  it('flags attribute values (remote/experience/type) skewed toward rejection', () => {
+    const rejected = [
+      job({ remote: 'No' }),
+      job({ remote: 'No' }),
+      job({ remote: 'No' }),
+    ];
+    const interested = [job({ remote: 'Full' })];
+    const out = computeAntiResume(interested, rejected);
+    const attr = out.attributes.find(
+      (a) => a.attribute === 'remote' && a.value === 'No'
+    );
+    expect(attr).toBeDefined();
+    expect(attr.avoidScore).toBeGreaterThan(0.1);
+  });
+
+  it('does not flag skills present equally in both sets', () => {
+    const rejected = [job({ skills: [{ name: 'React' }] })];
+    const interested = [job({ skills: [{ name: 'React' }] })];
+    const out = computeAntiResume(interested, rejected);
+    expect(out.skills.find((s) => s.skill === 'react')).toBeUndefined();
+  });
+});
+
+describe('computeSkillAdjacency', () => {
+  it('recommends skills that co-occur with the user skills but they lack', () => {
+    const market = [
+      job({ skills: [{ name: 'React' }, { name: 'GraphQL' }] }),
+      job({ skills: [{ name: 'React' }, { name: 'GraphQL' }] }),
+    ];
+    const out = computeSkillAdjacency(market, ['react']);
+    const rec = out.find((r) => r.skill === 'graphql');
+    expect(rec).toBeDefined();
+    expect(rec.because).toBe('react');
+    expect(rec.coCount).toBe(2);
+  });
+
+  it('does not recommend skills the user already has', () => {
+    const market = [job({ skills: [{ name: 'React' }, { name: 'GraphQL' }] })];
+    const out = computeSkillAdjacency(market, ['react', 'graphql']);
+    expect(out).toEqual([]);
+  });
+
+  it('returns empty when no user skill appears in the market', () => {
+    const market = [job({ skills: [{ name: 'COBOL' }, { name: 'Fortran' }] })];
+    const out = computeSkillAdjacency(market, ['react']);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('computeArchetypes', () => {
+  it('returns empty when fewer than 3 interested jobs', () => {
+    expect(computeArchetypes([job(), job()])).toEqual([]);
+  });
+
+  it('groups jobs sharing their top-3 skill signature', () => {
+    const skills = [{ name: 'React' }, { name: 'Node' }, { name: 'AWS' }];
+    const interested = [
+      job({ title: 'A', skills }),
+      job({ title: 'B', skills }),
+      job({ title: 'C', skills }),
+    ];
+    const out = computeArchetypes(interested);
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    expect(out[0].count).toBe(3);
+    expect(out[0].titles).toContain('A');
+  });
+
+  it('drops groups with fewer than 2 jobs', () => {
+    const interested = [
+      job({ skills: [{ name: 'React' }, { name: 'Node' }, { name: 'AWS' }] }),
+      job({ skills: [{ name: 'React' }, { name: 'Node' }, { name: 'AWS' }] }),
+      job({ skills: [{ name: 'Rust' }, { name: 'WASM' }, { name: 'C++' }] }),
+    ];
+    const out = computeArchetypes(interested);
+    // only the 2-job React/Node/AWS group survives
+    expect(out).toHaveLength(1);
+    expect(out[0].count).toBe(2);
+  });
+});
+
+describe('computeMarketDrift', () => {
+  it('returns empty trends when no jobs are provided', () => {
+    expect(computeMarketDrift([])).toEqual({
+      trends: [],
+      growing: [],
+      declining: [],
+    });
+  });
+
+  it('returns trends but no growing/declining with a single week', () => {
+    const jobs = [
+      job({ posted_at: '2026-01-05', skills: [{ name: 'React' }] }), // a Monday
+      job({ posted_at: '2026-01-06', skills: [{ name: 'Go' }] }),
+    ];
+    const out = computeMarketDrift(jobs);
+    expect(out.trends.length).toBe(1);
+    expect(out.growing).toEqual([]);
+    expect(out.declining).toEqual([]);
+  });
+
+  it('detects skills growing and declining between first and last week', () => {
+    const jobs = [
+      // week 1: React absent, Go present
+      job({ posted_at: '2026-01-05', skills: [{ name: 'Go' }] }),
+      job({ posted_at: '2026-01-06', skills: [{ name: 'Go' }] }),
+      // week 3: React present, Go absent
+      job({ posted_at: '2026-01-19', skills: [{ name: 'React' }] }),
+      job({ posted_at: '2026-01-20', skills: [{ name: 'React' }] }),
+    ];
+    const out = computeMarketDrift(jobs);
+    expect(out.trends.length).toBeGreaterThanOrEqual(2);
+    expect(out.growing.some((g) => g.skill === 'react')).toBe(true);
+    expect(out.declining.some((d) => d.skill === 'golang')).toBe(true);
+  });
+});
+
+describe('computeReadinessScores', () => {
+  const resume = {
+    work: [{ startDate: '2018-01-01', endDate: '2025-01-01' }], // ~7 yrs
+    basics: { location: { countryCode: 'US' } },
+  };
+  const salaryStats = { market: { p25: 80000, p50: 120000, p75: 160000 } };
+
+  it('returns one entry per interested job (capped at 8)', () => {
+    const jobs = Array.from({ length: 12 }, (_, i) =>
+      job({ id: i, skills: [{ name: 'React' }] })
+    );
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out).toHaveLength(8);
+  });
+
+  it('scores a full skill match at 100', () => {
+    const jobs = [job({ skills: [{ name: 'React' }] })];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out[0].scores.skills).toBe(100);
+    expect(out[0].matchedSkills).toContain('react');
+  });
+
+  it('lists missing skills the user lacks', () => {
+    const jobs = [job({ skills: [{ name: 'React' }, { name: 'Rust' }] })];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out[0].missingSkills).toContain('rust');
+    expect(out[0].scores.skills).toBe(50);
+  });
+
+  it('rewards a senior role for a candidate with 5+ years', () => {
+    const jobs = [job({ experience: 'Senior', skills: [{ name: 'React' }] })];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out[0].scores.experience).toBe(100);
+  });
+
+  it('scores salary against market percentiles', () => {
+    const jobs = [
+      job({ salary_usd: 200000, skills: [{ name: 'React' }] }), // >= p75
+    ];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out[0].scores.salary).toBe(95);
+  });
+
+  it('boosts remote=full location compatibility', () => {
+    const jobs = [job({ remote: 'Full', skills: [{ name: 'React' }] })];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    expect(out[0].scores.location).toBe(95);
+    expect(out[0].scores.remote).toBe(95);
+  });
+
+  it('computes overall as the mean of the six sub-scores', () => {
+    const jobs = [job({ skills: [{ name: 'React' }] })];
+    const out = computeReadinessScores(jobs, ['react'], resume, salaryStats);
+    const s = out[0].scores;
+    const mean = Math.round(
+      (s.skills + s.experience + s.remote + s.salary + s.location + s.visa) / 6
+    );
+    expect(out[0].overall).toBe(mean);
+  });
+});
+
+describe('computeBestMatchSimilar', () => {
+  it('returns empty when there are no interested jobs', () => {
+    const allJobs = Array.from({ length: 6 }, (_, i) => job({ id: i }));
+    expect(computeBestMatchSimilar([], allJobs, [])).toEqual([]);
+  });
+
+  it('returns empty when there are fewer than 5 parsed jobs', () => {
+    const interested = [job({ skills: [{ name: 'React' }] })];
+    expect(computeBestMatchSimilar(interested, [job(), job()], [])).toEqual([]);
+  });
+
+  it('suggests unreviewed jobs that overlap >= 2 skills with liked jobs', () => {
+    const interested = [
+      job({
+        id: 'liked',
+        title: 'Liked',
+        company: 'Likedco',
+        skills: [{ name: 'React' }, { name: 'Node' }, { name: 'AWS' }],
+      }),
+    ];
+    const allJobs = [
+      job({ id: 1, skills: [{ name: 'React' }, { name: 'Node' }] }), // overlap 2
+      job({ id: 2, skills: [{ name: 'COBOL' }] }), // overlap 0
+      job({ id: 3, skills: [{ name: 'React' }] }), // overlap 1
+      job({ id: 4, skills: [] }),
+      job({ id: 5, skills: [] }),
+    ];
+    const out = computeBestMatchSimilar(interested, allJobs, []);
+    expect(out.some((j) => j.id === 1)).toBe(true);
+    expect(out.some((j) => j.id === 2)).toBe(false);
+    expect(out.some((j) => j.id === 3)).toBe(false); // overlap 1 < 2
+    const match = out.find((j) => j.id === 1);
+    expect(match.similarTo).toEqual({ title: 'Liked', company: 'Likedco' });
+  });
+
+  it('excludes already-reviewed jobs by id', () => {
+    const interested = [
+      job({ skills: [{ name: 'React' }, { name: 'Node' }, { name: 'AWS' }] }),
+    ];
+    const allJobs = [
+      job({ id: 1, skills: [{ name: 'React' }, { name: 'Node' }] }),
+      job({ id: 2, skills: [{ name: 'React' }, { name: 'Node' }] }),
+      job({ id: 3, skills: [] }),
+      job({ id: 4, skills: [] }),
+      job({ id: 5, skills: [] }),
+    ];
+    const out = computeBestMatchSimilar(interested, allJobs, [1]);
+    expect(out.some((j) => j.id === 1)).toBe(false);
+    expect(out.some((j) => j.id === 2)).toBe(true);
+  });
+});

--- a/apps/registry/app/api/v1/report/[username]/analytics.test.js
+++ b/apps/registry/app/api/v1/report/[username]/analytics.test.js
@@ -1,0 +1,423 @@
+/**
+ * Characterization tests for the v1 report analytics aggregators.
+ * All functions here are pure; fixtures model realistic feedback rows
+ * (sentiment + created_at) and parsed job objects.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  computePipeline,
+  computeTimeline,
+  computeSalary,
+  computeRemoteIndex,
+  computeDealBreakers,
+  computeSkillGaps,
+  computeMomentum,
+  computeTopCompanies,
+  computeRecentActivity,
+  findSecondLookJobs,
+} from './analytics';
+
+const fb = (sentiment, createdAt, extra = {}) => ({
+  sentiment,
+  created_at: createdAt,
+  ...extra,
+});
+
+describe('computePipeline', () => {
+  it('returns all-zero counts for empty feedback', () => {
+    const out = computePipeline([]);
+    expect(out).toEqual({
+      totalJobs: 0,
+      reviewed: 0,
+      interested: 0,
+      maybe: 0,
+      applied: 0,
+      notInterested: 0,
+      dossiers: 0,
+    });
+  });
+
+  it('tallies each sentiment bucket', () => {
+    const feedback = [
+      fb('interested', '2026-01-01'),
+      fb('interested', '2026-01-02'),
+      fb('maybe', '2026-01-03'),
+      fb('applied', '2026-01-04'),
+      fb('not_interested', '2026-01-05'),
+      fb('dismissed', '2026-01-06'),
+      fb('dossier', '2026-01-07'),
+    ];
+    const out = computePipeline(feedback);
+    expect(out.totalJobs).toBe(7);
+    expect(out.interested).toBe(2);
+    expect(out.maybe).toBe(1);
+    expect(out.applied).toBe(1);
+    // not_interested + dismissed collapse into notInterested
+    expect(out.notInterested).toBe(2);
+    expect(out.dossiers).toBe(1);
+    // reviewed = total - dossiers
+    expect(out.reviewed).toBe(6);
+  });
+
+  it('ignores unknown sentiment values', () => {
+    const out = computePipeline([fb('wishlist', '2026-01-01')]);
+    expect(out.totalJobs).toBe(1);
+    expect(out.interested).toBe(0);
+    expect(out.reviewed).toBe(1);
+  });
+});
+
+describe('computeTimeline', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('produces one bucket per day, sorted ascending', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const out = computeTimeline([], 5);
+    expect(out).toHaveLength(5);
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i].date >= out[i - 1].date).toBe(true);
+    }
+  });
+
+  it('bins feedback into the matching day bucket', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const feedback = [
+      fb('interested', '2026-01-10T01:00:00Z'),
+      fb('maybe', '2026-01-10T02:00:00Z'),
+      fb('applied', '2026-01-09T05:00:00Z'),
+      fb('dismissed', '2026-01-09T06:00:00Z'),
+    ];
+    const out = computeTimeline(feedback, 7);
+    const day10 = out.find((d) => d.date === '2026-01-10');
+    const day09 = out.find((d) => d.date === '2026-01-09');
+    expect(day10.interested).toBe(1);
+    expect(day10.maybe).toBe(1);
+    expect(day09.applied).toBe(1);
+    expect(day09.notInterested).toBe(1);
+  });
+
+  it('drops feedback outside the window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+    const feedback = [fb('interested', '2025-12-01T00:00:00Z')];
+    const out = computeTimeline(feedback, 3);
+    const totalInterested = out.reduce((s, d) => s + d.interested, 0);
+    expect(totalInterested).toBe(0);
+  });
+});
+
+describe('computeSalary', () => {
+  it('returns zeroed percentiles when no salaries present', () => {
+    const out = computeSalary([], []);
+    expect(out.market).toEqual({ min: 0, p25: 0, p50: 0, p75: 0, max: 0 });
+    expect(out.distribution).toHaveLength(7);
+  });
+
+  it('prefers salary_usd over the salary string', () => {
+    const out = computeSalary([{ salary_usd: 100000, salary: '$5/hr' }], []);
+    expect(out.market.min).toBe(100000);
+  });
+
+  it('parses k-notation from the salary string fallback', () => {
+    const out = computeSalary([{ salary: '$120k-150k' }], []);
+    // average of 120000 and 150000
+    expect(out.market.min).toBe(135000);
+  });
+
+  it('averages raw dollar figures within sane bounds', () => {
+    const out = computeSalary([{ salary: '$100,000 to $150,000' }], []);
+    expect(out.market.min).toBe(125000);
+  });
+
+  it('computes percentiles across a market set', () => {
+    const market = [
+      { salary_usd: 50000 },
+      { salary_usd: 100000 },
+      { salary_usd: 150000 },
+      { salary_usd: 200000 },
+    ];
+    const out = computeSalary(market, []);
+    expect(out.market.min).toBe(50000);
+    expect(out.market.max).toBe(200000);
+    expect(out.market.p50).toBe(150000);
+  });
+
+  it('builds a distribution histogram across salary ranges', () => {
+    const market = [
+      { salary_usd: 40000 }, // 0-50k
+      { salary_usd: 90000 }, // 80-120k
+      { salary_usd: 130000 }, // 120-160k
+      { salary_usd: 350000 }, // 300k+
+    ];
+    const out = computeSalary(market, []);
+    const byRange = Object.fromEntries(
+      out.distribution.map((d) => [d.range, d.market])
+    );
+    expect(byRange['$0k-$50k']).toBe(1);
+    expect(byRange['$80k-$120k']).toBe(1);
+    expect(byRange['$120k-$160k']).toBe(1);
+    expect(byRange['$300k+']).toBe(1);
+  });
+});
+
+describe('computeRemoteIndex', () => {
+  it('buckets jobs into full / hybrid / none case-insensitively', () => {
+    const market = [
+      { remote: 'Full' },
+      { remote: 'full' },
+      { remote: 'Hybrid' },
+      { remote: 'No' },
+      { remote: null },
+    ];
+    const out = computeRemoteIndex(market, []);
+    expect(out.market.full).toBe(2);
+    expect(out.market.hybrid).toBe(1);
+    // 'No' and null both fall into none
+    expect(out.market.none).toBe(2);
+  });
+
+  it('tracks market and interested separately', () => {
+    const out = computeRemoteIndex(
+      [{ remote: 'Full' }],
+      [{ remote: 'Hybrid' }]
+    );
+    expect(out.market.full).toBe(1);
+    expect(out.interested.hybrid).toBe(1);
+  });
+});
+
+describe('computeDealBreakers', () => {
+  it('returns empty when either accepted or rejected is empty', () => {
+    expect(computeDealBreakers([], [{ remote: 'No' }])).toEqual([]);
+    expect(computeDealBreakers([{ remote: 'Full' }], [])).toEqual([]);
+  });
+
+  it('surfaces a feature value that diverges between accept and reject', () => {
+    const accepted = [
+      { remote: 'Full' },
+      { remote: 'Full' },
+      { remote: 'Full' },
+    ];
+    const rejected = [{ remote: 'No' }, { remote: 'No' }, { remote: 'No' }];
+    const out = computeDealBreakers(accepted, rejected);
+    const noRemote = out.find(
+      (d) => d.feature === 'remote' && d.value === 'No'
+    );
+    expect(noRemote).toBeDefined();
+    expect(noRemote.rejectRate).toBe(1);
+    expect(noRemote.acceptRate).toBe(0);
+    expect(noRemote.divergence).toBe(1);
+  });
+
+  it('derives "country" from location.countryCode', () => {
+    const accepted = [{ location: { countryCode: 'US' } }];
+    const rejected = [
+      { location: { countryCode: 'IN' } },
+      { location: { countryCode: 'IN' } },
+    ];
+    const out = computeDealBreakers(accepted, rejected);
+    const inCountry = out.find(
+      (d) => d.feature === 'country' && d.value === 'IN'
+    );
+    expect(inCountry).toBeDefined();
+    expect(inCountry.divergence).toBeGreaterThan(0);
+  });
+
+  it('ignores divergences at or below the 0.05 threshold', () => {
+    // identical distributions => zero divergence => filtered out
+    const accepted = [{ type: 'Full-time' }, { type: 'Contract' }];
+    const rejected = [{ type: 'Full-time' }, { type: 'Contract' }];
+    expect(computeDealBreakers(accepted, rejected)).toEqual([]);
+  });
+});
+
+describe('computeSkillGaps', () => {
+  it('lists the most demanded market skills', () => {
+    const market = [
+      { skills: [{ name: 'React' }] },
+      { skills: [{ name: 'React' }] },
+      { skills: [{ name: 'Go' }] },
+    ];
+    const out = computeSkillGaps(market, [], []);
+    expect(out.topDemanded[0]).toEqual({ skill: 'react', count: 2 });
+  });
+
+  it('reports interested-job skills the user lacks as gaps', () => {
+    const interested = [
+      { skills: [{ name: 'Rust' }] },
+      { skills: [{ name: 'Rust' }] },
+    ];
+    const out = computeSkillGaps([], interested, ['react']);
+    const rustGap = out.gaps.find((g) => g.skill === 'rust');
+    expect(rustGap).toBeDefined();
+    expect(rustGap.count).toBe(2);
+  });
+
+  it('excludes skills the user already has from gaps', () => {
+    const interested = [{ skills: [{ name: 'React' }] }];
+    const out = computeSkillGaps([], interested, ['react']);
+    expect(out.gaps.find((g) => g.skill === 'react')).toBeUndefined();
+  });
+
+  it('echoes back the userSkills passed in', () => {
+    const out = computeSkillGaps([], [], ['react', 'node.js']);
+    expect(out.userSkills).toEqual(['react', 'node.js']);
+  });
+});
+
+describe('computeMomentum', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('labels acceleration when this week outpaces last week', () => {
+    vi.useFakeTimers();
+    const now = new Date('2026-06-15T12:00:00Z');
+    vi.setSystemTime(now);
+    const feedback = [
+      fb('interested', '2026-06-14T00:00:00Z'),
+      fb('interested', '2026-06-13T00:00:00Z'),
+      fb('maybe', '2026-06-12T00:00:00Z'),
+      // last week: one item ~10 days ago
+      fb('applied', '2026-06-05T00:00:00Z'),
+    ];
+    const out = computeMomentum(feedback);
+    expect(out.reviewsThisWeek).toBe(3);
+    expect(out.reviewsLastWeek).toBe(1);
+    expect(out.label).toBe('accelerating');
+    expect(out.score).toBeGreaterThan(20);
+  });
+
+  it('excludes dossier sentiment from momentum', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+    const feedback = [
+      fb('dossier', '2026-06-14T00:00:00Z'),
+      fb('dossier', '2026-06-13T00:00:00Z'),
+    ];
+    const out = computeMomentum(feedback);
+    expect(out.reviewsThisWeek).toBe(0);
+  });
+
+  it('clamps the score into [-100, 100]', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+    const feedback = Array.from({ length: 50 }, () =>
+      fb('interested', '2026-06-14T00:00:00Z')
+    );
+    const out = computeMomentum(feedback);
+    expect(out.score).toBeLessThanOrEqual(100);
+    expect(out.score).toBeGreaterThanOrEqual(-100);
+  });
+});
+
+describe('computeTopCompanies', () => {
+  it('ranks companies by review count, capped at 10', () => {
+    const feedback = [
+      fb('interested', '2026-01-01', { job_company: 'Acme' }),
+      fb('maybe', '2026-01-02', { job_company: 'Acme' }),
+      fb('applied', '2026-01-03', { job_company: 'Globex' }),
+    ];
+    const out = computeTopCompanies(feedback);
+    expect(out[0].company).toBe('Acme');
+    expect(out[0].count).toBe(2);
+  });
+
+  it('reports the dominant sentiment per company', () => {
+    const feedback = [
+      fb('interested', '2026-01-01', { job_company: 'Acme' }),
+      fb('interested', '2026-01-02', { job_company: 'Acme' }),
+      fb('maybe', '2026-01-03', { job_company: 'Acme' }),
+    ];
+    const out = computeTopCompanies(feedback);
+    expect(out[0].sentiment).toBe('interested');
+  });
+
+  it('runs company names through truncCompany', () => {
+    const feedback = [
+      fb('interested', '2026-01-01', { job_company: 'Acme, Inc' }),
+    ];
+    const out = computeTopCompanies(feedback);
+    expect(out[0].company).toBe('Acme');
+  });
+});
+
+describe('computeRecentActivity', () => {
+  it('excludes dossier rows and sorts newest first', () => {
+    const feedback = [
+      fb('interested', '2026-01-01T00:00:00Z', {
+        job_company: 'Acme',
+        job_title: 'Eng',
+      }),
+      fb('maybe', '2026-01-05T00:00:00Z', {
+        job_company: 'Globex',
+        job_title: 'Dev',
+      }),
+      fb('dossier', '2026-01-09T00:00:00Z', { job_company: 'Hidden' }),
+    ];
+    const out = computeRecentActivity(feedback);
+    expect(out).toHaveLength(2);
+    expect(out[0].company).toBe('Globex'); // newest non-dossier
+    expect(out.find((a) => a.company === 'Hidden')).toBeUndefined();
+  });
+
+  it('defaults a missing title to "Unknown"', () => {
+    const out = computeRecentActivity([
+      fb('interested', '2026-01-01T00:00:00Z', { job_company: 'Acme' }),
+    ]);
+    expect(out[0].title).toBe('Unknown');
+  });
+
+  it('caps output at 20 items', () => {
+    const feedback = Array.from({ length: 30 }, (_, i) =>
+      fb(
+        'interested',
+        `2026-01-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`,
+        {
+          job_company: `Co${i}`,
+        }
+      )
+    );
+    expect(computeRecentActivity(feedback)).toHaveLength(20);
+  });
+});
+
+describe('findSecondLookJobs', () => {
+  it('returns empty when interested or rejected is empty', () => {
+    expect(findSecondLookJobs([], [{ skills: [] }], [])).toEqual([]);
+    expect(findSecondLookJobs([{ skills: [] }], [], [])).toEqual([]);
+  });
+
+  it('surfaces rejected jobs that share skills with interested jobs', () => {
+    const interested = [{ skills: [{ name: 'React' }, { name: 'Go' }] }];
+    const rejected = [
+      { id: 1, title: 'A', skills: [{ name: 'React' }] }, // overlap 1
+      { id: 2, title: 'B', skills: [{ name: 'COBOL' }] }, // overlap 0
+    ];
+    const out = findSecondLookJobs(rejected, interested, []);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe(1);
+  });
+
+  it('strips the internal _overlap field from results', () => {
+    const interested = [{ skills: [{ name: 'React' }] }];
+    const rejected = [{ id: 1, skills: [{ name: 'React' }] }];
+    const out = findSecondLookJobs(rejected, interested, []);
+    expect(out[0]._overlap).toBeUndefined();
+  });
+
+  it('sorts by descending overlap and caps at 5', () => {
+    const interested = [
+      { skills: [{ name: 'React' }, { name: 'Go' }, { name: 'AWS' }] },
+    ];
+    const rejected = Array.from({ length: 8 }, (_, i) => ({
+      id: i,
+      skills: [{ name: 'React' }],
+    }));
+    // give one job a higher overlap
+    rejected[3].skills = [{ name: 'React' }, { name: 'Go' }, { name: 'AWS' }];
+    const out = findSecondLookJobs(rejected, interested, []);
+    expect(out).toHaveLength(5);
+    expect(out[0].id).toBe(3);
+  });
+});

--- a/apps/registry/app/api/v1/report/[username]/helpers.test.js
+++ b/apps/registry/app/api/v1/report/[username]/helpers.test.js
@@ -1,0 +1,264 @@
+/**
+ * Characterization tests for the pure helpers used by the report endpoint:
+ * truncCompany, parseJobContent, extractUserSkills, normalizeSkill,
+ * flattenJobSkills, skillMatches, and the EMPTY_REPORT shape. getSupabase()
+ * is a thin client factory and is not unit-tested.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  truncCompany,
+  parseJobContent,
+  extractUserSkills,
+  normalizeSkill,
+  flattenJobSkills,
+  skillMatches,
+  EMPTY_REPORT,
+} from './helpers';
+
+describe('truncCompany', () => {
+  it('returns "Unknown" for empty / nullish names', () => {
+    expect(truncCompany('')).toBe('Unknown');
+    expect(truncCompany(null)).toBe('Unknown');
+    expect(truncCompany(undefined)).toBe('Unknown');
+  });
+
+  it('keeps a short clean company name intact', () => {
+    expect(truncCompany('Acme')).toBe('Acme');
+  });
+
+  it('cuts a tagline off at the first period', () => {
+    expect(truncCompany('Acme. The best widgets in town')).toBe('Acme');
+  });
+
+  it('cuts at the first comma', () => {
+    expect(truncCompany('Acme, Inc')).toBe('Acme');
+  });
+
+  it('cuts at descriptive connectors like " is " / " builds "', () => {
+    expect(truncCompany('Stripe is a payments company')).toBe('Stripe');
+    expect(truncCompany('Vercel builds the frontend cloud')).toBe('Vercel');
+    expect(truncCompany('Plaid provides banking APIs')).toBe('Plaid');
+    expect(truncCompany('Notion turns notes into apps')).toBe('Notion');
+  });
+
+  it('truncates very long single-token names to 57 chars + ellipsis', () => {
+    const long = 'A'.repeat(80);
+    const out = truncCompany(long);
+    expect(out).toHaveLength(60);
+    expect(out.endsWith('...')).toBe(true);
+    expect(out.slice(0, 57)).toBe('A'.repeat(57));
+  });
+
+  it('keeps a name exactly 60 chars without truncating', () => {
+    const name = 'B'.repeat(60);
+    expect(truncCompany(name)).toBe(name);
+  });
+});
+
+describe('normalizeSkill', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeSkill('  React  ')).toBe('react');
+  });
+
+  it.each([
+    ['node', 'node.js'],
+    ['nodejs', 'node.js'],
+    ['React.js', 'react'],
+    ['reactjs', 'react'],
+    ['Vue.js', 'vue'],
+    ['postgres', 'postgresql'],
+    ['k8s', 'kubernetes'],
+    ['TF', 'terraform'],
+    ['JS', 'javascript'],
+    ['es6', 'javascript'],
+    ['ts', 'typescript'],
+    ['py', 'python'],
+    ['python3', 'python'],
+    ['Go', 'golang'],
+    ['cpp', 'c++'],
+    ['csharp', 'c#'],
+    ['gcp', 'google cloud'],
+    ['Amazon Web Services', 'aws'],
+    ['ci', 'ci/cd'],
+    ['ml', 'machine learning'],
+    ['REST API', 'rest'],
+  ])('maps alias "%s" -> "%s"', (input, expected) => {
+    expect(normalizeSkill(input)).toBe(expected);
+  });
+
+  it('passes through an unknown skill unchanged (lowercased)', () => {
+    expect(normalizeSkill('Rust')).toBe('rust');
+    expect(normalizeSkill('GraphQL')).toBe('graphql');
+  });
+});
+
+describe('extractUserSkills', () => {
+  it('returns empty array for a resume with no skills', () => {
+    expect(extractUserSkills({})).toEqual([]);
+    expect(extractUserSkills({ skills: [] })).toEqual([]);
+  });
+
+  it('collects skill names and keywords, normalized and deduped', () => {
+    const resume = {
+      skills: [
+        { name: 'Node', keywords: ['nodejs', 'Express'] },
+        { name: 'React.js', keywords: ['reactjs'] },
+      ],
+    };
+    const out = extractUserSkills(resume);
+    // node, nodejs both -> node.js; react.js, reactjs both -> react
+    expect(out).toContain('node.js');
+    expect(out).toContain('react');
+    expect(out).toContain('express');
+    // deduped
+    expect(out.filter((s) => s === 'node.js')).toHaveLength(1);
+    expect(out.filter((s) => s === 'react')).toHaveLength(1);
+  });
+
+  it('handles skills that have a name but no keywords', () => {
+    const out = extractUserSkills({ skills: [{ name: 'Python' }] });
+    expect(out).toEqual(['python']);
+  });
+});
+
+describe('flattenJobSkills', () => {
+  it('returns empty array when there are no skills', () => {
+    expect(flattenJobSkills({})).toEqual([]);
+    expect(flattenJobSkills({ skills: [] })).toEqual([]);
+  });
+
+  it('flattens object skills with name + keywords (normalized & deduped)', () => {
+    const job = {
+      skills: [
+        { name: 'Backend', keywords: ['Node', 'Go'] },
+        { name: 'Frontend', keywords: ['React.js'] },
+      ],
+    };
+    const out = flattenJobSkills(job);
+    expect(out).toContain('backend');
+    expect(out).toContain('node.js');
+    expect(out).toContain('golang');
+    expect(out).toContain('react');
+  });
+
+  it('supports plain-string skills', () => {
+    const out = flattenJobSkills({ skills: ['Python', 'k8s'] });
+    expect(out).toContain('python');
+    expect(out).toContain('kubernetes');
+  });
+
+  it('deduplicates skills that normalize to the same canonical form', () => {
+    const job = { skills: [{ name: 'Node' }, { name: 'nodejs' }] };
+    expect(flattenJobSkills(job)).toEqual(['node.js']);
+  });
+});
+
+describe('skillMatches', () => {
+  it('matches on exact membership', () => {
+    const userSet = new Set(['react', 'node.js']);
+    expect(skillMatches('react', userSet)).toBe(true);
+  });
+
+  it('matches when user skill contains the job skill (substring)', () => {
+    const userSet = new Set(['rest apis']);
+    expect(skillMatches('rest', userSet)).toBe(true);
+  });
+
+  it('matches when job skill contains a user skill (substring)', () => {
+    const userSet = new Set(['ci/cd']);
+    expect(skillMatches('ci/cd pipelines', userSet)).toBe(true);
+  });
+
+  it('returns false when there is no overlap', () => {
+    const userSet = new Set(['react', 'node.js']);
+    expect(skillMatches('rust', userSet)).toBe(false);
+  });
+
+  it('returns false against an empty user set', () => {
+    expect(skillMatches('react', new Set())).toBe(false);
+  });
+});
+
+describe('parseJobContent', () => {
+  const makeJob = (content, extra = {}) => ({
+    id: 1,
+    gpt_content: JSON.stringify(content),
+    salary_usd: 120000,
+    posted_at: '2026-01-01',
+    ...extra,
+  });
+
+  it('returns null when gpt_content is invalid JSON', () => {
+    expect(parseJobContent({ id: 1, gpt_content: 'not json' })).toBeNull();
+  });
+
+  it('returns null when the parsed content has no title', () => {
+    expect(parseJobContent(makeJob({ company: 'Acme' }))).toBeNull();
+  });
+
+  it('maps a well-formed job into the normalized shape', () => {
+    const job = makeJob({
+      title: 'Senior Engineer',
+      company: 'Acme, Inc',
+      remote: 'Full',
+      experience: 'Senior',
+      type: 'Full-time',
+      salary: '$120k',
+      skills: [{ name: 'React' }],
+      location: { countryCode: 'US' },
+      description: 'Build things',
+    });
+    const out = parseJobContent(job);
+    expect(out.id).toBe(1);
+    expect(out.title).toBe('Senior Engineer');
+    // company is run through truncCompany
+    expect(out.company).toBe('Acme');
+    expect(out.remote).toBe('Full');
+    expect(out.salary_usd).toBe(120000);
+    expect(out.posted_at).toBe('2026-01-01');
+    expect(out.skills).toEqual([{ name: 'React' }]);
+  });
+
+  it('defaults optional structured fields to null / empty array', () => {
+    const out = parseJobContent(makeJob({ title: 'Eng', company: 'Acme' }));
+    expect(out.salary_structured).toBeNull();
+    expect(out.visa_sponsorship).toBeNull();
+    expect(out.equity).toBeNull();
+    expect(out.skills).toEqual([]);
+  });
+});
+
+describe('EMPTY_REPORT', () => {
+  it('exposes the full report shape with zeroed pipeline counts', () => {
+    expect(EMPTY_REPORT.pipeline.totalJobs).toBe(0);
+    expect(EMPTY_REPORT.momentum.label).toBe('no-data');
+    expect(EMPTY_REPORT.salary).toEqual({
+      market: null,
+      interested: null,
+      distribution: [],
+    });
+  });
+
+  it('declares every top-level analytics section', () => {
+    const keys = Object.keys(EMPTY_REPORT);
+    for (const k of [
+      'pipeline',
+      'salary',
+      'remoteIndex',
+      'dealBreakers',
+      'skills',
+      'momentum',
+      'topCompanies',
+      'secondLook',
+      'recentActivity',
+      'antiResume',
+      'skillAdjacency',
+      'archetypes',
+      'marketDrift',
+      'readiness',
+      'bestMatchSimilar',
+    ]) {
+      expect(keys).toContain(k);
+    }
+  });
+});

--- a/apps/registry/scripts/jobs/salary-normalizer/salaryHelpers.test.js
+++ b/apps/registry/scripts/jobs/salary-normalizer/salaryHelpers.test.js
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for the individual salary-normalizer helpers that the existing
+ * salaryNormalizer.test.js only exercises indirectly through normalizeSalary:
+ * detectCurrency, detectPeriod, extractNumbers, annualize, roundToThousand.
+ * These are characterization tests of current behavior.
+ */
+import { describe, it, expect } from 'vitest';
+
+const {
+  detectCurrency,
+  detectPeriod,
+  extractNumbers,
+  annualize,
+  roundToThousand,
+} = require('./index');
+
+describe('detectCurrency', () => {
+  it('reads explicit ISO codes (case-insensitive)', () => {
+    expect(detectCurrency('100000 EUR')).toBe('EUR');
+    expect(detectCurrency('gbp 80,000')).toBe('GBP');
+    expect(detectCurrency('100k USD')).toBe('USD');
+  });
+
+  it('disambiguates prefixed dollar symbols longest-first', () => {
+    expect(detectCurrency('US$150,000')).toBe('USD');
+    expect(detectCurrency('CA$130k')).toBe('CAD');
+    expect(detectCurrency('C$130k')).toBe('CAD');
+    expect(detectCurrency('AU$150k')).toBe('AUD');
+    expect(detectCurrency('A$150,000')).toBe('AUD');
+    expect(detectCurrency('NZ$120,000')).toBe('NZD');
+    expect(detectCurrency('HK$1,200,000')).toBe('HKD');
+    expect(detectCurrency('S$150,000')).toBe('SGD');
+  });
+
+  it('reads single-character currency symbols', () => {
+    expect(detectCurrency('€100,000')).toBe('EUR');
+    expect(detectCurrency('£80,000')).toBe('GBP');
+    expect(detectCurrency('₹2,500,000')).toBe('INR');
+    expect(detectCurrency('₩150,000,000')).toBe('KRW');
+    expect(detectCurrency('₽5,000,000')).toBe('RUB');
+    expect(detectCurrency('₱2,500,000')).toBe('PHP');
+    expect(detectCurrency('฿3,000,000')).toBe('THB');
+    expect(detectCurrency('₪500,000')).toBe('ILS');
+  });
+
+  it('treats ¥ as JPY by default but CNY when hinted', () => {
+    expect(detectCurrency('¥15,000,000')).toBe('JPY');
+    expect(detectCurrency('¥800,000 CNY')).toBe('CNY');
+    expect(detectCurrency('¥800,000 rmb')).toBe('CNY');
+  });
+
+  it('recognizes South African Rand via R prefix', () => {
+    expect(detectCurrency('R2,000,000')).toBe('ZAR');
+  });
+
+  it('recognizes Indian LPA notation as INR', () => {
+    expect(detectCurrency('25 LPA')).toBe('INR');
+  });
+
+  it('defaults to USD when only a $ or no symbol is present', () => {
+    expect(detectCurrency('$100,000')).toBe('USD');
+    expect(detectCurrency('100000')).toBe('USD');
+  });
+});
+
+describe('detectPeriod', () => {
+  it('detects hourly variants', () => {
+    expect(detectPeriod('$50/hr')).toBe('hour');
+    expect(detectPeriod('$50 per hour')).toBe('hour');
+    expect(detectPeriod('$50 hourly')).toBe('hour');
+  });
+
+  it('detects daily / weekly / monthly variants', () => {
+    expect(detectPeriod('$400/day')).toBe('day');
+    expect(detectPeriod('$2000 per week')).toBe('week');
+    expect(detectPeriod('$8000/mo')).toBe('month');
+    expect(detectPeriod('$8000 monthly')).toBe('month');
+  });
+
+  it('detects yearly variants', () => {
+    expect(detectPeriod('$100k/yr')).toBe('year');
+    expect(detectPeriod('$100k per year')).toBe('year');
+    expect(detectPeriod('$100k annual')).toBe('year');
+    expect(detectPeriod('$100k p.a.')).toBe('year');
+  });
+
+  it('defaults to year when no period word is present', () => {
+    expect(detectPeriod('$100,000')).toBe('year');
+  });
+});
+
+describe('extractNumbers', () => {
+  it('returns a single number twice for a lone value', () => {
+    expect(extractNumbers('100000')).toEqual({ min: 100000, max: 100000 });
+  });
+
+  it('expands K notation', () => {
+    expect(extractNumbers('100k')).toEqual({ min: 100000, max: 100000 });
+  });
+
+  it('parses shorthand K ranges where K applies to both ends', () => {
+    expect(extractNumbers('80-120k')).toEqual({ min: 80000, max: 120000 });
+    expect(extractNumbers('$100-150k')).toEqual({ min: 100000, max: 150000 });
+  });
+
+  it('parses full numeric ranges with separators', () => {
+    expect(extractNumbers('100,000 - 150,000')).toEqual({
+      min: 100000,
+      max: 150000,
+    });
+  });
+
+  it('orders an out-of-order pair from the multi-number fallback path', () => {
+    // No dash and no recognised separator words: both numbers fall through to
+    // the generic number scan, which slices the first two and sorts them.
+    expect(extractNumbers('150000 / 100000')).toEqual({
+      min: 100000,
+      max: 150000,
+    });
+  });
+
+  // BUG (documented, not fixed in this PR): when a word separator such as
+  // "and"/"between"/"to" sits between two plain numbers, the cleaner replaces
+  // the word with a space, the greedy range regex captures BOTH numbers in its
+  // first group, and parseNumber strips the whitespace — concatenating them
+  // into one garbage value instead of producing a {min,max} range.
+  it('CURRENT BEHAVIOR: word-separated plain numbers are concatenated', () => {
+    expect(extractNumbers('150000 and 100000')).toEqual({
+      min: 150000100000,
+      max: 150000100000,
+    });
+  });
+
+  it.skip('EXPECTED: word-separated plain numbers should parse as a range', () => {
+    expect(extractNumbers('150000 and 100000')).toEqual({
+      min: 100000,
+      max: 150000,
+    });
+  });
+
+  // BUG (documented, not fixed in this PR): the dash/"to" range path returns
+  // numbers in their literal order and never sorts, so a descending range like
+  // "150,000 - 100,000" yields min > max.
+  it('CURRENT BEHAVIOR: descending dash range is not reordered (min > max)', () => {
+    expect(extractNumbers('150,000 - 100,000')).toEqual({
+      min: 150000,
+      max: 100000,
+    });
+  });
+
+  it.skip('EXPECTED: descending dash range should be reordered to min <= max', () => {
+    expect(extractNumbers('150,000 - 100,000')).toEqual({
+      min: 100000,
+      max: 150000,
+    });
+  });
+
+  it('handles Indian lakh notations', () => {
+    expect(extractNumbers('25 LPA')).toEqual({ min: 2500000, max: 2500000 });
+    expect(extractNumbers('19L-30L')).toEqual({ min: 1900000, max: 3000000 });
+    expect(extractNumbers('35-80L')).toEqual({ min: 3500000, max: 8000000 });
+  });
+
+  it('returns nulls when there is nothing numeric to extract', () => {
+    expect(extractNumbers('competitive')).toEqual({ min: null, max: null });
+  });
+
+  it('strips equity / stock additions and keeps the base', () => {
+    expect(extractNumbers('$150k base + equity')).toEqual({
+      min: 150000,
+      max: 150000,
+    });
+  });
+});
+
+describe('annualize', () => {
+  it('annualizes hourly at 40h * 52w', () => {
+    expect(annualize(50, 'hour')).toBe(50 * 40 * 52);
+  });
+
+  it('annualizes daily at 5d * 52w', () => {
+    expect(annualize(400, 'day')).toBe(400 * 5 * 52);
+  });
+
+  it('annualizes weekly at 52w', () => {
+    expect(annualize(2000, 'week')).toBe(2000 * 52);
+  });
+
+  it('annualizes monthly at 12mo', () => {
+    expect(annualize(8000, 'month')).toBe(96000);
+  });
+
+  it('leaves yearly and unknown periods unchanged', () => {
+    expect(annualize(100000, 'year')).toBe(100000);
+    expect(annualize(100000, 'decade')).toBe(100000);
+  });
+});
+
+describe('roundToThousand', () => {
+  it('rounds to the nearest thousand', () => {
+    expect(roundToThousand(123456)).toBe(123000);
+    expect(roundToThousand(123500)).toBe(124000);
+    expect(roundToThousand(999)).toBe(1000);
+    expect(roundToThousand(400)).toBe(0);
+  });
+
+  it('returns null for null / NaN', () => {
+    expect(roundToThousand(null)).toBeNull();
+    expect(roundToThousand(NaN)).toBeNull();
+  });
+
+  it('handles exact thousands', () => {
+    expect(roundToThousand(100000)).toBe(100000);
+  });
+});


### PR DESCRIPTION
## Summary

Fills test-coverage gaps in the registry API's pure logic. The jobs-matching and report-analytics endpoints carried real, deterministic logic with no colocated unit tests; the salary normalizer had end-to-end coverage but its individual exported helpers were only exercised indirectly. This PR adds characterization tests for that pure logic.

All async/DB/network functions (`getSupabase`, `generateHydeEmbedding`, `rerankJobs`, `matchJobs`, `getResumeEmbedding`) are intentionally left out of scope — only pure functions are covered.

Refs #275.

## Coverage: before → after (test counts per file)

| File under test | Test file | Before | After |
|---|---|---|---|
| `app/api/v1/jobs/matchingHelpers.js` | `matchingHelpers.test.js` (new) | 0 | 26 |
| `app/api/v1/report/[username]/helpers.js` | `helpers.test.js` (new) | 0 | 48 |
| `app/api/v1/report/[username]/analytics.js` | `analytics.test.js` (new) | 0 | 35 |
| `app/api/v1/report/[username]/analytics-v2.js` | `analytics-v2.test.js` (new) | 0 | 24 |
| `scripts/jobs/salary-normalizer/index.js` (helpers) | `salaryHelpers.test.js` (new) | 0* | 31 (29 pass + 2 skipped) |

\* The existing `salaryNormalizer.test.js` (180 tests) covers `normalizeSalary` end-to-end but does not directly test the exported helpers `detectCurrency`, `detectPeriod`, `extractNumbers`, `annualize`, `roundToThousand`. The new `salaryHelpers.test.js` targets those directly.

**Net: +164 test cases (162 passing + 2 skipped) across 5 new files.**

Full registry suite: `1359 → 1521` passing, `24 → 26` skipped, all green.
`pnpm --filter registry test -- --run` ✅

## What is covered

- **matchingHelpers**: `normalize`, `interpolate`, `subtractDirection`, `timeDecayScore` (fake-timer half-life math), `averageEmbeddings` — unit-length invariants, zero-vector safety, no-mutation, recency decay.
- **report/helpers**: `truncCompany`, `parseJobContent`, `extractUserSkills`, `normalizeSkill` (alias table), `flattenJobSkills`, `skillMatches` (fuzzy substring), `EMPTY_REPORT` shape.
- **report/analytics**: `computePipeline`, `computeTimeline`, `computeSalary` (k-notation + percentiles + histogram), `computeRemoteIndex`, `computeDealBreakers`, `computeSkillGaps`, `computeMomentum`, `computeTopCompanies`, `computeRecentActivity`, `findSecondLookJobs`.
- **report/analytics-v2**: `computeAntiResume`, `computeSkillAdjacency`, `computeArchetypes`, `computeMarketDrift`, `computeReadinessScores`, `computeBestMatchSimilar`.
- **salary-normalizer helpers**: `detectCurrency` (prefix disambiguation, ¥ JPY/CNY, LPA, ZAR), `detectPeriod`, `extractNumbers` (K ranges, lakhs, equity stripping), `annualize`, `roundToThousand`.

## Bugs found (documented, NOT fixed in this PR)

These are characterized with a passing `CURRENT BEHAVIOR` test plus a `.skip`'d `EXPECTED` test in `salaryHelpers.test.js`:

1. **Word-separated plain numbers are concatenated.** `extractNumbers('150000 and 100000')` returns `{min: 150000100000, max: 150000100000}` instead of a `{min:100000, max:150000}` range. The cleaner replaces the word `"and"` (also `"between"`, `"to"`) with a space, then the greedy range regex's first capture group `(\d[\d,.\s']*)` swallows both numbers and `parseNumber` strips the whitespace, joining them. Dash/`-` and shorthand-`K` ranges are unaffected.
2. **Descending dash ranges are not reordered.** `extractNumbers('150,000 - 100,000')` returns `{min:150000, max:100000}` (min > max). The dash/`to` range path preserves literal order and never sorts; only the multi-number fallback path sorts its pair.

Neither changes output of the public `normalizeSalary` average in common ascending cases, so they were left untouched per the characterization-only scope.

— AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites covering analytics calculations, job matching logic, salary processing, and report generation. New tests verify expected behavior and accuracy across various data scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->