### PR TITLE
fix(registry): normalizeDates mangling object date values

### DIFF
--- a/apps/registry/lib/formatters/template/format.js
+++ b/apps/registry/lib/formatters/template/format.js
@@ -24,9 +24,11 @@ function normalizeDates(resume) {
         for (const field of dateFields) {
           if (copy[field] instanceof Date) {
             copy[field] = copy[field].toISOString().split('T')[0];
-          } else if (copy[field] && typeof copy[field] === 'object') {
-            copy[field] = String(copy[field]);
           }
+          // Non-Date, non-string values (plain objects, arrays, etc.) are left
+          // untouched. Previously these were String()-coerced, which turned a
+          // malformed object date into the literal "[object Object]" and joined
+          // arrays into comma strings — mangling the value handed to the theme.
         }
         return copy;
       });

--- a/apps/registry/lib/formatters/template/format.normalizeDates.test.js
+++ b/apps/registry/lib/formatters/template/format.normalizeDates.test.js
@@ -126,6 +126,50 @@ describe('format() normalizeDates', () => {
     const out = await renderedResume(resume);
     expect(out.work[0]).toEqual({ name: 'Co', position: 'Dev' });
   });
+
+  it('leaves a malformed (plain object) date value untouched instead of coercing to "[object Object]"', async () => {
+    // Regression: a non-Date object in a date field was String()-coerced to the
+    // literal "[object Object]", which would render as garbage. Such values are
+    // left as-is so the theme can decide how to handle them.
+    const bogus = { year: 2020, month: 3 };
+    const resume = {
+      basics: { name: 'X' },
+      work: [{ name: 'Co', startDate: bogus }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0].startDate).not.toBe('[object Object]');
+    expect(out.work[0].startDate).toEqual({ year: 2020, month: 3 });
+  });
+
+  it('leaves an array date value untouched instead of joining its elements', async () => {
+    // String([...]) silently joins array elements, mangling the value; the
+    // array is now left intact.
+    const resume = {
+      basics: { name: 'X' },
+      work: [{ name: 'Co', endDate: ['2020', '01'] }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0].endDate).toEqual(['2020', '01']);
+  });
+
+  it('leaves a null date value untouched', async () => {
+    const resume = {
+      basics: { name: 'X' },
+      education: [{ institution: 'U', endDate: null }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.education[0].endDate).toBeNull();
+  });
+
+  it('still coerces real Date objects even though they are typeof object', async () => {
+    // Guard: the defensive change must not regress the core Date -> ISO path.
+    const resume = {
+      basics: { name: 'X' },
+      work: [{ name: 'Co', startDate: new Date('2021-03-15T10:00:00Z') }],
+    };
+    const out = await renderedResume(resume);
+    expect(out.work[0].startDate).toBe('2021-03-15');
+  });
 });
 
 describe('format() theme resolution and headers', () => {


### PR DESCRIPTION
## Bug

`normalizeDates()` in `apps/registry/lib/formatters/template/format.js` `String()`-coerced **any** non-Date, non-string object in a date field before handing the resume to a theme's `render()`. This turned:

- a malformed object date (`{ year: 2020 }`) into the literal `"[object Object]"`
- an array date (`['2020','01']`) into a comma-joined string

…both of which render as garbage in a theme.

## Fix

Leave non-Date / non-string date values untouched so the theme decides how to handle them. The core `Date -> YYYY-MM-DD` path (and already-string values) is unchanged.

Per the JSON Resume schema, only `work/education/volunteer/projects/awards/publications` have date fields, so the section list is unchanged (skills/languages correctly excluded).

## Tests

Updated the #410 characterization suite (`format.normalizeDates.test.js`) to assert the corrected behavior, and added regression tests for object / array / null date values plus a guard that real `Date` objects still normalize. The two new object/array tests fail on `master` and pass with this change.

- `pnpm --filter registry test -- --run`: 1638 passed, 26 skipped, 0 failed
- `pnpm turbo lint typecheck prettier`: exits 0

registry is private (no changeset needed).

Refs #275

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date field formatting to preserve non-date values instead of coercing them to invalid string representations, preventing data corruption.

* **Tests**
  * Added regression test coverage for date field handling with various data types including objects, arrays, and null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->