### PR TITLE
feat(cli): markdown + plain-text export (no theme required)

### DIFF
--- a/.changeset/cli-markdown-text-export.md
+++ b/.changeset/cli-markdown-text-export.md
@@ -1,0 +1,5 @@
+---
+'resume-cli': minor
+---
+
+Add `markdown` and `text` export formats to `resume export` (no theme required). Render the resume as clean Markdown (`.md` / `--format markdown`) or readable plain text (`.txt` / `--format text`), covering every JSON Resume section. Reuses the capability of the archived resume-to-markdown / resume-to-text projects inside the maintained CLI.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -24,7 +24,7 @@ npm install -g resume-cli
 |---|---|
 | init | Initialize a `resume.json` file. |
 | validate | Schema validation test your `resume.json`. |
-| export path/to/file.html | Export to `.html`. |
+| export path/to/file.html | Export to `.html`, `.pdf`, `.md` or `.txt`. |
 | serve | Serve resume at `http://localhost:4000/`. |
 
 ### `resume --help`
@@ -43,9 +43,30 @@ Validates your `resume.json` against our schema to ensure it complies with the s
 
 ### `resume export [fileName]`
 
-Exports your resume in a stylized HTML or PDF format.
+Exports your resume to one of four formats:
 
-A list of available themes can be found here:  
+- `.html` / `.pdf` — stylized output rendered through a theme.
+- `.md` — clean Markdown (one heading per section). No theme required.
+- `.txt` — readable plain text. No theme required.
+
+The format is inferred from the file extension, or set it explicitly with
+`--format`:
+
+```
+resume export resume.md                  # Markdown (inferred)
+resume export resume.txt --format text   # plain text (explicit)
+resume export resume.html --theme even   # themed HTML
+resume export resume.pdf --theme even    # themed PDF
+```
+
+`--format` accepts `html`, `pdf`, `markdown` (or `md`) and `text` (or `txt`).
+
+The Markdown and text formats render every JSON Resume section that is present
+(basics, work, volunteer, education, awards, publications, skills, languages,
+interests, references, projects) and skip any that are missing — so no theme
+install is needed.
+
+A list of available themes (for `.html` / `.pdf`) can be found here:  
 https://jsonresume.org/themes/
 
 Please npm install the theme you wish to use before attempting to export it.
@@ -53,7 +74,7 @@ Please npm install the theme you wish to use before attempting to export it.
 Options:
 
 - `--format <file type>` Example: `--format pdf`
-- `--theme <name>` Example: `--theme even`
+- `--theme <name>` Example: `--theme even` (only used for `.html` / `.pdf`)
 
 ### `resume serve`
 

--- a/packages/cli/lib/export-resume.js
+++ b/packages/cli/lib/export-resume.js
@@ -7,6 +7,17 @@ const path = require('path');
 const puppeteer = require('puppeteer');
 const btoa = require('btoa');
 const { ThemeNotFoundError } = require('./theme-errors');
+const toMarkdown = require('./formatters/markdown');
+const toText = require('./formatters/text');
+
+// Theme-less formatters keyed by their normalized format. The value pairs the
+// pure renderer with the file extension used on disk.
+const THEMELESS_FORMATTERS = {
+  md: { render: toMarkdown, ext: '.md' },
+  markdown: { render: toMarkdown, ext: '.md' },
+  txt: { render: toText, ext: '.txt' },
+  text: { render: toText, ext: '.txt' },
+};
 
 module.exports = (
   { resume: resumeJson, fileName, theme, format },
@@ -20,6 +31,16 @@ module.exports = (
   const fileNameAndFormat = getFileNameAndFormat(fileName, format);
   fileName = fileNameAndFormat.fileName;
   const fileFormatToUse = fileNameAndFormat.fileFormatToUse;
+  const themeless = THEMELESS_FORMATTERS[(fileFormatToUse || '').toLowerCase()];
+  if (themeless) {
+    createThemeless(resumeJson, fileName, themeless, (error) => {
+      if (error) {
+        console.error(error, '`createThemeless` errored out');
+      }
+      callback(error, fileName, themeless.ext);
+    });
+    return;
+  }
   const formatToUse = '.' + fileFormatToUse;
   if (formatToUse === '.html') {
     createHtml(resumeJson, fileName, theme, formatToUse, (error) => {
@@ -83,6 +104,18 @@ async function createHtml(resumeJson, fileName, themePath, format, callback) {
     stream.close(callback);
   });
 }
+// Render a resume with a pure (theme-less) formatter and write it to disk.
+async function createThemeless(resumeJson, fileName, formatter, callback) {
+  try {
+    const output = formatter.render(resumeJson);
+    const pathToStream = path.resolve(process.cwd(), fileName + formatter.ext);
+    await writeFile(pathToStream, output);
+    callback(null);
+  } catch (err) {
+    callback(err);
+  }
+}
+
 const createPdf = (resumeJson, fileName, theme, format, callback) => {
   (async () => {
     const themePkg = getThemePkg(theme);

--- a/packages/cli/lib/formatters/markdown.js
+++ b/packages/cli/lib/formatters/markdown.js
@@ -1,0 +1,169 @@
+// Pure Markdown formatter for a JSON Resume. No external theme required.
+// Renders every JSON Resume schema section that is present, and silently
+// skips sections that are missing or empty so partial resumes work too.
+
+const {
+  isNonEmptyArray,
+  dateRange,
+  contactParts,
+  section,
+} = require('./utils');
+
+const link = (label, url) => (url ? `[${label}](${url})` : label);
+
+const sec = (title, items, renderItem) =>
+  section([`## ${title}`], items, renderItem);
+
+const highlights = (items) =>
+  isNonEmptyArray(items) ? items.map((h) => `- ${h}`) : [];
+
+const csv = (keywords) =>
+  isNonEmptyArray(keywords) ? [keywords.join(', ')] : [];
+
+const italic = (text) => (text ? [`*${text}*`] : []);
+
+const basics = (resume) => {
+  const b = resume.basics;
+  if (!b) {
+    return [];
+  }
+  const lines = [];
+  if (b.name) {
+    lines.push(`# ${b.name}`);
+  }
+  if (b.label) {
+    lines.push(`> ${b.label}`);
+  }
+  const contact = contactParts(b);
+  if (contact.length) {
+    lines.push(contact.join(' | '));
+  }
+  if (isNonEmptyArray(b.profiles)) {
+    const profiles = b.profiles
+      .map((p) => link(p.network || p.username || p.url, p.url))
+      .filter(Boolean);
+    if (profiles.length) {
+      lines.push(profiles.join(' | '));
+    }
+  }
+  if (b.summary) {
+    lines.push('', b.summary);
+  }
+  return lines;
+};
+
+const work = (resume) =>
+  sec('Work', resume.work, (w) => {
+    const heading = [w.position, w.name || w.company]
+      .filter(Boolean)
+      .join(', ');
+    const lines = [`### ${link(heading || 'Role', w.url)}`];
+    lines.push(...italic(dateRange(w.startDate, w.endDate)));
+    if (w.summary) {
+      lines.push('', w.summary);
+    }
+    return lines.concat(highlights(w.highlights));
+  });
+
+const volunteer = (resume) =>
+  sec('Volunteer', resume.volunteer, (v) => {
+    const heading = [v.position, v.organization].filter(Boolean).join(', ');
+    const lines = [`### ${link(heading || 'Volunteer', v.url)}`];
+    lines.push(...italic(dateRange(v.startDate, v.endDate)));
+    if (v.summary) {
+      lines.push('', v.summary);
+    }
+    return lines.concat(highlights(v.highlights));
+  });
+
+const education = (resume) =>
+  sec('Education', resume.education, (e) => {
+    const study = [e.studyType, e.area].filter(Boolean).join(', ');
+    const title = [e.institution, study].filter(Boolean).join(' — ');
+    const lines = [`### ${link(title || 'Education', e.url)}`];
+    lines.push(...italic(dateRange(e.startDate, e.endDate)));
+    if (e.score) {
+      lines.push(`Score: ${e.score}`);
+    }
+    if (isNonEmptyArray(e.courses)) {
+      lines.push('', ...e.courses.map((c) => `- ${c}`));
+    }
+    return lines;
+  });
+
+const awards = (resume) =>
+  sec('Awards', resume.awards, (a) => {
+    const lines = [`### ${a.title || 'Award'}`];
+    lines.push(...italic([a.awarder, a.date].filter(Boolean).join(' — ')));
+    if (a.summary) {
+      lines.push('', a.summary);
+    }
+    return lines;
+  });
+
+const publications = (resume) =>
+  sec('Publications', resume.publications, (p) => {
+    const lines = [`### ${link(p.name || 'Publication', p.url)}`];
+    lines.push(
+      ...italic([p.publisher, p.releaseDate].filter(Boolean).join(' — ')),
+    );
+    if (p.summary) {
+      lines.push('', p.summary);
+    }
+    return lines;
+  });
+
+const skills = (resume) =>
+  sec('Skills', resume.skills, (s) => {
+    const heading = [s.name, s.level].filter(Boolean).join(' — ');
+    return [`### ${heading || 'Skill'}`].concat(csv(s.keywords));
+  });
+
+const languages = (resume) =>
+  sec('Languages', resume.languages, (l) => [
+    `- ${[l.language, l.fluency].filter(Boolean).join(' — ')}`,
+  ]);
+
+const interests = (resume) =>
+  sec('Interests', resume.interests, (i) =>
+    [`### ${i.name || 'Interest'}`].concat(csv(i.keywords)),
+  );
+
+const references = (resume) =>
+  sec('References', resume.references, (r) => {
+    const lines = [`### ${r.name || 'Reference'}`];
+    if (r.reference) {
+      lines.push('', `> ${r.reference}`);
+    }
+    return lines;
+  });
+
+const projects = (resume) =>
+  sec('Projects', resume.projects, (p) => {
+    const lines = [`### ${link(p.name || 'Project', p.url)}`];
+    lines.push(...italic(dateRange(p.startDate, p.endDate)));
+    if (p.description) {
+      lines.push('', p.description);
+    }
+    return lines.concat(highlights(p.highlights)).concat(csv(p.keywords));
+  });
+
+const toMarkdown = (resume = {}) => {
+  const lines = [
+    ...basics(resume),
+    ...work(resume),
+    ...volunteer(resume),
+    ...education(resume),
+    ...awards(resume),
+    ...publications(resume),
+    ...skills(resume),
+    ...languages(resume),
+    ...interests(resume),
+    ...references(resume),
+    ...projects(resume),
+  ];
+  return `${lines.join('\n').trim()}\n`;
+};
+
+module.exports = toMarkdown;
+module.exports.toMarkdown = toMarkdown;

--- a/packages/cli/lib/formatters/markdown.test.js
+++ b/packages/cli/lib/formatters/markdown.test.js
@@ -1,0 +1,72 @@
+import toMarkdown from './markdown';
+
+const sample = require('@jsonresume/schema/sample.resume.json');
+
+describe('markdown formatter', () => {
+  describe('against the bundled sample resume', () => {
+    let md;
+    beforeAll(() => {
+      md = toMarkdown(sample);
+    });
+
+    it('returns a non-empty string ending in a newline', () => {
+      expect(typeof md).toBe('string');
+      expect(md.length).toBeGreaterThan(0);
+      expect(md.endsWith('\n')).toBe(true);
+    });
+
+    it('renders the person name as the top-level heading', () => {
+      expect(md).toContain('# Richard Hendriks');
+    });
+
+    it('renders a heading for every populated section', () => {
+      [
+        '## Work',
+        '## Volunteer',
+        '## Education',
+        '## Awards',
+        '## Publications',
+        '## Skills',
+        '## Languages',
+        '## Interests',
+        '## References',
+        '## Projects',
+      ].forEach((heading) => {
+        expect(md).toContain(heading);
+      });
+    });
+
+    it('renders entry details, highlights and keywords', () => {
+      expect(md).toContain('Pied Piper');
+      expect(md).toContain('CEO/President');
+      expect(md).toContain('- Successfully won Techcrunch Disrupt');
+      expect(md).toContain('University of Oklahoma');
+      expect(md).toContain('Miss Direction');
+      expect(md).toContain('HTML, CSS, Javascript');
+      expect(md).toContain('English — Native speaker');
+    });
+
+    it('links urls using markdown link syntax', () => {
+      expect(md).toContain('](http://piedpiper.example.com)');
+    });
+  });
+
+  describe('with missing / partial sections', () => {
+    it('handles an empty resume without throwing', () => {
+      expect(() => toMarkdown({})).not.toThrow();
+      expect(() => toMarkdown()).not.toThrow();
+    });
+
+    it('omits sections that are absent', () => {
+      const md = toMarkdown({ basics: { name: 'Jane Doe' } });
+      expect(md).toContain('# Jane Doe');
+      expect(md).not.toContain('## Work');
+      expect(md).not.toContain('## Skills');
+    });
+
+    it('omits sections that are present but empty', () => {
+      const md = toMarkdown({ basics: { name: 'Jane Doe' }, work: [] });
+      expect(md).not.toContain('## Work');
+    });
+  });
+});

--- a/packages/cli/lib/formatters/text.js
+++ b/packages/cli/lib/formatters/text.js
@@ -1,0 +1,188 @@
+// Pure plain-text formatter for a JSON Resume. No external theme required.
+// Renders every JSON Resume schema section that is present, and silently
+// skips sections that are missing or empty so partial resumes work too.
+
+const {
+  isNonEmptyArray,
+  dateRange,
+  contactParts,
+  section,
+} = require('./utils');
+
+const heading = (text) => [text.toUpperCase(), '='.repeat(text.length)];
+
+const sec = (title, items, renderItem) =>
+  section(heading(title), items, renderItem);
+
+const bullets = (items) =>
+  isNonEmptyArray(items) ? items.map((i) => `  * ${i}`) : [];
+
+const csv = (keywords) =>
+  isNonEmptyArray(keywords) ? [`  ${keywords.join(', ')}`] : [];
+
+const basics = (resume) => {
+  const b = resume.basics;
+  if (!b) {
+    return [];
+  }
+  const lines = [];
+  if (b.name) {
+    lines.push(b.name);
+  }
+  if (b.label) {
+    lines.push(b.label);
+  }
+  const contact = contactParts(b);
+  if (contact.length) {
+    lines.push(contact.join(' | '));
+  }
+  if (isNonEmptyArray(b.profiles)) {
+    b.profiles.forEach((p) => {
+      const label = [p.network, p.username].filter(Boolean).join(' ');
+      const parts = [label, p.url].filter(Boolean);
+      if (parts.length) {
+        lines.push(parts.join(': '));
+      }
+    });
+  }
+  if (b.summary) {
+    lines.push('', b.summary);
+  }
+  return lines;
+};
+
+const work = (resume) =>
+  sec('Work', resume.work, (w) => {
+    const title = [w.position, w.name || w.company].filter(Boolean).join(' @ ');
+    const lines = [title || 'Role'];
+    const range = dateRange(w.startDate, w.endDate);
+    if (range) {
+      lines.push(range);
+    }
+    if (w.url) {
+      lines.push(w.url);
+    }
+    if (w.summary) {
+      lines.push(w.summary);
+    }
+    return lines.concat(bullets(w.highlights));
+  });
+
+const volunteer = (resume) =>
+  sec('Volunteer', resume.volunteer, (v) => {
+    const title = [v.position, v.organization].filter(Boolean).join(' @ ');
+    const lines = [title || 'Volunteer'];
+    const range = dateRange(v.startDate, v.endDate);
+    if (range) {
+      lines.push(range);
+    }
+    if (v.summary) {
+      lines.push(v.summary);
+    }
+    return lines.concat(bullets(v.highlights));
+  });
+
+const education = (resume) =>
+  sec('Education', resume.education, (e) => {
+    const study = [e.studyType, e.area].filter(Boolean).join(', ');
+    const title = [e.institution, study].filter(Boolean).join(' - ');
+    const lines = [title || 'Education'];
+    const range = dateRange(e.startDate, e.endDate);
+    if (range) {
+      lines.push(range);
+    }
+    if (e.score) {
+      lines.push(`Score: ${e.score}`);
+    }
+    return lines.concat(bullets(e.courses));
+  });
+
+const awards = (resume) =>
+  sec('Awards', resume.awards, (a) => {
+    const lines = [a.title || 'Award'];
+    const meta = [a.awarder, a.date].filter(Boolean).join(' - ');
+    if (meta) {
+      lines.push(meta);
+    }
+    if (a.summary) {
+      lines.push(a.summary);
+    }
+    return lines;
+  });
+
+const publications = (resume) =>
+  sec('Publications', resume.publications, (p) => {
+    const lines = [p.name || 'Publication'];
+    const meta = [p.publisher, p.releaseDate].filter(Boolean).join(' - ');
+    if (meta) {
+      lines.push(meta);
+    }
+    if (p.url) {
+      lines.push(p.url);
+    }
+    if (p.summary) {
+      lines.push(p.summary);
+    }
+    return lines;
+  });
+
+const skills = (resume) =>
+  sec('Skills', resume.skills, (s) => {
+    const title = [s.name, s.level].filter(Boolean).join(' - ');
+    return [title || 'Skill'].concat(csv(s.keywords));
+  });
+
+const languages = (resume) =>
+  sec('Languages', resume.languages, (l) => [
+    `  * ${[l.language, l.fluency].filter(Boolean).join(' - ')}`,
+  ]);
+
+const interests = (resume) =>
+  sec('Interests', resume.interests, (i) =>
+    [i.name || 'Interest'].concat(csv(i.keywords)),
+  );
+
+const references = (resume) =>
+  sec('References', resume.references, (r) => {
+    const lines = [r.name || 'Reference'];
+    if (r.reference) {
+      lines.push(r.reference);
+    }
+    return lines;
+  });
+
+const projects = (resume) =>
+  sec('Projects', resume.projects, (p) => {
+    const lines = [p.name || 'Project'];
+    const range = dateRange(p.startDate, p.endDate);
+    if (range) {
+      lines.push(range);
+    }
+    if (p.url) {
+      lines.push(p.url);
+    }
+    if (p.description) {
+      lines.push(p.description);
+    }
+    return lines.concat(bullets(p.highlights)).concat(csv(p.keywords));
+  });
+
+const toText = (resume = {}) => {
+  const lines = [
+    ...basics(resume),
+    ...work(resume),
+    ...volunteer(resume),
+    ...education(resume),
+    ...awards(resume),
+    ...publications(resume),
+    ...skills(resume),
+    ...languages(resume),
+    ...interests(resume),
+    ...references(resume),
+    ...projects(resume),
+  ];
+  return `${lines.join('\n').trim()}\n`;
+};
+
+module.exports = toText;
+module.exports.toText = toText;

--- a/packages/cli/lib/formatters/text.test.js
+++ b/packages/cli/lib/formatters/text.test.js
@@ -1,0 +1,74 @@
+import toText from './text';
+
+const sample = require('@jsonresume/schema/sample.resume.json');
+
+describe('text formatter', () => {
+  describe('against the bundled sample resume', () => {
+    let txt;
+    beforeAll(() => {
+      txt = toText(sample);
+    });
+
+    it('returns a non-empty string ending in a newline', () => {
+      expect(typeof txt).toBe('string');
+      expect(txt.length).toBeGreaterThan(0);
+      expect(txt.endsWith('\n')).toBe(true);
+    });
+
+    it('renders the person name', () => {
+      expect(txt).toContain('Richard Hendriks');
+    });
+
+    it('renders an underlined heading for every populated section', () => {
+      [
+        'WORK',
+        'VOLUNTEER',
+        'EDUCATION',
+        'AWARDS',
+        'PUBLICATIONS',
+        'SKILLS',
+        'LANGUAGES',
+        'INTERESTS',
+        'REFERENCES',
+        'PROJECTS',
+      ].forEach((heading) => {
+        expect(txt).toContain(heading);
+      });
+      // headings are underlined with '=' rules
+      expect(txt).toContain('====');
+    });
+
+    it('renders entry details, highlights and keywords', () => {
+      expect(txt).toContain('CEO/President @ Pied Piper');
+      expect(txt).toContain('  * Successfully won Techcrunch Disrupt');
+      expect(txt).toContain('University of Oklahoma');
+      expect(txt).toContain('Miss Direction');
+      expect(txt).toContain('HTML, CSS, Javascript');
+      expect(txt).toContain('English - Native speaker');
+    });
+
+    it('does not contain markdown markup', () => {
+      expect(txt).not.toContain('# ');
+      expect(txt).not.toContain('](');
+    });
+  });
+
+  describe('with missing / partial sections', () => {
+    it('handles an empty resume without throwing', () => {
+      expect(() => toText({})).not.toThrow();
+      expect(() => toText()).not.toThrow();
+    });
+
+    it('omits sections that are absent', () => {
+      const txt = toText({ basics: { name: 'Jane Doe' } });
+      expect(txt).toContain('Jane Doe');
+      expect(txt).not.toContain('WORK');
+      expect(txt).not.toContain('SKILLS');
+    });
+
+    it('omits sections that are present but empty', () => {
+      const txt = toText({ basics: { name: 'Jane Doe' }, work: [] });
+      expect(txt).not.toContain('WORK');
+    });
+  });
+});

--- a/packages/cli/lib/formatters/utils.js
+++ b/packages/cli/lib/formatters/utils.js
@@ -1,0 +1,59 @@
+// Shared helpers for the theme-less resume formatters (markdown + text).
+
+const isNonEmptyArray = (value) => Array.isArray(value) && value.length > 0;
+
+const dateRange = (startDate, endDate) => {
+  if (!startDate && !endDate) {
+    return '';
+  }
+  return `${startDate || ''} - ${endDate || 'Present'}`;
+};
+
+// Flatten a contact line out of basics: email, phone, url and a one-line
+// location. Returns an array of fragments (caller decides the separator).
+const contactParts = (basics = {}) => {
+  const parts = [];
+  if (basics.email) {
+    parts.push(basics.email);
+  }
+  if (basics.phone) {
+    parts.push(basics.phone);
+  }
+  if (basics.url) {
+    parts.push(basics.url);
+  }
+  const loc = basics.location;
+  if (loc) {
+    const locParts = [
+      loc.address,
+      loc.city,
+      loc.region,
+      loc.postalCode,
+      loc.countryCode,
+    ].filter(Boolean);
+    if (locParts.length) {
+      parts.push(locParts.join(', '));
+    }
+  }
+  return parts;
+};
+
+// Build a section block: returns [] when there are no items, otherwise the
+// `headerLines` followed by each rendered item (separated by a blank line).
+const section = (headerLines, items, renderItem) => {
+  if (!isNonEmptyArray(items)) {
+    return [];
+  }
+  const lines = ['', ...headerLines];
+  items.forEach((item) => {
+    lines.push('', ...renderItem(item));
+  });
+  return lines;
+};
+
+module.exports = {
+  isNonEmptyArray,
+  dateRange,
+  contactParts,
+  section,
+};

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -91,7 +91,7 @@ const normalizeTheme = (value, defaultValue) => {
   program
     .command('export [fileName]')
     .description(
-      'Export locally to .html or .pdf. Supply a --format <file format> flag and argument to specify export format. Pick a theme with --theme (https://jsonresume.org/themes/).',
+      'Export locally to .html, .pdf, .md (markdown) or .txt (text). Supply a --format <file format> flag and argument to specify export format. .md and .txt need no theme; pick a theme for .html/.pdf with --theme (https://jsonresume.org/themes/).',
     )
     .action(async (fileName) => {
       const resume = await getResume({ path: program.resume });

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -89,10 +89,12 @@ describe('cli configuration', () => {
       Commands:
         init                                Initialize a resume.json file
         validate                            Validate your resume's schema
-        export [fileName]                   Export locally to .html or .pdf. Supply
-                                            a --format <file format> flag and
-                                            argument to specify export format. Pick a
-                                            theme with --theme
+        export [fileName]                   Export locally to .html, .pdf, .md
+                                            (markdown) or .txt (text). Supply a
+                                            --format <file format> flag and argument
+                                            to specify export format. .md and .txt
+                                            need no theme; pick a theme for
+                                            .html/.pdf with --theme
                                             (https://jsonresume.org/themes/).
         serve                               Serve resume at http://localhost:4000/
         help [command]                      display help for command
@@ -190,6 +192,46 @@ describe('cli configuration', () => {
          /test-resumes/exported-resume.html
         "
       `);
+    });
+    it('should export markdown without requiring a theme', async () => {
+      const { stdout, volume } = await run(
+        [
+          'export',
+          '/test-resumes/exported-resume.md',
+          '--resume',
+          '-',
+          '--format',
+          'markdown',
+        ],
+        {
+          stdin: JSON.stringify({
+            basics: { name: 'thomas-md' },
+            skills: [{ name: 'JS', keywords: ['Node'] }],
+          }),
+        },
+      );
+      const output = volume['/test-resumes/exported-resume.md'];
+      expect(output).toEqual(expect.stringContaining('# thomas-md'));
+      expect(output).toEqual(expect.stringContaining('## Skills'));
+      expect(stdout).toContain('.md resume at:');
+    });
+    it('should export plain text without requiring a theme', async () => {
+      const { stdout, volume } = await run(
+        [
+          'export',
+          '/test-resumes/exported-resume.txt',
+          '--resume',
+          '-',
+          '--format',
+          'text',
+        ],
+        {
+          stdin: JSON.stringify({ basics: { name: 'thomas-txt' } }),
+        },
+      );
+      const output = volume['/test-resumes/exported-resume.txt'];
+      expect(output).toEqual(expect.stringContaining('thomas-txt'));
+      expect(stdout).toContain('.txt resume at:');
     });
     it('should print a friendly, actionable message and exit non-zero when the theme is not installed', async () => {
       const { code, stderr } = await run(


### PR DESCRIPTION
## What

Adds `markdown` and `text` export formats to `resume export` in `packages/cli` — reviving the capability of the archived `resume-to-markdown` / `resume-to-text` projects inside the maintained CLI.

```bash
resume export out.md  --format markdown   # or infer from .md
resume export out.txt --format text       # or infer from .txt
```

Both formats need **no theme**: pure formatters in `lib/formatters/` render every JSON Resume section (basics, work, volunteer, education, awards, publications, skills, languages, interests, references, projects) and skip any that are missing.

## How

- `lib/formatters/markdown.js`, `text.js` — small pure `(resume) => string` functions (shared helpers in `utils.js`), unit-testable.
- `lib/export-resume.js` — dispatches `.md`/`markdown` and `.txt`/`text` to a theme-less writer **before** the existing theme→HTML/PDF path. The default theme/html/pdf behavior is unchanged.
- README export section + help text updated; minor changeset for `resume-cli`.

## Tests

- New unit tests for both formatters against the bundled `@jsonresume/schema` sample (all sections present; handles missing/empty sections).
- 2 new end-to-end export tests (md + txt).
- Existing 20 CLI tests still pass — **38 total green**. Lint + turbo gate green.

Refs #275

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Markdown (`.md`) and plain text (`.txt`) export formats to the `resume export` command, enabling exports without theme selection unlike HTML and PDF options.

* **Documentation**
  * Updated CLI documentation to describe all four supported export formats and clarify that Markdown and text exports require no theme configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->