### PR TITLE
fix(cli): friendly errors for missing/malformed resume input

### DIFF
--- a/.changeset/cli-friendly-input-errors.md
+++ b/.changeset/cli-friendly-input-errors.md
@@ -1,0 +1,8 @@
+---
+'resume-cli': patch
+---
+
+`validate` and `export` now print a friendly, stack-trace-free error and exit
+non-zero when the resume file is missing, unreadable, or contains malformed
+JSON/YAML (and when a custom `--schema` fails to load), instead of crashing
+with an unhandled-rejection Node-internal stack trace.

--- a/packages/cli/lib/load-resume.js
+++ b/packages/cli/lib/load-resume.js
@@ -1,0 +1,21 @@
+import chalk from 'chalk';
+import getResume from './get-resume';
+
+// Load the resume from the given path, turning the low-level failures
+// (missing file, unreadable stream, malformed JSON/YAML) into a single
+// friendly, stack-trace-free message. Returns null on failure after printing
+// the message and flagging a non-zero exit code, so callers can bail early
+// instead of leaking an unhandled rejection / Node-internal stack trace.
+const loadResumeOrReport = async (resumePath) => {
+  try {
+    return await getResume({ path: resumePath });
+  } catch (err) {
+    const label = resumePath === '-' ? 'stdin' : resumePath;
+    console.error(chalk.red(`Could not read resume: ${label}`));
+    console.error(err && err.message ? err.message : String(err));
+    process.exitCode = 1;
+    return null;
+  }
+};
+
+export default loadResumeOrReport;

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -3,7 +3,7 @@
 import 'dotenv/config';
 
 import init from './init';
-import getResume from './get-resume';
+import loadResumeOrReport from './load-resume';
 import getSchema from './get-schema';
 import validate from './validate';
 
@@ -94,8 +94,19 @@ const normalizeTheme = (value, defaultValue) => {
     .command('validate')
     .description("Validate your resume's schema")
     .action(async () => {
-      const resume = await getResume({ path: program.resume });
-      const schema = await getSchema({ path: program.schema });
+      const resume = await loadResumeOrReport(program.resume);
+      if (resume === null) {
+        return;
+      }
+      let schema;
+      try {
+        schema = await getSchema({ path: program.schema });
+      } catch (e) {
+        console.error(chalk.red('Could not load schema.'));
+        console.error(e.message || String(e));
+        process.exitCode = 1;
+        return;
+      }
       try {
         await validate({
           resume,
@@ -114,7 +125,10 @@ const normalizeTheme = (value, defaultValue) => {
       'Export locally to .html, .pdf, .md (markdown) or .txt (text). Supply a --format <file format> flag and argument to specify export format. .md and .txt need no theme; pick a theme for .html/.pdf with --theme (https://jsonresume.org/themes/).',
     )
     .action(async (fileName) => {
-      const resume = await getResume({ path: program.resume });
+      const resume = await loadResumeOrReport(program.resume);
+      if (resume === null) {
+        return;
+      }
       exportResume(
         { ...program, resume, fileName },
         (err, fileName, format) => {

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -158,6 +158,31 @@ describe('cli configuration', () => {
         "
       `);
     });
+    it('should print a friendly error and exit non-zero when the resume file is missing', async () => {
+      const { code, stderr } = await run(
+        ['validate', '--resume', '/test-resumes/does-not-exist.json'],
+        { waitForVolumeExport: false, captureStderr: true },
+      );
+      expect(code).toEqual(1);
+      expect(stderr).toContain(
+        'Could not read resume: /test-resumes/does-not-exist.json',
+      );
+      // No raw Node unhandled-rejection stack trace must leak.
+      expect(stderr).not.toContain('triggerUncaughtException');
+      expect(stderr).not.toContain('node:internal');
+    });
+    it('should print a friendly error and exit non-zero when the resume JSON is malformed', async () => {
+      const { code, stderr } = await run(
+        ['validate', '--resume', '/test-resumes/malformed-resume.json'],
+        { waitForVolumeExport: false, captureStderr: true },
+      );
+      expect(code).toEqual(1);
+      expect(stderr).toContain(
+        'Could not read resume: /test-resumes/malformed-resume.json',
+      );
+      expect(stderr).not.toContain('triggerUncaughtException');
+      expect(stderr).not.toContain('node:internal');
+    });
   });
   describe('themes', () => {
     it('lists installed themes by slug and links the gallery', async () => {
@@ -275,6 +300,26 @@ describe('cli configuration', () => {
       expect(stderr).toContain('https://jsonresume.org/themes/');
       // The raw stack trace must not leak to the user.
       expect(stderr).not.toContain('at _default');
+    });
+    it('should print a friendly error and exit non-zero when the resume file is missing', async () => {
+      const { code, stderr } = await run(
+        [
+          'export',
+          '/test-resumes/exported-resume.html',
+          '--resume',
+          '/test-resumes/does-not-exist.json',
+          '--theme',
+          'even',
+        ],
+        { waitForVolumeExport: false, captureStderr: true },
+      );
+      expect(code).toEqual(1);
+      expect(stderr).toContain(
+        'Could not read resume: /test-resumes/does-not-exist.json',
+      );
+      // No raw Node unhandled-rejection stack trace must leak.
+      expect(stderr).not.toContain('triggerUncaughtException');
+      expect(stderr).not.toContain('node:internal');
     });
   });
 });

--- a/packages/cli/lib/test-utils/mocked-volume-builder.js
+++ b/packages/cli/lib/test-utils/mocked-volume-builder.js
@@ -13,6 +13,8 @@ module.exports = ({ mount = '/' } = {}) => {
             name: 123,
           },
         }),
+        // Syntactically broken JSON — exercises the parse-error path.
+        'malformed-resume.json': '{ "basics": { "name": "x" ',
         'resume.json': JSON.stringify({
           basics: {
             name: 'thomas',


### PR DESCRIPTION
## Problem

`resume validate` and `resume export` awaited `getResume` directly in their command actions. A missing/unreadable resume file or malformed JSON/YAML escaped as an **unhandled promise rejection**, dumping a Node-internal stack trace at the user. A custom `--schema` that failed to load did the same.

Repro on `master`:

```
$ resume validate --resume nope.json
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
[Error: ENOENT: no such file or directory, stat 'nope.json'] ...
```

## Fix

Route resume loading through a small `loadResumeOrReport` helper that catches the failure, prints a friendly `Could not read resume: <path>` message (plus the underlying reason) and sets a non-zero exit code. `getSchema` is wrapped the same way. This matches the existing theme-not-found UX.

```
$ resume validate --resume nope.json   # exit 1
Could not read resume: nope.json
ENOENT: no such file or directory, stat 'nope.json'
```

## Tests

New regression tests in `main.test.js` (each fails on `master`, passes here):
- validate: missing file -> exit 1, friendly message, no leaked stack trace
- validate: malformed JSON -> exit 1, friendly message, no leaked stack trace
- export: missing file -> exit 1, friendly message, no leaked stack trace

Full suite green (66 passed). Patch changeset added for `resume-cli`.

Refs #275.

— AI