### PR TITLE
feat(schema): add diverse example resumes (new-grad, career-changer, senior-IC)

### DIFF
--- a/.changeset/schema-example-resumes.md
+++ b/.changeset/schema-example-resumes.md
@@ -1,0 +1,5 @@
+---
+'@jsonresume/schema': minor
+---
+
+Ship three diverse, realistic example resumes under `examples/` (new-grad, career-changer, and senior IC / staff engineer). Each validates against `schema.json` and exercises a broad set of sections, making them useful for theme testing, onboarding, and demonstrating the breadth of the spec.

--- a/packages/schema/examples/career-changer.resume.json
+++ b/packages/schema/examples/career-changer.resume.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Daniel Reyes",
+    "label": "Junior Data Analyst (former Restaurant Manager)",
+    "image": "",
+    "email": "daniel.reyes@example.com",
+    "phone": "(512) 555-0188",
+    "url": "https://danielreyes.example.com",
+    "summary": "After eight years running high-volume restaurants, I retrained as a data analyst to turn my instinct for operations into measurable impact. I completed a part-time analytics bootcamp and three certifications while still working full time, and I now combine SQL, Python, and dashboarding with hard-won people-and-process experience. I'm looking for a first analytics role on a team that values curiosity and an owner's mindset.",
+    "location": {
+      "address": "920 Lavaca Street",
+      "postalCode": "78701",
+      "city": "Austin",
+      "countryCode": "US",
+      "region": "Texas"
+    },
+    "profiles": [
+      {
+        "network": "LinkedIn",
+        "username": "danielreyesdata",
+        "url": "https://www.linkedin.com/in/danielreyesdata"
+      },
+      {
+        "network": "GitHub",
+        "username": "dreyes-data",
+        "url": "https://github.com/dreyes-data"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Freelance",
+      "location": "Austin, TX",
+      "description": "Independent analytics consulting",
+      "position": "Data Analyst (Contract)",
+      "startDate": "2024-08-01",
+      "endDate": "2025-04-01",
+      "summary": "Took on small analytics engagements for local hospitality businesses while transitioning careers.",
+      "highlights": [
+        "Built a Looker Studio sales dashboard for a 3-location cafe group, surfacing a 12% margin gap by daypart",
+        "Wrote SQL models in dbt to standardize point-of-sale data across vendors",
+        "Automated weekly reporting that saved owners roughly 5 hours per week"
+      ]
+    },
+    {
+      "name": "Salt & Cedar Restaurant Group",
+      "location": "Austin, TX",
+      "description": "Regional restaurant group, four locations",
+      "position": "General Manager",
+      "startDate": "2018-03-01",
+      "endDate": "2024-07-01",
+      "summary": "Ran daily operations, staffing, and P&L for a flagship 120-seat restaurant.",
+      "highlights": [
+        "Grew annual revenue 28% over three years while holding food cost flat",
+        "Introduced a spreadsheet-driven scheduling model that cut overtime spend by 18%",
+        "Hired, trained, and retained a team of 35 across front and back of house"
+      ]
+    },
+    {
+      "name": "Café Lumen",
+      "location": "Austin, TX",
+      "description": "Independent neighborhood cafe",
+      "position": "Shift Supervisor",
+      "startDate": "2016-01-01",
+      "endDate": "2018-02-01",
+      "summary": "Led service shifts and managed inventory ordering.",
+      "highlights": [
+        "Reduced waste 9% by tightening par-level ordering",
+        "Trained six baristas who were later promoted"
+      ]
+    }
+  ],
+  "volunteer": [
+    {
+      "organization": "Central Texas Food Bank",
+      "position": "Data Volunteer",
+      "url": "https://www.centraltexasfoodbank.org/",
+      "startDate": "2024-02-01",
+      "endDate": "2025-03-01",
+      "summary": "Helped the operations team make sense of distribution data.",
+      "highlights": [
+        "Cleaned and consolidated three years of distribution spreadsheets into a single queryable dataset",
+        "Built a monthly volunteer-hours report adopted by the program director"
+      ]
+    },
+    {
+      "organization": "Austin Free-Net",
+      "position": "Digital Literacy Tutor",
+      "url": "https://www.austinfree.net/",
+      "startDate": "2023-09-01",
+      "endDate": "2024-06-01",
+      "summary": "Taught spreadsheet and internet basics to adults re-entering the workforce.",
+      "highlights": ["Ran weekly Excel workshops for groups of 8-10 learners"]
+    }
+  ],
+  "education": [
+    {
+      "institution": "Austin Community College",
+      "url": "https://www.austincc.edu/",
+      "area": "Business Administration",
+      "studyType": "Associate of Applied Science",
+      "startDate": "2012-09-01",
+      "endDate": "2014-05-01",
+      "score": "3.5/4.0",
+      "courses": [
+        "Statistics",
+        "Managerial Accounting",
+        "Operations Management"
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "Google Data Analytics Professional Certificate",
+      "date": "2024-05-01",
+      "issuer": "Google / Coursera",
+      "url": "https://www.coursera.org/professional-certificates/google-data-analytics"
+    },
+    {
+      "name": "Databases and SQL for Data Science",
+      "date": "2024-09-01",
+      "issuer": "IBM / Coursera",
+      "url": "https://www.coursera.org/learn/sql-data-science"
+    },
+    {
+      "name": "Tableau Desktop Specialist",
+      "date": "2025-01-01",
+      "issuer": "Tableau",
+      "url": "https://www.tableau.com/learn/certification/desktop-specialist"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Data Analysis",
+      "level": "Intermediate",
+      "keywords": ["SQL", "Python", "pandas", "dbt", "Excel"]
+    },
+    {
+      "name": "Data Visualization",
+      "level": "Intermediate",
+      "keywords": ["Tableau", "Looker Studio", "Matplotlib"]
+    },
+    {
+      "name": "Operations & Leadership",
+      "level": "Advanced",
+      "keywords": [
+        "P&L management",
+        "Scheduling",
+        "Team training",
+        "Vendor negotiation"
+      ]
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    },
+    {
+      "language": "Spanish",
+      "fluency": "Native speaker"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Home Cooking",
+      "keywords": ["Fermentation", "Bread baking"]
+    },
+    {
+      "name": "Cycling",
+      "keywords": ["Gravel", "Commuting"]
+    }
+  ],
+  "references": [
+    {
+      "name": "Priya Natarajan, Owner, Salt & Cedar Restaurant Group",
+      "reference": "Daniel ran our busiest location with a steady hand and a relentless focus on the numbers. When he started teaching himself SQL on nights off, none of us were surprised. He turns data into decisions."
+    }
+  ],
+  "meta": {
+    "canonical": "https://danielreyes.example.com/resume.json",
+    "version": "v1.0.0",
+    "lastModified": "2025-04-20T14:30:00"
+  }
+}

--- a/packages/schema/examples/new-grad.resume.json
+++ b/packages/schema/examples/new-grad.resume.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Maya Okonkwo",
+    "label": "Computer Science Graduate",
+    "image": "",
+    "email": "maya.okonkwo@example.com",
+    "phone": "(206) 555-0142",
+    "url": "https://mayaokonkwo.example.com",
+    "summary": "Recent computer science graduate with a focus on distributed systems and machine learning. Two summer internships building production web services, plus a capstone project deployed for 400+ campus users. Eager to join an engineering team where I can keep learning from senior mentors while shipping real features.",
+    "location": {
+      "address": "417 Maple Avenue, Apt 6",
+      "postalCode": "98105",
+      "city": "Seattle",
+      "countryCode": "US",
+      "region": "Washington"
+    },
+    "profiles": [
+      {
+        "network": "GitHub",
+        "username": "mayaokonkwo",
+        "url": "https://github.com/mayaokonkwo"
+      },
+      {
+        "network": "LinkedIn",
+        "username": "maya-okonkwo",
+        "url": "https://www.linkedin.com/in/maya-okonkwo"
+      }
+    ]
+  },
+  "education": [
+    {
+      "institution": "University of Washington",
+      "url": "https://www.washington.edu/",
+      "area": "Computer Science",
+      "studyType": "Bachelor of Science",
+      "startDate": "2021-09-01",
+      "endDate": "2025-06-01",
+      "score": "3.81/4.0",
+      "courses": [
+        "CSE 451 - Operating Systems",
+        "CSE 444 - Database Systems",
+        "CSE 446 - Machine Learning",
+        "CSE 461 - Computer Networks",
+        "CSE 421 - Algorithms"
+      ]
+    }
+  ],
+  "work": [
+    {
+      "name": "Outreach",
+      "location": "Seattle, WA",
+      "description": "Sales engagement platform",
+      "position": "Software Engineering Intern",
+      "url": "https://www.outreach.io/",
+      "startDate": "2024-06-01",
+      "endDate": "2024-09-01",
+      "summary": "Joined the platform infrastructure team to improve internal developer tooling.",
+      "highlights": [
+        "Built a service-health dashboard in React and TypeScript adopted by three on-call teams",
+        "Cut local test-suite runtime by 35% by parallelizing integration fixtures",
+        "Wrote the onboarding runbook used by the next intern cohort"
+      ]
+    },
+    {
+      "name": "Allen Institute for AI",
+      "location": "Seattle, WA",
+      "description": "Non-profit AI research institute",
+      "position": "Research Intern",
+      "url": "https://allenai.org/",
+      "startDate": "2023-06-01",
+      "endDate": "2023-09-01",
+      "summary": "Supported an NLP research group evaluating retrieval-augmented question answering.",
+      "highlights": [
+        "Implemented a reproducible evaluation harness in Python for three benchmark datasets",
+        "Reduced experiment turnaround from hours to minutes by caching intermediate embeddings"
+      ]
+    }
+  ],
+  "projects": [
+    {
+      "name": "DormSwap",
+      "description": "A campus marketplace for students to buy, sell, and trade dorm essentials.",
+      "highlights": [
+        "Deployed to 400+ active students across two residence halls",
+        "Built with Next.js, PostgreSQL, and Prisma on Vercel",
+        "Designed an image-moderation flow to keep listings safe"
+      ],
+      "keywords": ["Next.js", "PostgreSQL", "Prisma", "Vercel"],
+      "startDate": "2024-09-01",
+      "endDate": "2025-05-01",
+      "url": "https://dormswap.example.com",
+      "roles": ["Full-stack developer", "Team lead"],
+      "entity": "University of Washington Capstone",
+      "type": "application"
+    },
+    {
+      "name": "gradient-viz",
+      "description": "An interactive visualizer that animates gradient descent over 2D loss surfaces.",
+      "highlights": [
+        "Open-sourced with 120+ GitHub stars",
+        "Renders surfaces in WebGL with adjustable learning-rate controls"
+      ],
+      "keywords": ["WebGL", "JavaScript", "Machine Learning"],
+      "startDate": "2024-01-01",
+      "endDate": "2024-03-01",
+      "url": "https://github.com/mayaokonkwo/gradient-viz",
+      "roles": ["Author"],
+      "type": "application"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Programming Languages",
+      "level": "Intermediate",
+      "keywords": ["Python", "TypeScript", "Java", "Go", "SQL"]
+    },
+    {
+      "name": "Web Development",
+      "level": "Intermediate",
+      "keywords": ["React", "Next.js", "Node.js", "REST APIs"]
+    },
+    {
+      "name": "Data & Infrastructure",
+      "level": "Beginner",
+      "keywords": ["PostgreSQL", "Docker", "Git", "AWS"]
+    }
+  ],
+  "awards": [
+    {
+      "title": "Dean's List",
+      "date": "2024-12-01",
+      "awarder": "University of Washington",
+      "summary": "Recognized for academic excellence across four consecutive quarters."
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    },
+    {
+      "language": "Igbo",
+      "fluency": "Conversational"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Open Source",
+      "keywords": ["Hacktoberfest", "Documentation"]
+    },
+    {
+      "name": "Rock Climbing",
+      "keywords": ["Bouldering", "Top rope"]
+    }
+  ],
+  "meta": {
+    "canonical": "https://mayaokonkwo.example.com/resume.json",
+    "version": "v1.0.0",
+    "lastModified": "2025-06-15T09:00:00"
+  }
+}

--- a/packages/schema/examples/senior-engineer.resume.json
+++ b/packages/schema/examples/senior-engineer.resume.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "basics": {
+    "name": "Dr. Lena Vasquez",
+    "label": "Staff Software Engineer, Distributed Systems",
+    "image": "",
+    "email": "lena.vasquez@example.com",
+    "phone": "(415) 555-0117",
+    "url": "https://lenavasquez.example.com",
+    "summary": "Staff engineer with 14 years building large-scale distributed storage and streaming systems. I lead cross-team technical direction, mentor senior engineers, and still spend most of my week in the codebase. My work spans consensus protocols, multi-region data replication, and the boring-but-critical operability that keeps petabyte-scale systems healthy.",
+    "location": {
+      "address": "88 Harrison Street, Unit 1402",
+      "postalCode": "94105",
+      "city": "San Francisco",
+      "countryCode": "US",
+      "region": "California"
+    },
+    "profiles": [
+      {
+        "network": "GitHub",
+        "username": "lvasquez",
+        "url": "https://github.com/lvasquez"
+      },
+      {
+        "network": "Mastodon",
+        "username": "lena",
+        "url": "https://hachyderm.io/@lena"
+      },
+      {
+        "network": "LinkedIn",
+        "username": "lena-vasquez-eng",
+        "url": "https://www.linkedin.com/in/lena-vasquez-eng"
+      }
+    ]
+  },
+  "work": [
+    {
+      "name": "Confluent",
+      "location": "Mountain View, CA",
+      "description": "Data streaming platform built on Apache Kafka",
+      "position": "Staff Software Engineer",
+      "url": "https://www.confluent.io/",
+      "startDate": "2020-02-01",
+      "summary": "Technical lead for the multi-region replication and tiered-storage initiatives.",
+      "highlights": [
+        "Designed the tiered-storage architecture that offloaded 80% of broker disk usage to object stores",
+        "Led a six-engineer working group to ship active-active cluster linking across three cloud regions",
+        "Cut p99 produce latency 40% by reworking the replication fetch path",
+        "Authored the internal design-review rubric now used org-wide"
+      ]
+    },
+    {
+      "name": "Dropbox",
+      "location": "San Francisco, CA",
+      "description": "Cloud storage and collaboration",
+      "position": "Senior Software Engineer",
+      "url": "https://www.dropbox.com/",
+      "startDate": "2015-06-01",
+      "endDate": "2020-01-01",
+      "summary": "Worked on Magic Pocket, Dropbox's exabyte-scale custom storage system.",
+      "highlights": [
+        "Built the erasure-coding pipeline that reduced storage cost per byte by 25%",
+        "Owned the cross-zone repair scheduler responsible for durability SLAs",
+        "Mentored four engineers, two of whom were promoted to senior"
+      ]
+    },
+    {
+      "name": "Rackspace",
+      "location": "San Antonio, TX",
+      "description": "Managed cloud hosting provider",
+      "position": "Software Engineer",
+      "url": "https://www.rackspace.com/",
+      "startDate": "2011-08-01",
+      "endDate": "2015-05-01",
+      "summary": "Contributed to OpenStack Swift, the open-source object storage project.",
+      "highlights": [
+        "Implemented container-sync replication improvements upstreamed to OpenStack Swift",
+        "Reduced cluster rebalance time by redesigning the ring-builder partition assignment"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "institution": "University of Texas at Austin",
+      "url": "https://www.utexas.edu/",
+      "area": "Computer Science",
+      "studyType": "Ph.D.",
+      "startDate": "2006-09-01",
+      "endDate": "2011-06-01",
+      "score": "Dissertation: Consistency Trade-offs in Geo-Replicated Key-Value Stores"
+    },
+    {
+      "institution": "University of Texas at Austin",
+      "url": "https://www.utexas.edu/",
+      "area": "Computer Science",
+      "studyType": "Bachelor of Science",
+      "startDate": "2002-09-01",
+      "endDate": "2006-05-01",
+      "score": "3.9/4.0"
+    }
+  ],
+  "publications": [
+    {
+      "name": "Bounded Staleness for Geo-Replicated Key-Value Stores",
+      "publisher": "USENIX OSDI",
+      "releaseDate": "2014-10-01",
+      "url": "https://www.usenix.org/conference/osdi14",
+      "summary": "A tunable consistency model that bounds replica staleness while preserving low write latency across regions."
+    },
+    {
+      "name": "Operating Tiered Storage at Streaming Scale",
+      "publisher": "ACM Queue",
+      "releaseDate": "2022-07-01",
+      "url": "https://queue.acm.org/",
+      "summary": "Lessons from offloading streaming log segments to object storage without sacrificing read latency."
+    }
+  ],
+  "awards": [
+    {
+      "title": "Best Paper Award",
+      "date": "2014-10-01",
+      "awarder": "USENIX OSDI",
+      "summary": "Recognized for the geo-replication consistency model paper."
+    },
+    {
+      "title": "Distinguished Engineer Spotlight",
+      "date": "2021-12-01",
+      "awarder": "Confluent",
+      "summary": "Internal recognition for technical leadership on the tiered-storage launch."
+    }
+  ],
+  "certificates": [
+    {
+      "name": "AWS Certified Solutions Architect - Professional",
+      "date": "2019-03-01",
+      "issuer": "Amazon Web Services",
+      "url": "https://aws.amazon.com/certification/certified-solutions-architect-professional/"
+    }
+  ],
+  "skills": [
+    {
+      "name": "Distributed Systems",
+      "level": "Master",
+      "keywords": [
+        "Consensus",
+        "Replication",
+        "Erasure coding",
+        "Consistency models"
+      ]
+    },
+    {
+      "name": "Programming Languages",
+      "level": "Master",
+      "keywords": ["Go", "Rust", "Java", "Python", "C++"]
+    },
+    {
+      "name": "Infrastructure",
+      "level": "Advanced",
+      "keywords": ["Kafka", "Kubernetes", "Terraform", "Prometheus", "S3"]
+    }
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "fluency": "Native speaker"
+    },
+    {
+      "language": "Spanish",
+      "fluency": "Fluent"
+    },
+    {
+      "language": "Portuguese",
+      "fluency": "Professional working proficiency"
+    }
+  ],
+  "projects": [
+    {
+      "name": "raft-lab",
+      "description": "A teaching implementation of the Raft consensus protocol with a deterministic network simulator.",
+      "highlights": [
+        "Used in a graduate distributed-systems course at two universities",
+        "Includes a fault-injection harness for partition and clock-skew scenarios"
+      ],
+      "keywords": ["Go", "Raft", "Consensus"],
+      "startDate": "2019-01-01",
+      "url": "https://github.com/lvasquez/raft-lab",
+      "roles": ["Author", "Maintainer"],
+      "type": "application"
+    }
+  ],
+  "interests": [
+    {
+      "name": "Mentoring",
+      "keywords": ["Conference speaking", "Open source"]
+    },
+    {
+      "name": "Cartography",
+      "keywords": ["Topographic maps", "GIS"]
+    }
+  ],
+  "references": [
+    {
+      "name": "Marcus Feng, Engineering Director at Confluent",
+      "reference": "Lena is the engineer other staff engineers go to. She has a rare ability to hold an entire distributed system in her head and still write the cleanest pull request on the team. Her design reviews raised the bar for the whole org."
+    },
+    {
+      "name": "Dr. Anita Bose, Professor of Computer Science, UT Austin",
+      "reference": "Lena was among the strongest doctoral students I have advised. Her OSDI paper continues to be cited, and she has the unusual gift of making hard systems ideas legible to students."
+    }
+  ],
+  "meta": {
+    "canonical": "https://lenavasquez.example.com/resume.json",
+    "version": "v1.0.0",
+    "lastModified": "2025-03-02T11:15:00"
+  }
+}

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -23,7 +23,8 @@
     "sample.job.json",
     "schema.json",
     "job-schema.json",
-    "validator.js"
+    "validator.js",
+    "examples"
   ],
   "dependencies": {
     "jsonschema": "^1.4.1"

--- a/packages/schema/test/examples.spec.js
+++ b/packages/schema/test/examples.spec.js
@@ -1,0 +1,26 @@
+var test = require('tape');
+var { validate } = require('../validator');
+
+// Every example bundled in the package (the diverse personas under examples/
+// plus the canonical sample.resume.json) is shipped in package.json "files"
+// and referenced from docs/themes. They must each validate against schema.json.
+const bundledExamples = {
+  'sample.resume.json': require('../sample.resume.json'),
+  'examples/new-grad.resume.json': require('../examples/new-grad.resume.json'),
+  'examples/career-changer.resume.json': require('../examples/career-changer.resume.json'),
+  'examples/senior-engineer.resume.json': require('../examples/senior-engineer.resume.json'),
+};
+
+Object.keys(bundledExamples).forEach((name) => {
+  test(name + ' validates against schema', (t) => {
+    validate(bundledExamples[name], (err, valid) => {
+      t.equal(
+        err,
+        null,
+        'err should be null' + (err ? ': ' + JSON.stringify(err) : '')
+      );
+      t.true(valid, name + ' is valid');
+    });
+    t.end();
+  });
+});


### PR DESCRIPTION
Adds three realistic example resumes under `packages/schema/examples/`, each validating against `schema.json` and exercising a distinct, broad set of sections:

- `new-grad.resume.json` — education-heavy, projects, internships, minimal work.
- `career-changer.resume.json` — volunteer, certificates, varied work history, a summary explaining the pivot.
- `senior-engineer.resume.json` — deep work history, publications, awards, languages, references.

Useful for theme testing, onboarding, and demonstrating the breadth of the spec.

- `examples/` added to package.json `files` so they ship in the npm package alongside `sample.resume.json` (verified via `npm pack --dry-run`).
- New `test/examples.spec.js` asserts every bundled example (the new ones + `sample.resume.json`) validates via the package validator. Existing tests still pass (433 total).
- MINOR changeset added (published package gains files).

Refs #275.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three example resume files demonstrating the JSON Resume schema in action: new graduate, career-changer, and senior engineer profiles with diverse work history and skill sets.

* **Tests**
  * Added validation tests to ensure all bundled example resumes conform to the schema specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->