### PR TITLE
feat(cli): list installed themes for discoverability

### DIFF
--- a/.changeset/cli-list-themes.md
+++ b/.changeset/cli-list-themes.md
@@ -1,0 +1,8 @@
+---
+'resume-cli': minor
+---
+
+Add a `resume themes` command that lists the JSON Resume themes installed in
+`node_modules` (project and global), printing the slug to pass to `--theme`
+plus a usage example and the gallery link. Discovery is local and
+network-free, so you no longer have to know a theme slug ahead of time.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ npm install -g resume-cli
 | init | Initialize a `resume.json` file. |
 | validate | Schema validation test your `resume.json`. |
 | export path/to/file.html | Export to `.html`, `.pdf`, `.md` or `.txt`. |
+| themes | List the JSON Resume themes installed in `node_modules`. |
 | serve | Serve resume at `http://localhost:4000/`. |
 
 ### `resume --help`
@@ -103,6 +104,27 @@ Options:
 
 - `--format <file type>` Example: `--format pdf`
 - `--theme <name>` Example: `--theme even` (only used for `.html` / `.pdf`)
+
+### `resume themes`
+
+Lists the JSON Resume themes installed in `node_modules` — both in your project
+and globally — so you don't have to know a theme slug ahead of time. It prints
+the slug to pass to `--theme` for `export` / `serve`:
+
+```
+$ resume themes
+Installed themes (2) — pass the slug to --theme:
+  elegant v1.16.1
+  even    v0.6.0
+
+Use it:         resume export resume.html --theme elegant
+Browse the full gallery:  https://jsonresume.org/themes/
+```
+
+If none are installed yet, it points you at how to install one. Discovery is
+local and network-free; browse the full gallery (with screenshots) at
+https://jsonresume.org/themes/ and `npm install jsonresume-theme-<slug>` the one
+you want.
 
 ### `resume serve`
 

--- a/packages/cli/lib/list-themes.js
+++ b/packages/cli/lib/list-themes.js
@@ -1,0 +1,151 @@
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+
+const THEME_PREFIX = 'jsonresume-theme-';
+
+// Read a theme package's `package.json` (best effort). Returns null if the
+// directory is not a readable npm package — keeps discovery dependency-free
+// and resilient to half-installed/broken folders.
+const readThemePkg = (themeDir) => {
+  try {
+    const raw = fs.readFileSync(path.join(themeDir, 'package.json'), 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    return null;
+  }
+};
+
+// List the immediate child directories of a node_modules folder that look like
+// JSON Resume theme packages (`jsonresume-theme-*`). Returns one entry per
+// theme with its slug (the name passed to `--theme`), full package name,
+// version and description. Missing/unreadable folders yield an empty list.
+const listThemesInDir = (nodeModulesDir) => {
+  let entries;
+  try {
+    entries = fs.readdirSync(nodeModulesDir, { withFileTypes: true });
+  } catch (err) {
+    return [];
+  }
+  const themes = [];
+  for (const entry of entries) {
+    // Tolerate environments where `withFileTypes` is unavailable.
+    const name = entry.name || entry;
+    if (typeof name !== 'string' || !name.startsWith(THEME_PREFIX)) {
+      continue;
+    }
+    // Ignore the prefix itself with nothing after it.
+    const slug = name.slice(THEME_PREFIX.length);
+    if (!slug) {
+      continue;
+    }
+    const pkg = readThemePkg(path.join(nodeModulesDir, name));
+    if (!pkg) {
+      continue;
+    }
+    themes.push({
+      slug,
+      name,
+      version: typeof pkg.version === 'string' ? pkg.version : null,
+      description: typeof pkg.description === 'string' ? pkg.description : null,
+    });
+  }
+  return themes;
+};
+
+// Build the list of `node_modules` directories to scan: every `node_modules`
+// from `cwd` up to the filesystem root (covers local + monorepo installs),
+// plus any directories supplied via `extraNodeModules` (e.g. the global root).
+const candidateNodeModules = (cwd, extraNodeModules) => {
+  const dirs = [];
+  let current = path.resolve(cwd);
+  // Walk up the tree collecting node_modules at each level.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    dirs.push(path.join(current, 'node_modules'));
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  for (const extra of extraNodeModules) {
+    if (extra) {
+      dirs.push(extra);
+    }
+  }
+  return dirs;
+};
+
+// Discover installed JSON Resume themes.
+//
+// Scans `node_modules` from the current working directory up the tree plus any
+// `extraNodeModules` (the global install root by default) for
+// `jsonresume-theme-*` packages. Returns a list of unique themes sorted by
+// slug. The first occurrence of a slug wins, so a project-local install
+// shadows a global one — matching how `require.resolve` would pick a theme.
+//
+// Pure and network-free: callers inject `cwd` and `extraNodeModules` in tests.
+const discoverThemes = ({
+  cwd = process.cwd(),
+  extraNodeModules = [],
+} = {}) => {
+  const seen = new Set();
+  const themes = [];
+  for (const dir of candidateNodeModules(cwd, extraNodeModules)) {
+    for (const theme of listThemesInDir(dir)) {
+      if (seen.has(theme.slug)) {
+        continue;
+      }
+      seen.add(theme.slug);
+      themes.push(theme);
+    }
+  }
+  themes.sort((a, b) => a.slug.localeCompare(b.slug));
+  return themes;
+};
+
+// Render the discovered themes as a clean, copy-pasteable block. Each line
+// shows the slug to pass to `--theme`. When nothing is installed we point the
+// user at how to install a theme; either way we link the full gallery.
+const formatThemesList = (themes) => {
+  const lines = [];
+  if (themes.length === 0) {
+    lines.push(chalk.yellow('No JSON Resume themes found in node_modules.'));
+    lines.push(
+      `Install one:    ${chalk.cyan('npm install jsonresume-theme-even')}`,
+    );
+  } else {
+    const count = themes.length;
+    lines.push(
+      chalk.bold(
+        `Installed themes (${count}) — pass the slug to ${chalk.cyan(
+          '--theme',
+        )}:`,
+      ),
+    );
+    const width = themes.reduce((max, t) => Math.max(max, t.slug.length), 0);
+    for (const theme of themes) {
+      const slug = chalk.green(theme.slug.padEnd(width));
+      const version = theme.version ? chalk.dim(` v${theme.version}`) : '';
+      lines.push(`  ${slug}${version}`);
+    }
+    lines.push('');
+    lines.push(
+      `Use it:         ${chalk.cyan(
+        `resume export resume.html --theme ${themes[0].slug}`,
+      )}`,
+    );
+  }
+  lines.push(
+    `Browse the full gallery:  ${chalk.cyan('https://jsonresume.org/themes/')}`,
+  );
+  return lines.join('\n');
+};
+
+module.exports = {
+  THEME_PREFIX,
+  discoverThemes,
+  listThemesInDir,
+  formatThemesList,
+};

--- a/packages/cli/lib/list-themes.test.js
+++ b/packages/cli/lib/list-themes.test.js
@@ -1,0 +1,151 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  discoverThemes,
+  listThemesInDir,
+  formatThemesList,
+} from './list-themes';
+
+// Build a throwaway project directory on the real filesystem whose
+// `node_modules` mirrors a typical install: a couple of real themes, a broken
+// theme folder (no package.json), and unrelated packages that must be ignored.
+const buildFixtureProject = () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-cli-themes-'));
+  const nodeModules = path.join(root, 'node_modules');
+
+  const writePkg = (dirName, pkg) => {
+    const dir = path.join(nodeModules, dirName);
+    fs.mkdirSync(dir, { recursive: true });
+    if (pkg) {
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+    }
+  };
+
+  // Two valid themes (out of alphabetical order to prove sorting).
+  writePkg('jsonresume-theme-even', {
+    name: 'jsonresume-theme-even',
+    version: '0.6.0',
+    description: 'A flat JSON Resume theme.',
+  });
+  writePkg('jsonresume-theme-elegant', {
+    name: 'jsonresume-theme-elegant',
+    version: '1.16.1',
+  });
+  // A theme-prefixed folder with no package.json — half-installed/broken;
+  // must be skipped, not crash discovery.
+  writePkg('jsonresume-theme-broken', null);
+  // Non-theme packages that must never appear in the list.
+  writePkg('chalk', { name: 'chalk', version: '4.1.0' });
+  writePkg('jsonresume-other', { name: 'jsonresume-other', version: '1.0.0' });
+
+  return { root, nodeModules };
+};
+
+describe('list-themes discovery', () => {
+  let fixture;
+
+  beforeAll(() => {
+    fixture = buildFixtureProject();
+  });
+
+  afterAll(() => {
+    fs.rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  it('lists installed jsonresume-theme-* packages by slug, sorted', () => {
+    const themes = discoverThemes({ cwd: fixture.root });
+    expect(themes.map((t) => t.slug)).toEqual(['elegant', 'even']);
+  });
+
+  it('ignores non-theme packages and broken theme folders', () => {
+    const slugs = discoverThemes({ cwd: fixture.root }).map((t) => t.slug);
+    expect(slugs).not.toContain('broken');
+    expect(slugs).not.toContain('other');
+    expect(slugs).not.toContain('chalk');
+  });
+
+  it('captures the package name, version and description of each theme', () => {
+    const themes = discoverThemes({ cwd: fixture.root });
+    const even = themes.find((t) => t.slug === 'even');
+    expect(even).toEqual({
+      slug: 'even',
+      name: 'jsonresume-theme-even',
+      version: '0.6.0',
+      description: 'A flat JSON Resume theme.',
+    });
+    // A theme without a description still resolves, with description null.
+    const elegant = themes.find((t) => t.slug === 'elegant');
+    expect(elegant.version).toEqual('1.16.1');
+    expect(elegant.description).toBeNull();
+  });
+
+  it('returns an empty list when node_modules is missing', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'resume-cli-empty-'));
+    try {
+      expect(discoverThemes({ cwd: empty })).toEqual([]);
+    } finally {
+      fs.rmSync(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('de-duplicates a slug installed in multiple node_modules (local wins)', () => {
+    // A second node_modules (e.g. a global root) also ships `even`, plus a
+    // theme not present locally. The local `even` should win; `global-only`
+    // should be added.
+    const globalRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'resume-cli-global-'),
+    );
+    try {
+      const writeGlobalPkg = (dirName, pkg) => {
+        const dir = path.join(globalRoot, dirName);
+        fs.mkdirSync(dir, { recursive: true });
+        fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+      };
+      writeGlobalPkg('jsonresume-theme-even', {
+        name: 'jsonresume-theme-even',
+        version: '9.9.9',
+      });
+      writeGlobalPkg('jsonresume-theme-global-only', {
+        name: 'jsonresume-theme-global-only',
+        version: '2.0.0',
+      });
+
+      const themes = discoverThemes({
+        cwd: fixture.root,
+        extraNodeModules: [globalRoot],
+      });
+      const slugs = themes.map((t) => t.slug);
+      expect(slugs).toEqual(['elegant', 'even', 'global-only']);
+      // Local install shadows the global one (version stays 0.6.0).
+      expect(themes.find((t) => t.slug === 'even').version).toEqual('0.6.0');
+    } finally {
+      fs.rmSync(globalRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('listThemesInDir returns [] for a non-existent directory', () => {
+    expect(listThemesInDir('/no/such/dir/node_modules')).toEqual([]);
+  });
+});
+
+describe('formatThemesList', () => {
+  it('prints each slug and a usage example when themes are installed', () => {
+    const output = formatThemesList([
+      { slug: 'elegant', name: 'jsonresume-theme-elegant', version: '1.16.1' },
+      { slug: 'even', name: 'jsonresume-theme-even', version: '0.6.0' },
+    ]);
+    expect(output).toContain('Installed themes (2)');
+    expect(output).toContain('elegant');
+    expect(output).toContain('even');
+    expect(output).toContain('--theme elegant');
+    expect(output).toContain('https://jsonresume.org/themes/');
+  });
+
+  it('prints an install hint and the gallery link when nothing is installed', () => {
+    const output = formatThemesList([]);
+    expect(output).toContain('No JSON Resume themes found');
+    expect(output).toContain('npm install jsonresume-theme-even');
+    expect(output).toContain('https://jsonresume.org/themes/');
+  });
+});

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -15,6 +15,25 @@ const chalk = require('chalk');
 const path = require('path');
 const { ThemeNotFoundError, formatThemeNotFound } = require('./theme-errors');
 const { formatOkSummary } = require('./validate-errors');
+const { discoverThemes, formatThemesList } = require('./list-themes');
+
+// Best-effort guess at the global `node_modules` root so `resume themes` also
+// surfaces globally-installed themes (e.g. `npm install -g`). Derived from the
+// node executable path; no network or extra dependency required.
+const globalNodeModules = () => {
+  try {
+    // <prefix>/bin/node -> <prefix>/lib/node_modules (POSIX),
+    // <prefix>/node.exe -> <prefix>/node_modules (Windows).
+    const binDir = path.dirname(process.execPath);
+    const candidates = [
+      path.join(binDir, '..', 'lib', 'node_modules'),
+      path.join(binDir, 'node_modules'),
+    ];
+    return candidates;
+  } catch (err) {
+    return [];
+  }
+};
 
 const normalizeTheme = (value, defaultValue) => {
   const theme = value || defaultValue;
@@ -118,6 +137,19 @@ const normalizeTheme = (value, defaultValue) => {
           );
         },
       );
+    });
+
+  program
+    .command('themes')
+    .description(
+      'List JSON Resume themes installed in node_modules (the slug to pass to --theme). Browse the full gallery at https://jsonresume.org/themes/.',
+    )
+    .action(async () => {
+      const themes = discoverThemes({
+        cwd: process.cwd(),
+        extraNodeModules: globalNodeModules(),
+      });
+      console.log(formatThemesList(themes));
     });
 
   program

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -96,6 +96,10 @@ describe('cli configuration', () => {
                                             need no theme; pick a theme for
                                             .html/.pdf with --theme
                                             (https://jsonresume.org/themes/).
+        themes                              List JSON Resume themes installed in
+                                            node_modules (the slug to pass to
+                                            --theme). Browse the full gallery at
+                                            https://jsonresume.org/themes/.
         serve                               Serve resume at http://localhost:4000/
         help [command]                      display help for command
       "
@@ -153,6 +157,20 @@ describe('cli configuration', () => {
         "✓ /test-resumes/resume.json is valid (thomas)
         "
       `);
+    });
+  });
+  describe('themes', () => {
+    it('lists installed themes by slug and links the gallery', async () => {
+      const { stdout, code } = await run(['themes'], {
+        waitForVolumeExport: false,
+      });
+      expect(code).toEqual(0);
+      // The CLI bundles the `elegant` and `even` themes as dependencies, so
+      // they are always discoverable from the package's node_modules.
+      expect(stdout).toContain('elegant');
+      expect(stdout).toContain('even');
+      expect(stdout).toContain('--theme');
+      expect(stdout).toContain('https://jsonresume.org/themes/');
     });
   });
   describe('export', () => {


### PR DESCRIPTION
## What

Adds a `resume themes` command so users can discover themes without already knowing a slug. Today `resume export --theme X` requires you to know `X` upfront.

It scans `node_modules` (project tree + global root) for `jsonresume-theme-*` packages and prints each slug to pass to `--theme`, with a usage example and a link to the full gallery (https://jsonresume.org/themes/). Discovery is dependency-free and network-free.

```
$ resume themes
Installed themes (2) — pass the slug to --theme:
  elegant v1.16.1
  even    v0.6.0

Use it:         resume export resume.html --theme elegant
Browse the full gallery:  https://jsonresume.org/themes/
```

When nothing is installed it prints an install hint plus the gallery link.

## Changes

- `packages/cli/lib/list-themes.js` — pure, injectable theme-discovery (`discoverThemes`/`listThemesInDir`) + `formatThemesList` renderer. First-occurrence-wins de-dupe so a project-local install shadows a global one (mirrors `require.resolve`).
- `packages/cli/lib/main.js` — wires up the `themes` command; derives the global `node_modules` root from `process.execPath`.
- `packages/cli/lib/list-themes.test.js` — unit tests against a real fixture `node_modules` (valid themes, broken folder, non-theme packages, empty tree, local-vs-global de-dupe).
- `packages/cli/lib/main.test.js` — integration test for the command + updated help snapshot.
- `packages/cli/README.md` — documents the command.
- Minor changeset for `resume-cli`.

## Verification

- `pnpm --filter resume-cli test` green (63 passed, was 54).
- `pnpm --filter resume-cli build` green; smoke: `node build/main.js themes` lists the bundled themes.
- `pnpm turbo lint typecheck prettier` exits 0 (18/18).

Refs #275.

— AI