### PR TITLE
feat(cli): `resume audit` — ATS-friendliness score via @jsonresume/ats-validator

### DIFF
--- a/.changeset/cli-audit-command.md
+++ b/.changeset/cli-audit-command.md
@@ -1,0 +1,12 @@
+---
+'resume-cli': minor
+---
+
+Add a `resume audit [fileName]` command that scores a resume for ATS (Applicant
+Tracking System) friendliness. It renders the resume to HTML with a theme
+(default `even`), runs `@jsonresume/ats-validator` against the markup, and prints
+an advisory report: an overall score and letter grade, a per-check pass/fail
+breakdown, and recommendations. The audit is advisory — a successful audit
+always exits `0`; only an unreadable resume or unrenderable theme exits non-zero
+(reusing the existing friendly-error path). This is the first user-facing entry
+point for `@jsonresume/ats-validator`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ npm install -g resume-cli
 | init | Initialize a `resume.json` file. |
 | validate | Schema validation test your `resume.json`. |
 | export path/to/file.html | Export to `.html`, `.pdf`, `.md` or `.txt`. |
+| audit | Score your resume for ATS (Applicant Tracking System) friendliness. |
 | themes | List the JSON Resume themes installed in `node_modules`. |
 | serve | Serve resume at `http://localhost:4000/`. |
 
@@ -104,6 +105,45 @@ Options:
 
 - `--format <file type>` Example: `--format pdf`
 - `--theme <name>` Example: `--theme even` (only used for `.html` / `.pdf`)
+
+### `resume audit [fileName]`
+
+Scores your resume for **ATS (Applicant Tracking System) friendliness**. It
+renders your resume to HTML with a theme, runs
+[`@jsonresume/ats-validator`](../ats-validator) against the markup, and prints an
+advisory report: an overall score and letter grade, a per-check pass/fail
+breakdown, and recommendations.
+
+```
+$ resume audit resume.json
+
+ATS score: 88/100  (grade B, excellent)
+9/10 checks passed, 1 need attention
+
+Checks:
+  ✓ Semantic HTML (10/10)
+  ✓ ATS-Friendly Fonts (10/15)
+  ✓ No Table Layouts (15/15)
+  ✗ Single-Column Layout (6/15)
+  ✓ Heading Structure (10/10)
+  ...
+
+Recommendations:
+  - 📋 Single-Column Layout: 6/15 - Review and fix issues in this category
+  - ✅ Great! Your resume is highly ATS-compatible. Minor improvements possible.
+```
+
+The audit is **advisory** — a successful audit always exits `0` regardless of
+score. It only exits non-zero when the resume can't be read or the theme can't
+be rendered (the same friendly errors as `export`).
+
+The file argument is optional; it falls back to `--resume` (default
+`resume.json`). The report is rendered with the bundled `even` theme by default;
+pass `--theme <name>` to audit the markup a specific theme produces.
+
+Options:
+
+- `--theme <name>` Example: `--theme elegant` (defaults to `even`)
 
 ### `resume themes`
 

--- a/packages/cli/lib/ats-validator.js
+++ b/packages/cli/lib/ats-validator.js
@@ -1,0 +1,21 @@
+// Adapter around the ESM-only `@jsonresume/ats-validator` package.
+//
+// The CLI is transpiled to CommonJS by Babel, which rewrites `import()` into a
+// `require()` call. `require()` of a native ES module throws on Node < 22, so
+// we reach for a real dynamic `import()` that Babel leaves untouched by hiding
+// it behind the Function constructor. This keeps the audit command working
+// uniformly across Node 18/20/22 without editing the validator package.
+const nativeImport = new Function('specifier', 'return import(specifier)');
+
+let cached;
+
+// Lazily load and memoize the validator's public API
+// (`validateATS` + `getRecommendations`).
+const loadValidator = async () => {
+  if (!cached) {
+    cached = await nativeImport('@jsonresume/ats-validator');
+  }
+  return cached;
+};
+
+module.exports = { loadValidator };

--- a/packages/cli/lib/audit.js
+++ b/packages/cli/lib/audit.js
@@ -1,0 +1,99 @@
+import chalk from 'chalk';
+import renderHTML from './render-html';
+import { ThemeNotFoundError, formatThemeNotFound } from './theme-errors';
+import { loadValidator } from './ats-validator';
+
+// Map a coarse ATS-compatibility band to a chalk colorizer so the headline
+// score reads at a glance.
+const colorForCompatibility = (compatibility) => {
+  switch (compatibility) {
+    case 'excellent':
+      return chalk.green;
+    case 'good':
+      return chalk.cyan;
+    case 'fair':
+      return chalk.yellow;
+    default:
+      return chalk.red;
+  }
+};
+
+// Build the human-readable report lines from a validateATS() result. Kept pure
+// (no console / no process) so it is trivially unit-testable.
+export const formatAuditReport = (result, recommendations) => {
+  const color = colorForCompatibility(result.atsCompatibility);
+  const lines = [];
+
+  lines.push('');
+  lines.push(
+    color(
+      `ATS score: ${result.score}/100  (grade ${result.grade}, ${result.atsCompatibility})`,
+    ),
+  );
+  lines.push(
+    chalk.gray(
+      `${result.passed}/${result.checks.length} checks passed, ${result.failed} need attention`,
+    ),
+  );
+  lines.push('');
+  lines.push(chalk.bold('Checks:'));
+  result.checks.forEach((check) => {
+    const mark = check.passed ? chalk.green('✓') : chalk.red('✗');
+    lines.push(`  ${mark} ${check.name} (${check.score}/${check.maxScore})`);
+  });
+
+  if (recommendations.length > 0) {
+    lines.push('');
+    lines.push(chalk.bold('Recommendations:'));
+    recommendations.forEach((rec) => {
+      lines.push(`  - ${rec}`);
+    });
+  }
+
+  lines.push('');
+  return lines.join('\n');
+};
+
+// Run an ATS-friendliness audit: render the resume to HTML with `themePath`,
+// score it with @jsonresume/ats-validator, and print an advisory report.
+//
+// `resume` is an already-loaded/parsed resume object (callers reuse the shared
+// loader). Render/validator failures are reported through the friendly error
+// path and surfaced via a non-zero exit; a successful audit always exits 0 —
+// the score is advisory, not a gate.
+const audit = async ({ resume, themePath, log = console.log }) => {
+  let html;
+  try {
+    html = await renderHTML({ resume, themePath });
+  } catch (err) {
+    if (err instanceof ThemeNotFoundError) {
+      console.error(formatThemeNotFound(err.theme));
+    } else {
+      console.error(chalk.red(err && err.message ? err.message : String(err)));
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  let result;
+  let recommendations;
+  try {
+    const { validateATS, getRecommendations } = await loadValidator();
+    result = validateATS(html);
+    recommendations = getRecommendations(result);
+  } catch (err) {
+    console.error(
+      chalk.red(
+        `Could not audit resume: ${
+          err && err.message ? err.message : String(err)
+        }`,
+      ),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  log(formatAuditReport(result, recommendations));
+};
+
+export default audit;

--- a/packages/cli/lib/audit.test.js
+++ b/packages/cli/lib/audit.test.js
@@ -1,0 +1,113 @@
+import { spawn, exec as execCB } from 'child_process';
+import streamToString from 'stream-to-string';
+import { promisify } from 'util';
+import packageJson from '../package.json';
+import { formatAuditReport } from './audit';
+
+const exec = promisify(execCB);
+
+// Spawn the built CLI through the in-memory volume test entry (same harness as
+// main.test.js) so `audit` exercises the real load -> render -> validate path.
+const run = async (argv, { captureStderr = false } = {}) => {
+  let exitCode;
+  const child = spawn(
+    process.execPath,
+    ['build/test-utils/cli-test-entry.js', ...argv],
+    {
+      stdio: ['pipe', 'pipe', captureStderr ? 'pipe' : 2, 'ipc'],
+    },
+  );
+  const exited = new Promise((resolve) => {
+    child.on('exit', (code) => {
+      exitCode = code;
+      resolve();
+    });
+  });
+  child.stdin.end();
+  const stdout = await streamToString(child.stdout);
+  const stderr = captureStderr ? await streamToString(child.stderr) : '';
+  await exited;
+  return { code: exitCode, stdout, stderr };
+};
+
+describe('formatAuditReport', () => {
+  const result = {
+    score: 85,
+    grade: 'B',
+    atsCompatibility: 'excellent',
+    passed: 1,
+    failed: 1,
+    checks: [
+      { name: 'Semantic HTML', score: 10, maxScore: 10, passed: true },
+      { name: 'Single-Column Layout', score: 6, maxScore: 15, passed: false },
+    ],
+  };
+
+  it('renders the headline score, grade, per-check marks and recommendations', () => {
+    const report = formatAuditReport(result, ['fix the layout']);
+    expect(report).toContain('ATS score: 85/100');
+    expect(report).toContain('grade B');
+    expect(report).toContain('1/2 checks passed');
+    expect(report).toContain('Semantic HTML (10/10)');
+    expect(report).toContain('Single-Column Layout (6/15)');
+    expect(report).toContain('Recommendations:');
+    expect(report).toContain('fix the layout');
+  });
+
+  it('omits the recommendations block when there are none', () => {
+    const report = formatAuditReport(result, []);
+    expect(report).not.toContain('Recommendations:');
+  });
+});
+
+describe('audit command', () => {
+  beforeAll(() => exec(packageJson.scripts.prepare));
+
+  it('prints a score and at least one recommendation for the sample resume, exit 0', async () => {
+    const { code, stdout } = await run([
+      'audit',
+      '/test-resumes/resume.json',
+      // `even` is bundled and renders minimal resumes; the default `elegant`
+      // theme requires a `basics.location`.
+      '--theme',
+      'even',
+    ]);
+    expect(code).toEqual(0);
+    expect(stdout).toMatch(/ATS score: \d+\/100/);
+    expect(stdout).toContain('grade');
+    expect(stdout).toContain('Checks:');
+    // The validator always returns at least one check; the sample resume also
+    // surfaces a recommendation, proving the recommendations path is wired.
+    expect(stdout).toContain('Recommendations:');
+  });
+
+  it('uses the bundled `even` theme by default (no --theme needed)', async () => {
+    const { code, stdout } = await run(['audit', '/test-resumes/resume.json']);
+    expect(code).toEqual(0);
+    expect(stdout).toMatch(/ATS score: \d+\/100/);
+  });
+
+  it('prints a friendly error and exits non-zero when the resume file is missing', async () => {
+    const { code, stderr } = await run(
+      ['audit', '/test-resumes/does-not-exist.json', '--theme', 'even'],
+      { captureStderr: true },
+    );
+    expect(code).toEqual(1);
+    expect(stderr).toContain(
+      'Could not read resume: /test-resumes/does-not-exist.json',
+    );
+    // No raw Node unhandled-rejection stack trace must leak.
+    expect(stderr).not.toContain('triggerUncaughtException');
+    expect(stderr).not.toContain('node:internal');
+  });
+
+  it('prints a friendly, actionable message and exits non-zero for an uninstalled theme', async () => {
+    const { code, stderr } = await run(
+      ['audit', '/test-resumes/resume.json', '--theme', 'nonexistent-xyz'],
+      { captureStderr: true },
+    );
+    expect(code).toEqual(1);
+    expect(stderr).toContain("Theme 'nonexistent-xyz' not found.");
+    expect(stderr).toContain('https://jsonresume.org/themes/');
+  });
+});

--- a/packages/cli/lib/main.js
+++ b/packages/cli/lib/main.js
@@ -6,6 +6,7 @@ import init from './init';
 import loadResumeOrReport from './load-resume';
 import getSchema from './get-schema';
 import validate from './validate';
+import audit from './audit';
 
 const pkg = require('../package.json');
 const exportResume = require('./export-resume');
@@ -164,6 +165,27 @@ const normalizeTheme = (value, defaultValue) => {
         extraNodeModules: globalNodeModules(),
       });
       console.log(formatThemesList(themes));
+    });
+
+  program
+    .command('audit [resumeFile]')
+    .description(
+      'Score your resume for ATS (Applicant Tracking System) friendliness: renders it with a theme to HTML, runs @jsonresume/ats-validator, and prints a score, per-check results and recommendations. Advisory only (always exits 0 on success). Pick a theme with --theme (default: even).',
+    )
+    .action(async (resumeFile) => {
+      const resume = await loadResumeOrReport(resumeFile || program.resume);
+      if (resume === null) {
+        return;
+      }
+      // The global `-t/--theme` option (default: elegant) is shared by every
+      // command, but `elegant` throws on minimal resumes. Default `audit` to
+      // the bundled, robust `even` theme unless the user explicitly asked for
+      // a theme on the command line.
+      const themeGiven = process.argv.some(
+        (arg) => arg === '-t' || arg === '--theme',
+      );
+      const themePath = themeGiven ? program.theme : 'jsonresume-theme-even';
+      await audit({ resume, themePath });
     });
 
   program

--- a/packages/cli/lib/main.test.js
+++ b/packages/cli/lib/main.test.js
@@ -100,6 +100,14 @@ describe('cli configuration', () => {
                                             node_modules (the slug to pass to
                                             --theme). Browse the full gallery at
                                             https://jsonresume.org/themes/.
+        audit [resumeFile]                  Score your resume for ATS (Applicant
+                                            Tracking System) friendliness: renders it
+                                            with a theme to HTML, runs
+                                            @jsonresume/ats-validator, and prints a
+                                            score, per-check results and
+                                            recommendations. Advisory only (always
+                                            exits 0 on success). Pick a theme with
+                                            --theme (default: even).
         serve                               Serve resume at http://localhost:4000/
         help [command]                      display help for command
       "

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "resume": "build/main.js"
   },
   "dependencies": {
+    "@jsonresume/ats-validator": "workspace:*",
     "@jsonresume/schema": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@jsonresume/ats-validator':
+        specifier: workspace:*
+        version: link:../ats-validator
       '@jsonresume/schema':
         specifier: workspace:*
         version: link:../schema


### PR DESCRIPTION
Adds `resume audit [fileName]` — the first user-facing entry point for `@jsonresume/ats-validator` (previously library-only).

It loads + renders the resume to HTML with a theme, runs the ATS validator, and prints an advisory report: overall score/grade, per-check pass/fail, and recommendations.

- Advisory: a successful audit always exits 0 regardless of score. Only an unreadable resume or unrenderable theme exits non-zero, reusing the existing friendly-error path (`Could not read resume` / `Theme not found`).
- Defaults to the bundled `even` theme (renders minimal resumes; the global default `elegant` requires `basics.location`); `--theme <name>` overrides.
- `@jsonresume/ats-validator` is ESM-only and the CLI transpiles to CJS, so it loads through a tiny adapter doing a real dynamic `import()` (hidden from Babel's import→require rewrite) — works on Node 18/20/22 without touching the validator package.

Tests: unit (`formatAuditReport`) + integration against the bundled sample resume + `even` theme (score + recommendations, exit 0), plus missing-file (exit 1, friendly message) and uninstalled-theme cases. Full suite green (72 tests). Minor changeset for `resume-cli`.

Refs #275.

— AI