### PR TITLE
feat(cli): precise, path-pointed resume validate errors

### DIFF
--- a/.changeset/cli-validate-precise-errors.md
+++ b/.changeset/cli-validate-precise-errors.md
@@ -1,0 +1,11 @@
+---
+'resume-cli': minor
+---
+
+`resume validate` now reports precise, actionable results. On failure each
+problem is shown with its JSON path (e.g. `work[0].startDate`), the failing
+rule, the offending value, and a one-line fix hint. On success it prints an OK
+summary with the candidate name and a count of each populated section. The
+classic `data/...` phrasing and the non-zero exit code on invalid input are
+preserved; raw Ajv errors are exposed on the thrown error for machine-readable
+callers.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -39,7 +39,35 @@ Complete the `resume.json` with your text editor. Be sure to follow the schema (
 
 ### `resume validate`
 
-Validates your `resume.json` against our schema to ensure it complies with the standard. Tries to identify where any errors may be occurring.
+Validates your `resume.json` against our schema to ensure it complies with the standard.
+
+On success it prints a one-line summary with the candidate name and a count of
+each populated section:
+
+```
+✓ resume.json is valid (Ada Lovelace — 1 work, 1 education, 2 skills)
+```
+
+On failure it exits non-zero and prints one annotated block per problem, naming
+the exact JSON path, the failing rule, the offending value, and a one-line hint:
+
+```
+Invalid resume: 2 problems found
+
+  ✖ data/basics/email must match format "email"
+    at:    basics.email
+    rule:  format (expected email)
+    found: "nope" (string)
+    hint:  "basics.email" must be a valid email address, e.g. "you@example.com".
+
+  ✖ data/work/0/startDate must match pattern "..."
+    at:    work[0].startDate
+    rule:  pattern
+    found: "13-2020" (string)
+    hint:  "work[0].startDate" must be an ISO-8601 date: YYYY, YYYY-MM, or YYYY-MM-DD.
+```
+
+Validate against a custom schema with `--schema <path>`.
 
 ### `resume export [fileName]`
 

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -14,6 +14,7 @@ const program = require('commander');
 const chalk = require('chalk');
 const path = require('path');
 const { ThemeNotFoundError, formatThemeNotFound } = require('./theme-errors');
+const { formatOkSummary } = require('./validate-errors');
 
 const normalizeTheme = (value, defaultValue) => {
   const theme = value || defaultValue;
@@ -81,9 +82,9 @@ const normalizeTheme = (value, defaultValue) => {
           resume,
           schema,
         });
-        console.log(chalk.green(`✓ ${program.resume} is valid`));
+        console.log(chalk.green(formatOkSummary(resume, program.resume)));
       } catch (e) {
-        console.error(e.message);
+        console.error(chalk.red(e.message));
         process.exitCode = 1;
       }
     });

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -126,14 +126,20 @@ describe('cli configuration', () => {
         ).code,
       ).toEqual(1);
     });
-    it('should print the per-field error list (not a success line) when validation fails', async () => {
+    it('should print precise, path-pointed errors (not a success line) when validation fails', async () => {
       const { code, stdout, stderr } = await run(
         ['validate', '--resume', '/test-resumes/invalid-resume.json'],
         { waitForVolumeExport: false, captureStderr: true },
       );
       expect(code).toEqual(1);
       expect(stderr).toContain('Invalid resume:');
+      // The classic data-path phrasing is preserved...
       expect(stderr).toContain('data/basics/name must be string');
+      // ...alongside the new annotated path/rule/value/hint lines.
+      expect(stderr).toContain('at:    basics.name');
+      expect(stderr).toContain('rule:  type (expected string)');
+      expect(stderr).toContain('found: 123 (number)');
+      expect(stderr).toContain('must be of type string');
       // The success line must not appear for an invalid resume.
       expect(stdout).not.toContain('is valid');
     });
@@ -144,7 +150,7 @@ describe('cli configuration', () => {
         '/test-resumes/resume.json',
       ]);
       expect(stdout).toMatchInlineSnapshot(`
-        "✓ /test-resumes/resume.json is valid
+        "✓ /test-resumes/resume.json is valid (thomas)
         "
       `);
     });

--- a/packages/cli/lib/validate-errors.js
+++ b/packages/cli/lib/validate-errors.js
@@ -1,0 +1,215 @@
+// Turns raw Ajv (draft-07) error objects into precise, actionable output.
+//
+// For each failure we surface four things:
+//   - the JSON path in dot/bracket notation (e.g. work[2].startDate)
+//   - the failing rule (the Ajv keyword, lightly humanised)
+//   - the offending value (with its JS type)
+//   - a one-line, human hint on how to fix it
+//
+// The first physical line of each error is kept as `<dataPath> <message>`
+// (e.g. `data/basics/name must be string`) so existing tooling that greps the
+// output for that classic phrasing keeps working.
+
+// "/work/1/startDate" -> "work[1].startDate"; the root is "(root)".
+const toDotPath = (instancePath) => {
+  if (!instancePath) {
+    return '(root)';
+  }
+  const segments = instancePath.split('/').filter(Boolean);
+  return segments
+    .map((segment) => (/^\d+$/.test(segment) ? `[${segment}]` : `.${segment}`))
+    .join('')
+    .replace(/^\./, '');
+};
+
+// "data" + instancePath, matching Ajv's classic dataPath phrasing.
+const toDataPath = (instancePath) =>
+  instancePath ? `data${instancePath}` : 'data';
+
+const previewValue = (value) => {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  let serialised;
+  try {
+    serialised = JSON.stringify(value);
+  } catch {
+    serialised = String(value);
+  }
+  if (serialised === undefined) {
+    serialised = String(value);
+  }
+  if (serialised.length > 80) {
+    serialised = `${serialised.slice(0, 77)}...`;
+  }
+  const type = Array.isArray(value) ? 'array' : typeof value;
+  return `${serialised} (${type})`;
+};
+
+// Resolve the value the error points at by walking the instancePath.
+const valueAtPath = (root, instancePath) => {
+  if (!instancePath) {
+    return root;
+  }
+  const segments = instancePath.split('/').filter(Boolean);
+  let current = root;
+  for (const segment of segments) {
+    if (current == null) {
+      return undefined;
+    }
+    // Ajv JSON-pointer-escapes "/" as "~1" and "~" as "~0".
+    const key = segment.replace(/~1/g, '/').replace(/~0/g, '~');
+    current = current[key];
+  }
+  return current;
+};
+
+// Map an Ajv keyword to a short human description of the rule it enforces.
+const describeRule = (error) => {
+  const { keyword, params } = error;
+  switch (keyword) {
+    case 'type':
+      return `type (expected ${params.type})`;
+    case 'format':
+      return `format (expected ${params.format})`;
+    case 'pattern':
+      return 'pattern';
+    case 'required':
+      return `required (${params.missingProperty})`;
+    case 'additionalProperties':
+      return `additionalProperties (${params.additionalProperty})`;
+    case 'enum':
+      return `enum (one of ${JSON.stringify(params.allowedValues)})`;
+    case 'minimum':
+    case 'maximum':
+    case 'minLength':
+    case 'maxLength':
+    case 'minItems':
+    case 'maxItems':
+      return `${keyword} (${params.limit})`;
+    default:
+      return keyword;
+  }
+};
+
+// A short, plain-language fix for the failing field.
+const hintFor = (error, dotPath) => {
+  const field = dotPath === '(root)' ? 'the resume' : `"${dotPath}"`;
+  const { keyword, params } = error;
+  switch (keyword) {
+    case 'type':
+      return `${field} must be of type ${params.type}.`;
+    case 'format':
+      if (params.format === 'email') {
+        return `${field} must be a valid email address, e.g. "you@example.com".`;
+      }
+      if (params.format === 'uri') {
+        return `${field} must be a full URL, e.g. "https://example.com".`;
+      }
+      if (params.format === 'date') {
+        return `${field} must be an ISO date, e.g. "2024-01-31".`;
+      }
+      return `${field} must match the "${params.format}" format.`;
+    case 'pattern':
+      // The JSON Resume date fields share one ISO-8601 pattern.
+      if (/iso8601/.test(error.schemaPath || '')) {
+        return `${field} must be an ISO-8601 date: YYYY, YYYY-MM, or YYYY-MM-DD.`;
+      }
+      return `${field} does not match the required pattern.`;
+    case 'required':
+      return `add the missing "${params.missingProperty}" property to ${field}.`;
+    case 'additionalProperties':
+      return `remove the unknown property "${params.additionalProperty}" from ${field} (or check for a typo).`;
+    case 'enum':
+      return `${field} must be one of: ${params.allowedValues
+        .map((v) => JSON.stringify(v))
+        .join(', ')}.`;
+    case 'minLength':
+      return `${field} must be at least ${params.limit} character(s) long.`;
+    case 'maxLength':
+      return `${field} must be at most ${params.limit} character(s) long.`;
+    case 'minItems':
+      return `${field} must contain at least ${params.limit} item(s).`;
+    case 'minimum':
+      return `${field} must be >= ${params.limit}.`;
+    case 'maximum':
+      return `${field} must be <= ${params.limit}.`;
+    default:
+      return `${field} ${error.message}.`;
+  }
+};
+
+// Format a single Ajv error into a multi-line, annotated block.
+const formatSingleError = (error, root) => {
+  const dataPath = toDataPath(error.instancePath);
+  const dotPath = toDotPath(error.instancePath);
+  // For `required`/`additionalProperties` the offending value is the *parent*
+  // object; show that, since the named property itself is missing/extra.
+  const value = valueAtPath(root, error.instancePath);
+  const lines = [
+    // Kept verbatim so `data/basics/name must be string`-style greps work.
+    `✖ ${dataPath} ${error.message}`,
+    `    at:    ${dotPath}`,
+    `    rule:  ${describeRule(error)}`,
+  ];
+  if (error.keyword !== 'required') {
+    lines.push(`    found: ${previewValue(value)}`);
+  }
+  lines.push(`    hint:  ${hintFor(error, dotPath)}`);
+  return lines.join('\n');
+};
+
+// Public: build the full failure message.
+//   formatErrors(ajvErrors, resume) -> string
+const formatErrors = (errors = [], root) => {
+  const count = errors.length;
+  const heading =
+    count === 1
+      ? 'Invalid resume: 1 problem found'
+      : `Invalid resume: ${count} problems found`;
+  const blocks = errors.map((error) => formatSingleError(error, root));
+  return `${heading}\n\n  ${blocks.join('\n\n  ')}`;
+};
+
+// Build a one-line OK summary that counts the populated array sections.
+const formatOkSummary = (resume, label) => {
+  const sections = [
+    'work',
+    'volunteer',
+    'education',
+    'awards',
+    'certificates',
+    'publications',
+    'skills',
+    'languages',
+    'interests',
+    'references',
+    'projects',
+  ];
+  const counts = sections
+    .filter((key) => Array.isArray(resume && resume[key]) && resume[key].length)
+    .map((key) => `${resume[key].length} ${key}`);
+  const name =
+    resume && resume.basics && typeof resume.basics.name === 'string'
+      ? resume.basics.name
+      : null;
+  const parts = [];
+  if (name) {
+    parts.push(name);
+  }
+  if (counts.length) {
+    parts.push(counts.join(', '));
+  }
+  const detail = parts.length ? ` (${parts.join(' — ')})` : '';
+  const subject = label ? `${label} is valid` : 'resume is valid';
+  return `✓ ${subject}${detail}`;
+};
+
+module.exports = {
+  formatErrors,
+  formatOkSummary,
+  // exported for unit testing of the path/value/hint helpers
+  toDotPath,
+  previewValue,
+  hintFor,
+};

--- a/packages/cli/lib/validate-errors.test.js
+++ b/packages/cli/lib/validate-errors.test.js
@@ -1,0 +1,156 @@
+const {
+  formatErrors,
+  formatOkSummary,
+  toDotPath,
+  previewValue,
+} = require('./validate-errors');
+
+// A representative slice of real Ajv (draft-07) error objects, as produced by
+// `ajv.compile(schema)` against a resume with several distinct violations.
+const sampleAjvErrors = [
+  {
+    instancePath: '/basics/name',
+    schemaPath: '#/properties/basics/properties/name/type',
+    keyword: 'type',
+    params: { type: 'string' },
+    message: 'must be string',
+  },
+  {
+    instancePath: '/basics/email',
+    schemaPath: '#/properties/basics/properties/email/format',
+    keyword: 'format',
+    params: { format: 'email' },
+    message: 'must match format "email"',
+  },
+  {
+    instancePath: '/work/2/startDate',
+    schemaPath: '#/definitions/iso8601/pattern',
+    keyword: 'pattern',
+    params: { pattern: '^(...)$' },
+    message: 'must match pattern "..."',
+  },
+];
+
+const sampleResume = {
+  basics: { name: 123, email: 'not-an-email' },
+  work: [{}, {}, { startDate: '13-2020' }],
+};
+
+describe('toDotPath', () => {
+  it('converts a JSON pointer to dot/bracket notation', () => {
+    expect(toDotPath('/work/2/startDate')).toBe('work[2].startDate');
+    expect(toDotPath('/basics/name')).toBe('basics.name');
+  });
+  it('labels the document root', () => {
+    expect(toDotPath('')).toBe('(root)');
+  });
+});
+
+describe('previewValue', () => {
+  it('shows the value with its JS type', () => {
+    expect(previewValue(123)).toBe('123 (number)');
+    expect(previewValue('hi')).toBe('"hi" (string)');
+    expect(previewValue([1, 2])).toBe('[1,2] (array)');
+  });
+  it('reports undefined for missing values', () => {
+    expect(previewValue(undefined)).toBe('undefined');
+  });
+});
+
+describe('formatErrors', () => {
+  const output = formatErrors(sampleAjvErrors, sampleResume);
+
+  it('counts the problems in the heading', () => {
+    expect(output).toContain('Invalid resume: 3 problems found');
+  });
+
+  it('names the right JSON path for each error', () => {
+    expect(output).toContain('at:    basics.name');
+    expect(output).toContain('at:    basics.email');
+    expect(output).toContain('at:    work[2].startDate');
+  });
+
+  it('reports the failing rule', () => {
+    expect(output).toContain('rule:  type (expected string)');
+    expect(output).toContain('rule:  format (expected email)');
+    expect(output).toContain('rule:  pattern');
+  });
+
+  it('shows the offending value with its type', () => {
+    expect(output).toContain('found: 123 (number)');
+    expect(output).toContain('found: "not-an-email" (string)');
+    expect(output).toContain('found: "13-2020" (string)');
+  });
+
+  it('gives a one-line human hint per error', () => {
+    expect(output).toContain('"basics.name" must be of type string.');
+    expect(output).toContain('must be a valid email address');
+    expect(output).toContain('must be an ISO-8601 date');
+  });
+
+  it('preserves the classic data-path phrasing for greppability', () => {
+    expect(output).toContain('data/basics/name must be string');
+  });
+
+  it('uses the singular "problem" for a single error', () => {
+    const single = formatErrors([sampleAjvErrors[0]], sampleResume);
+    expect(single).toContain('Invalid resume: 1 problem found');
+  });
+
+  it('handles required + additionalProperties without throwing', () => {
+    const out = formatErrors(
+      [
+        {
+          instancePath: '/work/0',
+          schemaPath: '#/.../required',
+          keyword: 'required',
+          params: { missingProperty: 'name' },
+          message: "must have required property 'name'",
+        },
+        {
+          instancePath: '/basics',
+          schemaPath: '#/.../additionalProperties',
+          keyword: 'additionalProperties',
+          params: { additionalProperty: 'nme' },
+          message: 'must NOT have additional properties',
+        },
+      ],
+      { work: [{}], basics: { nme: 'x' } },
+    );
+    expect(out).toContain('rule:  required (name)');
+    expect(out).toContain('add the missing "name" property');
+    expect(out).toContain('rule:  additionalProperties (nme)');
+    expect(out).toContain('remove the unknown property "nme"');
+  });
+});
+
+describe('formatOkSummary', () => {
+  it('summarises populated array sections and the candidate name', () => {
+    const summary = formatOkSummary(
+      {
+        basics: { name: 'Thomas' },
+        work: [{}, {}],
+        education: [{}],
+        skills: [{}, {}, {}],
+      },
+      'resume.json',
+    );
+    expect(summary).toContain('✓ resume.json is valid');
+    expect(summary).toContain('Thomas');
+    expect(summary).toContain('2 work');
+    expect(summary).toContain('1 education');
+    expect(summary).toContain('3 skills');
+  });
+
+  it('omits the detail block when there is nothing to count', () => {
+    expect(formatOkSummary({ basics: {} }, 'resume.json')).toBe(
+      '✓ resume.json is valid',
+    );
+  });
+
+  it('handles a non-object resume (custom schema override)', () => {
+    expect(formatOkSummary(123, 'only-number.json')).toBe(
+      '✓ only-number.json is valid',
+    );
+  });
+});

--- a/packages/cli/lib/validate.js
+++ b/packages/cli/lib/validate.js
@@ -1,15 +1,6 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-
-// Format a single Ajv error into a readable `field message` line.
-const formatError = (error) => {
-  // instancePath is like "/basics/name"; the root is an empty string.
-  const field = error.instancePath ? `data${error.instancePath}` : 'data';
-  if (error.keyword === 'additionalProperties') {
-    return `${field} ${error.message} (${error.params.additionalProperty})`;
-  }
-  return `${field} ${error.message}`;
-};
+import { formatErrors } from './validate-errors';
 
 export default async ({ resume, schema }) => {
   // strict:false is required: the JSON Resume schema is an externally authored
@@ -23,6 +14,8 @@ export default async ({ resume, schema }) => {
     return true;
   }
 
-  const details = (validateFn.errors || []).map(formatError).join('\n  ');
-  throw new Error(`Invalid resume:\n  ${details}`);
+  const error = new Error(formatErrors(validateFn.errors || [], resume));
+  // Expose the raw Ajv errors so callers can build machine-readable output.
+  error.validationErrors = validateFn.errors || [];
+  throw error;
 };

--- a/packages/cli/lib/validate.test.js
+++ b/packages/cli/lib/validate.test.js
@@ -9,13 +9,52 @@ describe('validate', () => {
   it('should not throw an error for a valid resume object', async () => {
     await validate({ resume: { basics: {} }, schema: defaultSchema });
   });
-  it('should throw a per-field error for an invalid resume object', async () => {
+  it('should throw a precise, path-pointed error for an invalid resume object', async () => {
     await expect(
       validate({ resume: { basics: { name: 123 } }, schema: defaultSchema }),
     ).rejects.toMatchInlineSnapshot(`
-      [Error: Invalid resume:
-        data/basics/name must be string]
+      [Error: Invalid resume: 1 problem found
+
+        ✖ data/basics/name must be string
+          at:    basics.name
+          rule:  type (expected string)
+          found: 123 (number)
+          hint:  "basics.name" must be of type string.]
     `);
+  });
+  it('should report every distinct violation with its own JSON path', async () => {
+    let thrown;
+    try {
+      await validate({
+        resume: {
+          basics: { name: 123, email: 'not-an-email' },
+          work: [{ name: 'Acme', startDate: '13-2020' }],
+        },
+        schema: defaultSchema,
+      });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeDefined();
+    expect(thrown.message).toContain('Invalid resume: 3 problems found');
+    // Each error names the right JSON path in dot/bracket notation.
+    expect(thrown.message).toContain('at:    basics.name');
+    expect(thrown.message).toContain('at:    basics.email');
+    expect(thrown.message).toContain('at:    work[0].startDate');
+    // ...the failing rule...
+    expect(thrown.message).toContain('rule:  type (expected string)');
+    expect(thrown.message).toContain('rule:  format (expected email)');
+    // ...the offending value...
+    expect(thrown.message).toContain('found: 123 (number)');
+    expect(thrown.message).toContain('found: "not-an-email" (string)');
+    // ...and a human hint.
+    expect(thrown.message).toContain('must be a valid email address');
+    expect(thrown.message).toContain('must be an ISO-8601 date');
+    // The classic `data/...` phrasing is preserved for greppability.
+    expect(thrown.message).toContain('data/basics/name must be string');
+    // Raw Ajv errors are exposed for machine-readable callers.
+    expect(Array.isArray(thrown.validationErrors)).toBe(true);
+    expect(thrown.validationErrors).toHaveLength(3);
   });
   it('should accept a schema override', async () => {
     await validate({
@@ -28,8 +67,13 @@ describe('validate', () => {
         schema: { type: 'number' },
       }),
     ).rejects.toMatchInlineSnapshot(`
-      [Error: Invalid resume:
-        data must be number]
+      [Error: Invalid resume: 1 problem found
+
+        ✖ data must be number
+          at:    (root)
+          rule:  type (expected number)
+          found: "thomas" (string)
+          hint:  the resume must be of type number.]
     `);
   });
 });


### PR DESCRIPTION
Improves `resume validate` UX. Formats the existing Ajv (draft-07) errors — no schema change, no validation-engine swap, no loosening.

**On failure**, each problem prints its JSON path (`work[0].startDate`), the failing rule, the offending value (with type), and a one-line fix hint:

```
Invalid resume: 2 problems found

  ✖ data/basics/email must match format "email"
    at:    basics.email
    rule:  format (expected email)
    found: "nope" (string)
    hint:  "basics.email" must be a valid email address, e.g. "you@example.com".
```

**On success**, an OK summary with name + section counts:

```
✓ resume.json is valid (Ada Lovelace — 1 work, 1 education, 2 skills)
```

**Preserved:** non-zero exit on invalid input; the classic `data/...` phrasing (kept as the first line of each block for greppability); `--schema` override path. Raw Ajv errors are exposed on the thrown error (`error.validationErrors`) for machine-readable callers.

New `lib/validate-errors.js` formatter (path/rule/value/hint + OK summary), unit-tested in `lib/validate-errors.test.js`. Updated `validate.test.js` / `main.test.js`; all 54 CLI tests pass. README + changeset (minor) included. Lane: `packages/cli/` only.

Refs #275

— AI