### PR TITLE
fix(docs): lint .ts/.tsx sources (unmask docs#lint CI failure)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --port 3002",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint . --max-warnings=0",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "typecheck": "fumadocs-mdx && tsc --noEmit",
     "test:e2e": "playwright test"
   },


### PR DESCRIPTION
## What
`apps/docs` lint was `eslint . --max-warnings=0`. After the Next 16 + Fumadocs migration:
- Next 16 **removed `next lint`**, so docs uses raw `eslint .`.
- ESLint 8 (eslintrc mode) lints `.js` by default; the migrated docs have only `.ts/.tsx` source, so `eslint .` matched **zero** files and exits 2 ("all files ignored").
- Turbo's remote cache served a stale green `docs#lint` result, so master *looked* green. Any cache-busting PR (e.g. #406, which edits root `package.json`) busted the cache and surfaced the failure as a red **Lint + Typecheck**.

## Fix
Add `--ext .js,.jsx,.ts,.tsx` so eslint actually lints the TS sources.

Verified locally under CI-equivalent mode (`ESLINT_USE_FLAT_CONFIG=false`): **11 files linted, 0 errors, 0 warnings**, exit 0.

Refs #275

— AI