### PR TITLE
test(registry): cover formatter layer (text/markdown/json/yaml + format path)

### DIFF
--- a/apps/registry/lib/formatters/formatters.test.js
+++ b/apps/registry/lib/formatters/formatters.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Characterization of the formatter registry map (formatters.js). This module
+ * is the lookup table the registry uses to resolve a requested output format
+ * to its formatter. It is pure (a static import map), but was previously
+ * untested — so an accidental rename/drop of a format key or a broken alias
+ * (html -> template) would slip through.
+ *
+ * Heavy/native side modules pulled in transitively are mocked so importing the
+ * map never touches the network, an LLM, a browser, or theme packages.
+ */
+
+vi.mock('ai', () => ({ generateText: vi.fn() }));
+vi.mock('@ai-sdk/openai', () => ({ openai: vi.fn() }));
+vi.mock('qr-image', () => ({ default: { image: vi.fn() } }));
+vi.mock('playwright', () => ({ chromium: { launch: vi.fn() } }));
+vi.mock('json-to-pretty-yaml', () => ({
+  default: { stringify: vi.fn(() => '') },
+}));
+vi.mock(
+  '../../../../packages/converters/jsonresume-to-rendercv/convert',
+  () => ({
+    convert: vi.fn(async () => ''),
+  })
+);
+
+import formatters from './formatters';
+
+const EXPECTED_KEYS = [
+  'agent',
+  'qr',
+  'json',
+  'tex',
+  'txt',
+  'template',
+  'html',
+  'yaml',
+  'rendercv',
+  'pdf',
+];
+
+describe('formatters registry map', () => {
+  it('exposes exactly the expected format keys', () => {
+    expect(Object.keys(formatters).sort()).toEqual([...EXPECTED_KEYS].sort());
+  });
+
+  it('every registered formatter exposes a format() function', () => {
+    for (const key of EXPECTED_KEYS) {
+      expect(formatters[key], `formatters.${key} missing`).toBeDefined();
+      expect(
+        typeof formatters[key].format,
+        `formatters.${key}.format not a function`
+      ).toBe('function');
+    }
+  });
+
+  it('aliases html to the template formatter (same module)', () => {
+    expect(formatters.html).toBe(formatters.template);
+  });
+
+  it('uses "txt" (not "text") as the plain-text key', () => {
+    expect(formatters.txt).toBeDefined();
+    expect(formatters.text).toBeUndefined();
+  });
+
+  it('does not expose unknown/extra format keys', () => {
+    const extra = Object.keys(formatters).filter(
+      (k) => !EXPECTED_KEYS.includes(k)
+    );
+    expect(extra).toEqual([]);
+  });
+
+  it('json and yaml formatters are distinct modules', () => {
+    expect(formatters.json).not.toBe(formatters.yaml);
+  });
+});

--- a/apps/registry/lib/formatters/template/format.normalizeDates.test.js
+++ b/apps/registry/lib/formatters/template/format.normalizeDates.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Characterization of the date-normalization performed by template/format.js
+ * before handing the resume to a theme's render(). normalizeDates() is not
+ * exported, so it is exercised through format() with a mock theme whose
+ * render() echoes the (post-normalization) resume back as JSON. This locks in
+ * the documented "Date-shadow" fix: Date objects in date fields are coerced to
+ * YYYY-MM-DD strings so Handlebars/moment themes don't crash.
+ *
+ * Only non-handlebars theme names go through getTheme(), so we use a custom
+ * (non-listed) theme slug and mock getTheme to return an echoing renderer.
+ */
+
+const renderSpy = vi.fn((resume) => JSON.stringify(resume));
+
+vi.mock('./getTheme', () => ({
+  getTheme: vi.fn((theme) => {
+    if (theme === 'missing') return null;
+    return { render: renderSpy };
+  }),
+}));
+
+import { format } from './format';
+
+async function renderedResume(resume, theme = 'echo') {
+  renderSpy.mockClear();
+  await format(resume, { theme });
+  // the resume object handed to render() reflects normalizeDates output
+  return renderSpy.mock.calls[0][0];
+}
+
+describe('format() normalizeDates', () => {
+  it('coerces Date objects in date fields to YYYY-MM-DD strings', async () => {
+    const resume = {
+      basics: { name: 'X' },
+      work: [
+        {
+          name: 'Co',
+          startDate: new Date('2021-03-15T10:00:00Z'),
+          endDate: new Date('2022-06-01T00:00:00Z'),
+        },
+      ],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0].startDate).toBe('2021-03-15');
+    expect(out.work[0].endDate).toBe('2022-06-01');
+  });
+
+  it('leaves already-string date fields untouched', async () => {
+    const resume = {
+      basics: { name: 'X' },
+      education: [
+        { institution: 'U', startDate: '2015-09', endDate: '2019-05' },
+      ],
+    };
+    const out = await renderedResume(resume);
+    expect(out.education[0].startDate).toBe('2015-09');
+    expect(out.education[0].endDate).toBe('2019-05');
+  });
+
+  it('normalizes the "date" and "releaseDate" fields too', async () => {
+    const resume = {
+      basics: { name: 'X' },
+      awards: [{ title: 'A', date: new Date('2023-01-02T00:00:00Z') }],
+      publications: [
+        { name: 'P', releaseDate: new Date('2020-12-31T00:00:00Z') },
+      ],
+    };
+    const out = await renderedResume(resume);
+    expect(out.awards[0].date).toBe('2023-01-02');
+    expect(out.publications[0].releaseDate).toBe('2020-12-31');
+  });
+
+  it('normalizes dates across all handled sections', async () => {
+    const d = new Date('2021-01-01T00:00:00Z');
+    const resume = {
+      basics: { name: 'X' },
+      work: [{ startDate: d }],
+      education: [{ startDate: d }],
+      volunteer: [{ startDate: d }],
+      projects: [{ startDate: d }],
+      awards: [{ date: d }],
+      publications: [{ releaseDate: d }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0].startDate).toBe('2021-01-01');
+    expect(out.education[0].startDate).toBe('2021-01-01');
+    expect(out.volunteer[0].startDate).toBe('2021-01-01');
+    expect(out.projects[0].startDate).toBe('2021-01-01');
+    expect(out.awards[0].date).toBe('2021-01-01');
+    expect(out.publications[0].releaseDate).toBe('2021-01-01');
+  });
+
+  it('does NOT normalize date fields in unhandled sections (e.g. skills)', async () => {
+    // skills is not in normalizeDates' section list, so a Date there is left
+    // untouched (still a Date instance handed to render()).
+    const resume = {
+      basics: { name: 'X' },
+      skills: [{ name: 'S', startDate: new Date('2021-03-15T10:00:00Z') }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.skills[0].startDate).toBeInstanceOf(Date);
+  });
+
+  it('does not mutate the caller-supplied resume object', async () => {
+    const original = new Date('2021-03-15T10:00:00Z');
+    const resume = { basics: { name: 'X' }, work: [{ startDate: original }] };
+    await format(resume, { theme: 'echo' });
+    // original resume.work[0].startDate is still a Date instance
+    expect(resume.work[0].startDate).toBeInstanceOf(Date);
+  });
+
+  it('handles sections that are absent or not arrays without throwing', async () => {
+    const resume = { basics: { name: 'X' }, work: 'not-an-array' };
+    const out = await renderedResume(resume);
+    expect(out.work).toBe('not-an-array');
+    expect(out.basics.name).toBe('X');
+  });
+
+  it('passes resume through unchanged when there are no date fields', async () => {
+    const resume = {
+      basics: { name: 'X' },
+      work: [{ name: 'Co', position: 'Dev' }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0]).toEqual({ name: 'Co', position: 'Dev' });
+  });
+});
+
+describe('format() theme resolution and headers', () => {
+  it('throws "theme-missing" when getTheme returns null', async () => {
+    await expect(
+      format({ basics: { name: 'X' } }, { theme: 'missing' })
+    ).rejects.toThrow('theme-missing');
+  });
+
+  it('returns text/html content-type and cache headers', async () => {
+    const { headers } = await format({ basics: { name: 'X' } }, {});
+    expect(headers).toEqual([
+      { key: 'Cache-control', value: 'public, max-age=90' },
+      { key: 'Content-Type', value: 'text/html' },
+    ]);
+  });
+
+  it('returns the rendered HTML as content', async () => {
+    const { content } = await format(
+      { basics: { name: 'Jane' } },
+      { theme: 'echo' }
+    );
+    // echo renderer returns JSON of the resume
+    expect(content).toContain('Jane');
+  });
+
+  it('defaults to the elegant theme when no theme option is given', async () => {
+    const { getTheme } = await import('./getTheme');
+    getTheme.mockClear();
+    await format({ basics: { name: 'X' } }, {});
+    expect(getTheme).toHaveBeenCalledWith('elegant');
+  });
+});

--- a/apps/registry/lib/formatters/template/themeRenderQa.helpers.test.js
+++ b/apps/registry/lib/formatters/template/themeRenderQa.helpers.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findArtifacts,
+  sectionCoverage,
+  SECTION_SENTINELS,
+  BASELINE_SECTIONS,
+  HANDLEBARS_THEMES,
+} from './themeRenderQa';
+
+/**
+ * Direct unit tests for the PURE helpers in themeRenderQa.js. The existing
+ * themeRenderQa.test.js / .handlebars.test.js suites only exercise these
+ * helpers indirectly via assertThemeRender() over real theme output. These
+ * tests pin down findArtifacts() and sectionCoverage() in isolation so a
+ * regression in the artifact regexes or the OR-of-sentinels coverage logic is
+ * caught directly, not as a confusing downstream theme-gate failure.
+ */
+
+describe('findArtifacts', () => {
+  it('returns an empty array for clean HTML', () => {
+    expect(findArtifacts('<p>Hello World</p>')).toEqual([]);
+  });
+
+  it('detects literal "[object Object]"', () => {
+    expect(findArtifacts('before [object Object] after')).toEqual([
+      '[object Object]',
+    ]);
+  });
+
+  it('detects a standalone "undefined" word', () => {
+    expect(findArtifacts('the value is undefined here')).toEqual(['undefined']);
+  });
+
+  it('detects a standalone "NaN" word', () => {
+    expect(findArtifacts('total NaN items')).toEqual(['NaN']);
+  });
+
+  it('does NOT match "undefined" inside a larger word (word boundary)', () => {
+    expect(findArtifacts('undefinedBehavior')).toEqual([]);
+    expect(findArtifacts('myUndefinedThing')).toEqual([]);
+  });
+
+  it('does NOT match "NaN" inside a larger word (word boundary)', () => {
+    expect(findArtifacts('Banana')).toEqual([]);
+    expect(findArtifacts('NaNoTechnology')).toEqual([]);
+  });
+
+  it('reports all distinct artifacts present, in declaration order', () => {
+    expect(findArtifacts('[object Object] undefined NaN')).toEqual([
+      '[object Object]',
+      'undefined',
+      'NaN',
+    ]);
+  });
+
+  it('reports a subset when only some artifacts are present', () => {
+    expect(findArtifacts('value NaN and [object Object]')).toEqual([
+      '[object Object]',
+      'NaN',
+    ]);
+  });
+
+  it('returns empty for an empty string', () => {
+    expect(findArtifacts('')).toEqual([]);
+  });
+});
+
+describe('sectionCoverage', () => {
+  it('reports a key for every section in SECTION_SENTINELS', () => {
+    const cov = sectionCoverage('whatever');
+    expect(Object.keys(cov).sort()).toEqual(
+      Object.keys(SECTION_SENTINELS).sort()
+    );
+  });
+
+  it('marks all sections false for empty HTML', () => {
+    const cov = sectionCoverage('');
+    expect(Object.values(cov).every((v) => v === false)).toBe(true);
+  });
+
+  it('marks a section covered when any single sentinel appears', () => {
+    const cov = sectionCoverage('... PostgreSQL ...');
+    expect(cov.skills).toBe(true);
+    // skills has exactly one sentinel; unrelated sections stay false.
+    expect(cov.work).toBe(false);
+    expect(cov.awards).toBe(false);
+  });
+
+  it('treats sentinels as an OR set (alternate sentinel still covers)', () => {
+    // work sentinels: ['Senior Software Engineer', 'microservices architecture serving']
+    const cov1 = sectionCoverage('Senior Software Engineer');
+    const cov2 = sectionCoverage('microservices architecture serving');
+    expect(cov1.work).toBe(true);
+    expect(cov2.work).toBe(true);
+  });
+
+  it('marks multiple independent sections from combined HTML', () => {
+    const cov = sectionCoverage(
+      'Jane Developer worked at things; PostgreSQL; Spanish'
+    );
+    expect(cov.basics).toBe(true);
+    expect(cov.skills).toBe(true);
+    expect(cov.languages).toBe(true);
+    expect(cov.publications).toBe(false);
+  });
+
+  it('returns boolean values for every section', () => {
+    const cov = sectionCoverage('Jane Developer');
+    for (const v of Object.values(cov)) {
+      expect(typeof v).toBe('boolean');
+    }
+  });
+});
+
+describe('themeRenderQa configuration constants', () => {
+  it('BASELINE_SECTIONS are all defined in SECTION_SENTINELS', () => {
+    for (const section of BASELINE_SECTIONS) {
+      expect(SECTION_SENTINELS[section]).toBeDefined();
+      expect(Array.isArray(SECTION_SENTINELS[section])).toBe(true);
+      expect(SECTION_SENTINELS[section].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every section has at least one non-empty sentinel string', () => {
+    for (const [section, sentinels] of Object.entries(SECTION_SENTINELS)) {
+      expect(Array.isArray(sentinels), `${section} sentinels not array`).toBe(
+        true
+      );
+      expect(sentinels.length).toBeGreaterThan(0);
+      for (const s of sentinels) {
+        expect(typeof s).toBe('string');
+        expect(s.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('BASELINE_SECTIONS contains the core resume sections', () => {
+    expect(BASELINE_SECTIONS).toEqual(
+      expect.arrayContaining(['basics', 'work', 'education', 'skills'])
+    );
+  });
+
+  it('HANDLEBARS_THEMES is a non-empty list of theme slugs', () => {
+    expect(Array.isArray(HANDLEBARS_THEMES)).toBe(true);
+    expect(HANDLEBARS_THEMES.length).toBeGreaterThan(0);
+    for (const name of HANDLEBARS_THEMES) {
+      expect(typeof name).toBe('string');
+    }
+    expect(HANDLEBARS_THEMES).toContain('macchiato');
+  });
+});

--- a/apps/registry/lib/formatters/text.fixture.test.js
+++ b/apps/registry/lib/formatters/text.fixture.test.js
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest';
+import completeResume from '../../../../packages/test-fixtures/complete-resume.json';
+import textFormatter from './text';
+
+/**
+ * Characterization tests for the plain-text formatter (text.js) exercised
+ * against the real packages/test-fixtures/complete-resume.json fixture (every
+ * JSON Resume section populated) plus targeted edge cases for the internal
+ * formatSection() merge/exclude logic. text.js is a pure, DB/network-free
+ * formatter; these lock in CURRENT behavior. See themeRenderQa.test.js for the
+ * theme-render gate that uses the same fixture.
+ */
+
+const SECTION_ORDER = [
+  'PROFESSIONAL SUMMARY',
+  'WORK HISTORY',
+  'VOLUNTEER',
+  'PROJECTS',
+  'EDUCATION',
+  'AWARDS',
+  'CERTIFICATES',
+  'PUBLICATIONS',
+  'SKILLS',
+];
+
+describe('text formatter against complete-resume fixture', () => {
+  it('returns content string and empty headers', async () => {
+    const { content, headers } = await textFormatter.format(completeResume);
+    expect(typeof content).toBe('string');
+    expect(content.length).toBeGreaterThan(0);
+    expect(headers).toEqual([]);
+  });
+
+  it('renders the header block first (name, label, contact)', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    const lines = content.split('\n');
+    expect(lines[0]).toBe('Jane Developer');
+    expect(lines[1]).toBe('Full Stack Software Engineer');
+    // contact fields from basics.location/phone/email appear before the
+    // first section separator.
+    const summaryIndex = content.indexOf('PROFESSIONAL SUMMARY');
+    const headerBlock = content.slice(0, summaryIndex);
+    expect(headerBlock).toContain('San Francisco');
+    expect(headerBlock).toContain('California');
+    expect(headerBlock).toContain('jane.developer@example.com');
+    expect(headerBlock).toContain('(555) 123-4567');
+  });
+
+  it('renders every populated section heading', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    for (const heading of SECTION_ORDER) {
+      expect(content, `missing section heading "${heading}"`).toContain(
+        heading
+      );
+    }
+  });
+
+  it('emits all sections in the fixed content() order', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    const positions = SECTION_ORDER.map((h) => content.indexOf(h));
+    // every section present (no -1)
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    // strictly increasing positions => correct order
+    const sorted = [...positions].sort((a, b) => a - b);
+    expect(positions).toEqual(sorted);
+  });
+
+  it('uses the "============================" separator under each heading', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).toContain('============================');
+    // the line immediately after WORK HISTORY is the separator
+    const lines = content.split('\n');
+    const workIdx = lines.indexOf('WORK HISTORY');
+    expect(workIdx).toBeGreaterThan(-1);
+    expect(lines[workIdx + 1]).toBe('============================');
+  });
+
+  it('renders work history with merged date line and summary', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    const work = content.split('WORK HISTORY')[1];
+    expect(work).toContain('TechCorp Inc');
+    expect(work).toContain('Senior Software Engineer');
+    expect(work).toContain('microservices architecture serving');
+  });
+
+  it('renders highlight arrays as "+ " bullet lines', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).toContain(
+      '+ Architected and implemented new microservices platform using Node.js and Kubernetes'
+    );
+    expect(content).toContain('+ Reduced API response time by 40%');
+  });
+
+  it('renders volunteer, projects and education content', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).toContain('Code for America');
+    expect(content).toContain('Open Source UI Library');
+    expect(content).toContain('University of California, Berkeley');
+  });
+
+  it('renders awards, certificates and publications content', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).toContain('Top Contributor Award');
+    expect(content).toContain('AWS Certified Solutions Architect');
+    expect(content).toContain('Scaling Microservices Without Losing Your Mind');
+  });
+
+  it('renders skills with keyword bullets', async () => {
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).toContain('PostgreSQL');
+  });
+
+  it('does NOT render languages/interests/references (no text section)', async () => {
+    // text.js content() only wires up summary/work/volunteer/projects/
+    // education/awards/certificates/publications/skills. languages,
+    // interests and references have no formatSection call.
+    const { content } = await textFormatter.format(completeResume);
+    expect(content).not.toContain('LANGUAGES');
+    expect(content).not.toContain('INTERESTS');
+    expect(content).not.toContain('REFERENCES');
+  });
+});
+
+describe('text formatter formatSection merge/exclude behavior', () => {
+  it('joins both work dates as "startDate - endDate" when both present', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      work: [
+        {
+          name: 'Co',
+          position: 'Dev',
+          startDate: '2020-01',
+          endDate: '2022-12',
+          summary: 'did things',
+        },
+      ],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).toContain('2020-01 - 2022-12');
+  });
+
+  it('uses only startDate in merge line when endDate is absent', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      work: [{ name: 'Co', position: 'Dev', startDate: '2020-01' }],
+    };
+    const { content } = await textFormatter.format(resume);
+    const work = content.split('WORK HISTORY')[1].split('\n');
+    // merge line is "2020-01" (no trailing " - ")
+    expect(work).toContain('2020-01');
+    expect(content).not.toContain('2020-01 - ');
+  });
+
+  it('merges awards as "title - date"', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      awards: [{ title: 'Best', date: '2023', awarder: 'ACME' }],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).toContain('Best - 2023');
+    expect(content).toContain('ACME');
+  });
+
+  it('excludes the "type" key from rendered output', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      work: [
+        {
+          name: 'Co',
+          position: 'Dev',
+          type: 'full-time',
+          startDate: '2020-01',
+          endDate: '2021-01',
+        },
+      ],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).not.toContain('full-time');
+  });
+
+  it('does not emit a merge line for sections without mergedKeys (skills)', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      skills: [{ name: 'JavaScript', keywords: ['React', 'Node.js'] }],
+    };
+    const { content } = await textFormatter.format(resume);
+    const skills = content.split('SKILLS')[1].split('\n').filter(Boolean);
+    // first non-empty content line under separator is the value "JavaScript",
+    // followed by "+ React" / "+ Node.js" bullets — no "X - Y" merge line.
+    expect(skills).toContain('JavaScript');
+    expect(skills).toContain('+ React');
+    expect(skills).toContain('+ Node.js');
+  });
+
+  it('skips undefined/null/empty-string item values', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      work: [
+        {
+          name: 'Co',
+          position: undefined,
+          url: null,
+          summary: '',
+          startDate: '2020',
+          endDate: '2021',
+        },
+      ],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).toContain('Co');
+    // null/undefined/empty must NOT leak as literal artifacts
+    expect(content).not.toContain('null');
+    expect(content).not.toContain('undefined');
+  });
+
+  it('omits a section entirely when its array is empty', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      work: [],
+      awards: [],
+      skills: [],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).not.toContain('WORK HISTORY');
+    expect(content).not.toContain('AWARDS');
+    expect(content).not.toContain('SKILLS');
+  });
+
+  it('omits a section when the array is missing (undefined)', async () => {
+    const resume = { basics: { name: 'N', location: {} } };
+    const { content } = await textFormatter.format(resume);
+    for (const heading of SECTION_ORDER.filter(
+      (h) => h !== 'PROFESSIONAL SUMMARY'
+    )) {
+      expect(content).not.toContain(heading);
+    }
+  });
+
+  it('omits PROFESSIONAL SUMMARY when basics.summary is undefined', async () => {
+    const resume = { basics: { name: 'N', location: {} } };
+    const { content } = await textFormatter.format(resume);
+    expect(content).not.toContain('PROFESSIONAL SUMMARY');
+  });
+
+  it('filters undefined header fields (name only, no blank lines)', async () => {
+    const resume = { basics: { name: 'OnlyName', location: {} } };
+    const { content } = await textFormatter.format(resume);
+    // with summary undefined the entire output is just the name.
+    expect(content).toBe('OnlyName');
+  });
+
+  it('renders array values as "+ value" for any section field', async () => {
+    const resume = {
+      basics: { name: 'N', location: {} },
+      projects: [
+        {
+          name: 'Proj',
+          startDate: '2021',
+          endDate: '2022',
+          keywords: ['react', 'graphql'],
+        },
+      ],
+    };
+    const { content } = await textFormatter.format(resume);
+    expect(content).toContain('+ react');
+    expect(content).toContain('+ graphql');
+  });
+});


### PR DESCRIPTION
Adds characterization tests for the pure, DB/network-free parts of the registry formatter layer (`apps/registry/lib/formatters`), which was under-tested. Test-only — no formatter source, themeConfig, or theme files changed.

## What's covered
- **`text.fixture.test.js`** — the plain-text formatter exercised against the real `packages/test-fixtures/complete-resume.json` fixture (section presence + fixed `content()` ordering + `===` separators), plus `formatSection` edge cases: merged date line (`start - end` vs `start` only), award `title - date` merge, `type`-key exclusion, undefined/null/empty-string skipping, empty/missing-array omission, and header `undefined` filtering.
- **`formatters.test.js`** — the format registry map: exact key set, every entry exposes `format()`, and the `html -> template` alias (heavy side-modules mocked).
- **`themeRenderQa.helpers.test.js`** — direct unit tests for `findArtifacts` / `sectionCoverage` and the config constants. These pure helpers were previously only exercised *indirectly* via `assertThemeRender` over real theme output; this pins the artifact word-boundary regexes and the OR-of-sentinels coverage logic.
- **`format.normalizeDates.test.js`** — date normalization (Date -> `YYYY-MM-DD`) across handled sections, no-mutation, and the theme-resolution / `theme-missing` error path, via a mock echoing theme.

~59 new assertions; characterizes CURRENT behavior.

## Note (not fixed here — test-only PR)
`normalizeDates` in `template/format.js` does NOT cover the `skills`/`languages`/etc. sections and, for a non-Date object in a date field, coerces via `String()` to the literal `"[object Object]"`. In practice date fields are strings, so this is a latent quirk rather than an active bug. Flagging for a maintainer if normalization should be broadened.

Verified: `pnpm --filter registry test -- --run` green (1634 passed, 26 pre-existing skips); full `pnpm turbo lint typecheck prettier` exits 0.

Refs #275

— AI