### PR TITLE
feat(cli): friendlier theme-not-found errors + clearer validate output

### DIFF
--- a/.changeset/cli-friendly-theme-errors.md
+++ b/.changeset/cli-friendly-theme-errors.md
@@ -1,0 +1,9 @@
+---
+'resume-cli': minor
+---
+
+Friendlier theme-not-found errors and clearer `validate` output.
+
+- `export` and `serve` now print an actionable message when a `--theme` is not installed (e.g. `Theme 'X' not found. Install it: npm install jsonresume-theme-X`) and a link to the themes gallery, instead of a raw stack trace. `export` exits with a non-zero code on failure.
+- `validate` now prints a concise `✓ <file> is valid` line on success while keeping the per-field error list on failure.
+- `--help` documents the `--theme` option and points to https://jsonresume.org/themes/.

--- a/packages/cli/lib/builder.js
+++ b/packages/cli/lib/builder.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const request = require('superagent');
 const chalk = require('chalk');
 const renderHtml = require('./render-html').default;
+const { ThemeNotFoundError, formatThemeNotFound } = require('./theme-errors');
 
 const denormalizeTheme = (value) => {
   return value.match(/jsonresume-theme-(.*)/)[1];
@@ -57,7 +58,13 @@ module.exports = function resumeBuilder(theme, dir, resumeFilename, cb) {
       const html = await renderHtml({ resume: resumeJson, themePath: theme });
       cb(null, html);
     } catch (err) {
-      console.log(err);
+      if (err instanceof ThemeNotFoundError) {
+        // Theme isn't installed locally. Show an actionable message, then fall
+        // back to the hosted theme server (preserving existing behavior).
+        console.log(formatThemeNotFound(err.theme));
+      } else {
+        console.log(err);
+      }
       console.log(
         chalk.yellow('Could not run the render function from local theme.'),
       );

--- a/packages/cli/lib/export-resume.js
+++ b/packages/cli/lib/export-resume.js
@@ -6,6 +6,7 @@ const writeFile = promisify(fs.writeFile);
 const path = require('path');
 const puppeteer = require('puppeteer');
 const btoa = require('btoa');
+const { ThemeNotFoundError } = require('./theme-errors');
 
 module.exports = (
   { resume: resumeJson, fileName, theme, format },
@@ -22,14 +23,16 @@ module.exports = (
   const formatToUse = '.' + fileFormatToUse;
   if (formatToUse === '.html') {
     createHtml(resumeJson, fileName, theme, formatToUse, (error) => {
-      if (error) {
+      // ThemeNotFoundError is reported as a friendly message by the caller;
+      // don't dump the raw object here.
+      if (error && !(error instanceof ThemeNotFoundError)) {
         console.error(error, '`createHtml` errored out');
       }
       callback(error, fileName, formatToUse);
     });
   } else if (formatToUse === '.pdf') {
     createPdf(resumeJson, fileName, theme, formatToUse, (error) => {
-      if (error) {
+      if (error && !(error instanceof ThemeNotFoundError)) {
         console.error(error, '`createPdf` errored out');
       }
       callback(error, fileName, formatToUse);
@@ -57,18 +60,22 @@ const getThemePkg = (theme) => {
     const themePkg = require(theme);
     return themePkg;
   } catch (err) {
-    // Theme not installed
-    console.log(
-      'You have to install this theme relative to the folder to use it e.g. `npm install ' +
-        theme +
-        '`',
-    );
-    process.exit();
+    // Theme not installed. Throw a typed error so the caller can render an
+    // actionable, stack-trace-free message and exit with a non-zero code.
+    throw new ThemeNotFoundError(theme);
   }
 };
 
 async function createHtml(resumeJson, fileName, themePath, format, callback) {
-  const html = await renderHTML({ resume: resumeJson, themePath });
+  let html;
+  try {
+    html = await renderHTML({ resume: resumeJson, themePath });
+  } catch (err) {
+    // Surface theme-resolution (and other render) failures to the caller so
+    // they can be reported as an actionable message rather than an
+    // unhandled-rejection stack trace.
+    return callback(err);
+  }
   const pathToStream = path.resolve(process.cwd(), fileName + format);
   await writeFile(pathToStream, ''); // workaround for https://github.com/streamich/unionfs/issues/428
   const stream = fs.createWriteStream(pathToStream);

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -13,6 +13,7 @@ const serve = require('./serve');
 const program = require('commander');
 const chalk = require('chalk');
 const path = require('path');
+const { ThemeNotFoundError, formatThemeNotFound } = require('./theme-errors');
 
 const normalizeTheme = (value, defaultValue) => {
   const theme = value || defaultValue;
@@ -36,7 +37,7 @@ const normalizeTheme = (value, defaultValue) => {
     )
     .option(
       '-t, --theme <theme name>',
-      'Specify theme used by `export` and `serve` or specify a path starting with . (use . for current directory or ../some/other/dir)',
+      'Theme used by `export` and `serve` (browse themes at https://jsonresume.org/themes/), or a path starting with . (use . for current directory or ../some/other/dir)',
       normalizeTheme,
       'jsonresume-theme-elegant',
     )
@@ -80,6 +81,7 @@ const normalizeTheme = (value, defaultValue) => {
           resume,
           schema,
         });
+        console.log(chalk.green(`✓ ${program.resume} is valid`));
       } catch (e) {
         console.error(e.message);
         process.exitCode = 1;
@@ -89,13 +91,22 @@ const normalizeTheme = (value, defaultValue) => {
   program
     .command('export [fileName]')
     .description(
-      'Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format.',
+      'Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format. Pick a theme with --theme (https://jsonresume.org/themes/).',
     )
     .action(async (fileName) => {
       const resume = await getResume({ path: program.resume });
       exportResume(
         { ...program, resume, fileName },
         (err, fileName, format) => {
+          if (err) {
+            if (err instanceof ThemeNotFoundError) {
+              console.error(formatThemeNotFound(err.theme));
+            } else {
+              console.error(err.message || err);
+            }
+            process.exitCode = 1;
+            return;
+          }
           console.log(
             chalk.green(
               '\nDone! Find your new',

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -5,14 +5,19 @@ import packageJson from '../package.json';
 
 const exec = promisify(execCB);
 
-const run = async (argv, { waitForVolumeExport = true, stdin = '' } = {}) => {
+const run = async (
+  argv,
+  { waitForVolumeExport = true, stdin = '', captureStderr = false } = {},
+) => {
   let volume;
   let exitCode;
   const child = spawn(
     process.execPath,
     ['build/test-utils/cli-test-entry.js', ...argv],
     {
-      stdio: ['pipe', 'pipe', 2, 'ipc'],
+      // When captureStderr is set, pipe fd 2 so the test can read the
+      // friendly error output; otherwise inherit it (existing behavior).
+      stdio: ['pipe', 'pipe', captureStderr ? 'pipe' : 2, 'ipc'],
     },
   );
   const allChecks = Promise.all([
@@ -35,12 +40,18 @@ const run = async (argv, { waitForVolumeExport = true, stdin = '' } = {}) => {
   ]);
   child.stdin.write(stdin);
   child.stdin.end();
-  const stdout = await streamToString(child.stdout);
+  const stdoutPromise = streamToString(child.stdout);
+  const stderrPromise = captureStderr
+    ? streamToString(child.stderr)
+    : Promise.resolve('');
+  const stdout = await stdoutPromise;
+  const stderr = await stderrPromise;
   await allChecks;
   return {
     volume,
     code: exitCode,
     stdout,
+    stderr,
   };
 };
 
@@ -55,10 +66,11 @@ describe('cli configuration', () => {
         -V, --version                       output the version number
         -F, --force                         Used by \`publish\` and \`export\` - bypasses
                                             schema testing.
-        -t, --theme <theme name>            Specify theme used by \`export\` and
-                                            \`serve\` or specify a path starting with .
-                                            (use . for current directory or
-                                            ../some/other/dir) (default:
+        -t, --theme <theme name>            Theme used by \`export\` and \`serve\`
+                                            (browse themes at
+                                            https://jsonresume.org/themes/), or a
+                                            path starting with . (use . for current
+                                            directory or ../some/other/dir) (default:
                                             "jsonresume-theme-elegant")
         -f, --format <file type extension>  Used by \`export\`.
         -r, --resume <resume filename>      path to the resume in json format. Use
@@ -79,7 +91,9 @@ describe('cli configuration', () => {
         validate                            Validate your resume's schema
         export [fileName]                   Export locally to .html or .pdf. Supply
                                             a --format <file format> flag and
-                                            argument to specify export format.
+                                            argument to specify export format. Pick a
+                                            theme with --theme
+                                            (https://jsonresume.org/themes/).
         serve                               Serve resume at http://localhost:4000/
         help [command]                      display help for command
       "
@@ -94,7 +108,10 @@ describe('cli configuration', () => {
         '--resume',
         '/test-resumes/only-number.json',
       ]);
-      expect(stdout).toMatchInlineSnapshot(`""`);
+      expect(stdout).toMatchInlineSnapshot(`
+        "✓ /test-resumes/only-number.json is valid
+        "
+      `);
     });
     it('should fail when trying to validate an invalid resume specified by the --resume option', async () => {
       expect(
@@ -107,13 +124,27 @@ describe('cli configuration', () => {
         ).code,
       ).toEqual(1);
     });
+    it('should print the per-field error list (not a success line) when validation fails', async () => {
+      const { code, stdout, stderr } = await run(
+        ['validate', '--resume', '/test-resumes/invalid-resume.json'],
+        { waitForVolumeExport: false, captureStderr: true },
+      );
+      expect(code).toEqual(1);
+      expect(stderr).toContain('Invalid resume:');
+      expect(stderr).toContain('data/basics/name must be string');
+      // The success line must not appear for an invalid resume.
+      expect(stdout).not.toContain('is valid');
+    });
     it('should validate a resume specified by the --resume option', async () => {
       const { stdout } = await run([
         'validate',
         '--resume',
         '/test-resumes/resume.json',
       ]);
-      expect(stdout).toMatchInlineSnapshot(`""`);
+      expect(stdout).toMatchInlineSnapshot(`
+        "✓ /test-resumes/resume.json is valid
+        "
+      `);
     });
   });
   describe('export', () => {
@@ -159,6 +190,25 @@ describe('cli configuration', () => {
          /test-resumes/exported-resume.html
         "
       `);
+    });
+    it('should print a friendly, actionable message and exit non-zero when the theme is not installed', async () => {
+      const { code, stderr } = await run(
+        [
+          'export',
+          '/test-resumes/exported-resume.html',
+          '--resume',
+          '/test-resumes/resume.json',
+          '--theme',
+          'nonexistent-xyz',
+        ],
+        { waitForVolumeExport: false, captureStderr: true },
+      );
+      expect(code).toEqual(1);
+      expect(stderr).toContain("Theme 'nonexistent-xyz' not found.");
+      expect(stderr).toContain('npm install jsonresume-theme-nonexistent-xyz');
+      expect(stderr).toContain('https://jsonresume.org/themes/');
+      // The raw stack trace must not leak to the user.
+      expect(stderr).not.toContain('at _default');
     });
   });
 });

--- a/packages/cli/lib/render-html.js
+++ b/packages/cli/lib/render-html.js
@@ -1,3 +1,5 @@
+import { ThemeNotFoundError } from './theme-errors';
+
 const tryResolve = (...args) => {
   try {
     return require.resolve(...args);
@@ -12,9 +14,7 @@ export default async ({ resume, themePath }) => {
   if (themePath[0] === '.') {
     path = tryResolve(require('path').join(cwd, themePath), { paths: [cwd] });
     if (!path) {
-      throw new Error(
-        `Theme ${themePath} could not be resolved relative to ${cwd}`,
-      );
+      throw new ThemeNotFoundError(themePath);
     }
   }
   if (!path) {
@@ -24,9 +24,7 @@ export default async ({ resume, themePath }) => {
     path = tryResolve(`jsonresume-theme-${themePath}`, { paths: [cwd] });
   }
   if (!path) {
-    throw new Error(
-      `theme path ${themePath} could not be resolved from current working directory`,
-    );
+    throw new ThemeNotFoundError(themePath);
   }
   const theme = require(path);
   if (typeof theme?.render !== 'function') {

--- a/packages/cli/lib/theme-errors.js
+++ b/packages/cli/lib/theme-errors.js
@@ -1,0 +1,40 @@
+const chalk = require('chalk');
+
+// Strip the `jsonresume-theme-` prefix (and any relative-path noise) so the
+// message we show the user matches what they would type with `--theme`.
+const shortThemeName = (theme) => {
+  if (!theme) {
+    return theme;
+  }
+  const base = theme.replace(/^.*jsonresume-theme-/, '');
+  return base.replace(/[/\\].*$/, '');
+};
+
+// Error raised when a `--theme` cannot be resolved. Carries the requested
+// theme name so the CLI can render an actionable, stack-trace-free message.
+class ThemeNotFoundError extends Error {
+  constructor(theme) {
+    super(`Theme not found: ${theme}`);
+    this.name = 'ThemeNotFoundError';
+    this.theme = theme;
+  }
+}
+
+// Build the user-facing, actionable message for a missing theme.
+const formatThemeNotFound = (theme) => {
+  const short = shortThemeName(theme);
+  const pkg = short.startsWith('jsonresume-theme-')
+    ? short
+    : `jsonresume-theme-${short}`;
+  return [
+    chalk.red(`Theme '${short}' not found.`),
+    `Install it:  ${chalk.cyan(`npm install ${pkg}`)}`,
+    `Browse themes:  ${chalk.cyan('https://jsonresume.org/themes/')}`,
+  ].join('\n');
+};
+
+module.exports = {
+  ThemeNotFoundError,
+  formatThemeNotFound,
+  shortThemeName,
+};


### PR DESCRIPTION
## What

Additive UX improvements to `resume-cli` (`packages/cli`) for new users. The happy path was already confirmed working in clean-room testing; this PR adds discoverability and better errors **without** changing any existing commands, flags, or behavior.

### Changes
- **Friendlier theme-not-found errors** — when `export` or `serve` is given a `--theme` that isn't installed, the CLI now catches the resolution failure and prints an actionable message instead of a raw stack trace:
  ```
  Theme 'nonexistent-xyz' not found.
  Install it:  npm install jsonresume-theme-nonexistent-xyz
  Browse themes:  https://jsonresume.org/themes/
  ```
  `export` now exits with a non-zero code on failure (previously it crashed with an unhandled rejection and exit 0). Covers both the HTML and PDF export paths. `serve` shows the friendly message before falling back to the hosted theme server (existing fallback behavior preserved).
- **Clearer `validate` output** — prints a concise `✓ <file> is valid` line on success; the per-field error list (and non-zero exit) on failure is unchanged.
- **Discoverability** — `--help` now documents the `--theme` option and points to the themes gallery (https://jsonresume.org/themes/) on both the option and the `export` command.

### Implementation
- New `lib/theme-errors.js`: a typed `ThemeNotFoundError` (carries the requested theme name) and a `formatThemeNotFound` helper. `render-html.js` and the PDF `getThemePkg` now throw this typed error; callers render the friendly message.
- Bundled default theme verified: default is `jsonresume-theme-elegant` (bundled + installed), and it renders the canonical `@jsonresume/schema/sample.resume.json` without error.

### Tests
- Existing 18 tests still pass (help/validate snapshots updated to reflect the new, intended output).
- Added: missing-theme export → friendly message + non-zero exit + no stack-trace leak; validate failure prints the per-field list and no success line.
- Total: **20 passing**.

### Verification
- `pnpm --filter resume-cli test` — green (20/20)
- `pnpm --filter resume-cli build` — green
- `pnpm turbo run build lint test --filter=resume-cli` — green (3/3)
- Smoke: `validate` valid (exit 0, `✓`), `validate` invalid (exit 1, field list), `export --theme nonexistent-xyz` (friendly error, exit 1, HTML + PDF)
- Changeset added (minor, `resume-cli`)

Refs #275

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export command now exits with non-zero status on failure.
  * Missing theme errors display actionable installation instructions and a link to the themes gallery instead of raw stack traces.

* **New Features**
  * Validate command now displays a success confirmation message with a checkmark.

* **Documentation**
  * Updated CLI help text to document the `--theme` option and link to themes documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->