### PR TITLE
fix(a11y): color-contrast fixes for low-effort wins

### DIFF
--- a/apps/homepage2/app/global.css
+++ b/apps/homepage2/app/global.css
@@ -48,9 +48,9 @@ pre {
 }
 .btn {
   background: #fff;
-  border: 2px solid #ddd !important; 
-  border-radius: 3px !important; 
-  color: #aaa;
+  border: 2px solid #ddd !important;
+  border-radius: 3px !important;
+  color: #737373;
   display: inline-block;
   font-size: 11px !important;
   letter-spacing: 1px !important;
@@ -278,7 +278,7 @@ pre {
   line-height: 1.2;
 }
 #docs .desc {
-  color: #aaa;
+  color: #737373;
   display: block;
   font-size: 12px;
   margin-top: 8px;
@@ -338,7 +338,7 @@ pre {
   background: #fff !important;
 }
 #schema pre span {
-  color: #bbb !important;
+  color: #737373 !important;
 }
 #schema .header {
   background: #f9f9f9 !important;
@@ -480,7 +480,7 @@ pre {
   margin-right: 6px;
 }
 #footer {
-  color: #bbb;
+  color: #737373;
   font-size: 11px;
   line-height: 1em;
   margin-top: 40px;

--- a/packages/themes/jsonresume-theme-claude/index.js
+++ b/packages/themes/jsonresume-theme-claude/index.js
@@ -98,7 +98,7 @@ export function render(resume) {
       --color-surface: #ffffff;
       --color-text: #1c1917;
       --color-text-secondary: #57534e;
-      --color-text-tertiary: #a8a29e;
+      --color-text-tertiary: #78716c;
       --color-accent: #2563eb;
       --color-accent-subtle: #dbeafe;
       --color-border: #e7e5e4;

--- a/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
+++ b/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
@@ -6181,7 +6181,7 @@ const WorkTitle = dt.h3`
 `;
 const WorkMeta = dt.div`
   font-size: 14px;
-  color: #94a3b8;
+  color: #64748b;
   font-weight: 500;
 `;
 const WorkCompany = dt.div`
@@ -6371,7 +6371,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "14px",
-              color: "#94a3b8",
+              color: "#64748b",
               marginTop: "8px"
             },
             children: award.date
@@ -6389,7 +6389,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "14px",
-              color: "#94a3b8",
+              color: "#64748b",
               marginTop: "8px"
             },
             children: cert.date
@@ -6407,7 +6407,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "14px",
-              color: "#94a3b8",
+              color: "#64748b",
               marginTop: "8px"
             },
             children: pub.releaseDate

--- a/packages/themes/jsonresume-theme-coastal-creative/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-coastal-creative/src/Resume.jsx
@@ -115,7 +115,7 @@ const WorkTitle = styled.h3`
 
 const WorkMeta = styled.div`
   font-size: 14px;
-  color: #94a3b8;
+  color: #64748b;
   font-weight: 500;
 `;
 
@@ -399,7 +399,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '14px',
-                      color: '#94a3b8',
+                      color: '#64748b',
                       marginTop: '8px',
                     }}
                   >
@@ -430,7 +430,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '14px',
-                      color: '#94a3b8',
+                      color: '#64748b',
                       marginTop: '8px',
                     }}
                   >
@@ -455,7 +455,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '14px',
-                      color: '#94a3b8',
+                      color: '#64748b',
                       marginTop: '8px',
                     }}
                   >

--- a/packages/themes/jsonresume-theme-flat/style.js
+++ b/packages/themes/jsonresume-theme-flat/style.js
@@ -48,7 +48,7 @@ blockquote {
 	font-size: 14px;
 }
 em {
-	color: #95a5a6;
+	color: #647274;
 	font-weight: normal;
 	font-style: normal;
 }
@@ -75,7 +75,7 @@ h4 span:first-child {
 	margin-bottom: 30px;
 }
 #header h2 {
-	color: #95a5a6;
+	color: #647274;
 	font-size: 24px;
 }
 #content h3 {

--- a/packages/themes/jsonresume-theme-investor-brief/dist/index.js
+++ b/packages/themes/jsonresume-theme-investor-brief/dist/index.js
@@ -6168,7 +6168,7 @@ const WorkTitle = dt.h3`
 `;
 const WorkMeta = dt.div`
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
   font-weight: 400;
 `;
 const WorkCompany = dt.div`
@@ -6391,7 +6391,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "13px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: award.date
@@ -6409,7 +6409,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "13px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: cert.date
@@ -6427,7 +6427,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "13px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: pub.releaseDate

--- a/packages/themes/jsonresume-theme-investor-brief/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-investor-brief/src/Resume.jsx
@@ -140,7 +140,7 @@ const WorkTitle = styled.h3`
 
 const WorkMeta = styled.div`
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
   font-weight: 400;
 `;
 
@@ -473,7 +473,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '13px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >
@@ -498,7 +498,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '13px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >
@@ -523,7 +523,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '13px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >

--- a/packages/themes/jsonresume-theme-minimalist-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-minimalist-grid/dist/index.js
@@ -6130,7 +6130,7 @@ const ContactWrapper = dt.div`
   flex-wrap: wrap;
   gap: 16px;
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
   letter-spacing: 0.5px;
 `;
 const SummarySection = dt(Section)`
@@ -6159,7 +6159,7 @@ const MainSection = dt(Section)`
 const MainSectionTitle = dt(SectionTitle)`
   font-size: 12px;
   font-weight: 500;
-  color: #9ca3af;
+  color: #6b7280;
   margin: 0 0 32px 0;
   text-transform: uppercase;
   letter-spacing: 2px;
@@ -6188,7 +6188,7 @@ const WorkTitle = dt.h3`
 `;
 const WorkMeta = dt.div`
   font-size: 12px;
-  color: #9ca3af;
+  color: #6b7280;
   font-weight: 400;
   letter-spacing: 0.5px;
 `;
@@ -6388,7 +6388,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "12px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: award.date
@@ -6406,7 +6406,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "12px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: cert.date
@@ -6424,7 +6424,7 @@ function Resume({ resume }) {
           {
             style: {
               fontSize: "12px",
-              color: "#9ca3af",
+              color: "#6b7280",
               marginTop: "4px"
             },
             children: pub.releaseDate

--- a/packages/themes/jsonresume-theme-minimalist-grid/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-minimalist-grid/src/Resume.jsx
@@ -56,7 +56,7 @@ const ContactWrapper = styled.div`
   flex-wrap: wrap;
   gap: 16px;
   font-size: 13px;
-  color: #9ca3af;
+  color: #6b7280;
   letter-spacing: 0.5px;
 `;
 
@@ -89,7 +89,7 @@ const MainSection = styled(Section)`
 const MainSectionTitle = styled(SectionTitle)`
   font-size: 12px;
   font-weight: 500;
-  color: #9ca3af;
+  color: #6b7280;
   margin: 0 0 32px 0;
   text-transform: uppercase;
   letter-spacing: 2px;
@@ -122,7 +122,7 @@ const WorkTitle = styled.h3`
 
 const WorkMeta = styled.div`
   font-size: 12px;
-  color: #9ca3af;
+  color: #6b7280;
   font-weight: 400;
   letter-spacing: 0.5px;
 `;
@@ -416,7 +416,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '12px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >
@@ -441,7 +441,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '12px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >
@@ -466,7 +466,7 @@ function Resume({ resume }) {
                   <div
                     style={{
                       fontSize: '12px',
-                      color: '#9ca3af',
+                      color: '#6b7280',
                       marginTop: '4px',
                     }}
                   >

--- a/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
+++ b/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
@@ -6188,7 +6188,7 @@ const Company = dt.span`
 `;
 const StyledDateRange = dt(DateRange)`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   font-variant-numeric: oldstyle-nums;
 `;
 const WorkSummary = dt.p`
@@ -6248,7 +6248,7 @@ const Institution = dt.span`
 `;
 const StudyType = dt.div`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   margin-top: 6px;
 `;
 const SkillsContainer = dt.div`
@@ -6324,7 +6324,7 @@ const ItemTitle = dt.h4`
 `;
 const ItemMeta = dt.div`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   margin-bottom: 8px;
   font-style: italic;
 `;

--- a/packages/themes/jsonresume-theme-new-york-editorial/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-new-york-editorial/src/Resume.jsx
@@ -156,7 +156,7 @@ const Company = styled.span`
 
 const StyledDateRange = styled(DateRange)`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   font-variant-numeric: oldstyle-nums;
 `;
 
@@ -223,7 +223,7 @@ const Institution = styled.span`
 
 const StudyType = styled.div`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   margin-top: 6px;
 `;
 
@@ -311,7 +311,7 @@ const ItemTitle = styled.h4`
 
 const ItemMeta = styled.div`
   font-size: 15px;
-  color: #777777;
+  color: #6e6e6e;
   margin-bottom: 8px;
   font-style: italic;
 `;

--- a/packages/themes/jsonresume-theme-nordic-minimal/dist/index.js
+++ b/packages/themes/jsonresume-theme-nordic-minimal/dist/index.js
@@ -6024,7 +6024,7 @@ const Name = dt.h1`
 const Title = dt.p`
   font-size: 1.25rem;
   font-weight: 300;
-  color: #7f8c8d;
+  color: #5f6c6d;
   margin: 0 0 20px 0;
 `;
 const Summary = dt.p`
@@ -6091,7 +6091,7 @@ const Company = dt.div`
 `;
 const StyledDateRange = dt(DateRange)`
   font-size: 0.875rem;
-  color: #95a5a6;
+  color: #647274;
   font-weight: 300;
 `;
 const Description = dt.p`
@@ -6138,7 +6138,7 @@ const Institution = dt.h3`
 `;
 const Degree = dt.div`
   font-size: 0.9375rem;
-  color: #7f8c8d;
+  color: #5f6c6d;
   font-weight: 300;
   margin-bottom: 4px;
 `;
@@ -6177,7 +6177,7 @@ const ContactLabel = dt.div`
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #95a5a6;
+  color: #647274;
   margin-bottom: 4px;
   font-weight: 600;
 `;
@@ -6212,7 +6212,7 @@ const LanguageName = dt.span`
   color: #2c3e50;
 `;
 const LanguageFluency = dt.span`
-  color: #7f8c8d;
+  color: #5f6c6d;
   font-weight: 300;
   margin-left: 8px;
 `;

--- a/packages/themes/jsonresume-theme-nordic-minimal/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-nordic-minimal/src/Resume.jsx
@@ -43,7 +43,7 @@ const Name = styled.h1`
 const Title = styled.p`
   font-size: 1.25rem;
   font-weight: 300;
-  color: #7f8c8d;
+  color: #5f6c6d;
   margin: 0 0 20px 0;
 `;
 
@@ -121,7 +121,7 @@ const Company = styled.div`
 
 const StyledDateRange = styled(DateRange)`
   font-size: 0.875rem;
-  color: #95a5a6;
+  color: #647274;
   font-weight: 300;
 `;
 
@@ -174,7 +174,7 @@ const Institution = styled.h3`
 
 const Degree = styled.div`
   font-size: 0.9375rem;
-  color: #7f8c8d;
+  color: #5f6c6d;
   font-weight: 300;
   margin-bottom: 4px;
 `;
@@ -218,7 +218,7 @@ const ContactLabel = styled.div`
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #95a5a6;
+  color: #647274;
   margin-bottom: 4px;
   font-weight: 600;
 `;
@@ -259,7 +259,7 @@ const LanguageName = styled.span`
 `;
 
 const LanguageFluency = styled.span`
-  color: #7f8c8d;
+  color: #5f6c6d;
   font-weight: 300;
   margin-left: 8px;
 `;

--- a/packages/themes/jsonresume-theme-urban-techno/dist/index.js
+++ b/packages/themes/jsonresume-theme-urban-techno/dist/index.js
@@ -6070,7 +6070,7 @@ const Tagline = dt.div`
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #666;
+  color: #8c8c8c;
 `;
 const ContactSection = dt.div`
   padding: 24px;

--- a/packages/themes/jsonresume-theme-urban-techno/src/Resume.jsx
+++ b/packages/themes/jsonresume-theme-urban-techno/src/Resume.jsx
@@ -54,7 +54,7 @@ const Tagline = styled.div`
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #666;
+  color: #8c8c8c;
 `;
 
 const ContactSection = styled.div`


### PR DESCRIPTION
## Summary

Second accessibility sweep, completing the color-contrast story that Wave 7 (#368) deferred. Audited homepage2 `/` and `/themes`, the docs landing, and rendered HTML of 14 representative themes (light/dark/accent-heavy) with `@axe-core/playwright` (color-contrast rule only, WCAG 2 AA).

This PR ships **only the clear, safe wins**: muted meta/UI text using a too-light gray within the surface's own neutral palette, darkened one step to clear WCAG AA while preserving the muted intent and visual hierarchy. Brand-accent-on-surface findings are genuine design tradeoffs and are **not** restyled here — they are catalogued in the backlog issue.

## Fixes

**homepage2** (`app/global.css`)
- `.btn` label, `#docs .desc`: `#aaa` → `#737373` (2.32 → 4.74:1)
- `#footer`, `#schema pre span`: `#bbb` → `#737373` (1.91 → 4.74:1)
- Clears `/themes` (57 → 0 nodes) and `/` (down to the `.btn-red` brand CTA, deferred)

**themes** (src + rebuilt dist)
- claude `--color-text-tertiary` `#a8a29e` → `#78716c` (stone-500, 2.52 → 4.8)
- minimalist-grid `#9ca3af` → `#6b7280` (gray-500, 2.53 → 4.83)
- investor-brief `#9ca3af` → `#6b7280` (gray-500, 2.42 → 4.63)
- new-york-editorial `#777777` → `#6e6e6e` (4.47 → 5.1)
- nordic-minimal muted `#7f8c8d`/`#95a5a6` → `#5f6c6d`/`#647274`
- coastal-creative slate-400 `#94a3b8` → slate-500 `#64748b`
- urban-techno tagline `#666` → `#8c8c8c` on `#111` (3.28 → 5.62)
- flat muted `#95a5a6` → `#647274`

Brand accents left untouched (deferred design calls, see issue): flat turquoise/yellow, nordic steelblue, coastal sky, homepage2 `.btn-red`.

## Verification

- Re-ran axe after each fix: every targeted node clears (each fixed theme/surface 0 contrast violations).
- Screenshot-checked all fixed surfaces — no visual regression, muted hierarchy preserved.
- Theme dist rebuilt deterministically via `vite build` (color-only diffs).
- `pnpm --filter registry test -- --run`: **1521 passed**, 0 failures.
- All 6 vite theme packages build green.

Full audit table and deferred design-call list: #390

Refs #275

— AI
