### PR TITLE
docs(ecosystem): READMEs for @jsonresume/types, utils, sample-data

### DIFF
--- a/.changeset/ecosystem-readme-sample-data.md
+++ b/.changeset/ecosystem-readme-sample-data.md
@@ -1,0 +1,7 @@
+---
+'@jsonresume/sample-data': patch
+---
+
+Add a README documenting the `completeResume`, `minimalResume`, and
+`resumeSample` exports with install and theme-test usage examples, so the
+npmjs.com page is no longer bare. (#421)

--- a/.changeset/ecosystem-readme-types.md
+++ b/.changeset/ecosystem-readme-types.md
@@ -1,0 +1,7 @@
+---
+'@jsonresume/types': patch
+---
+
+Add a README documenting the exported interfaces (`Resume`, `WorkItem`,
+`JobDescription`, etc.) with install and TypeScript usage examples, so the
+npmjs.com page is no longer bare. (#421)

--- a/.changeset/ecosystem-readme-utils.md
+++ b/.changeset/ecosystem-readme-utils.md
@@ -1,0 +1,7 @@
+---
+'@jsonresume/utils': patch
+---
+
+Add a README documenting every export grouped by subpath (`.`, `./dates`,
+`./metrics`, `./url`) with install and usage examples, so the npmjs.com page is
+no longer bare. (#421)

--- a/packages/sample-data/README.md
+++ b/packages/sample-data/README.md
@@ -1,0 +1,69 @@
+# @jsonresume/sample-data
+
+Sample [JSON Resume](https://jsonresume.org) fixtures for tests, demos, and theme development.
+
+Ships a complete every-section resume plus a minimal subset, so you can render or validate against realistic data without hand-rolling a fixture.
+
+## Install
+
+```bash
+npm install --save-dev @jsonresume/sample-data
+```
+
+## API
+
+Named exports from the root (`.`):
+
+| Export | Description |
+| --- | --- |
+| `completeResume` | An every-section resume (`basics` + all 12 standard sections). The canonical fixture used by the registry theme-render QA gate. |
+| `minimalResume` | A small `basics` + first `work` / `education` / `skills` subset, derived from `completeResume` so it never drifts from the canonical shape. |
+| `resumeSample` | A second, fuller sample resume kept alongside the complete fixture. |
+
+A default export bundles all three: `{ completeResume, minimalResume, resumeSample }`.
+
+The raw JSON is also reachable directly:
+
+```js
+import complete from '@jsonresume/sample-data/complete-resume.json';
+import sample from '@jsonresume/sample-data/resume-sample.json';
+```
+
+## Usage
+
+Render a theme against the complete fixture in a test:
+
+```js
+import { completeResume } from '@jsonresume/sample-data';
+import { render } from 'jsonresume-theme-flat';
+
+test('theme renders every section', () => {
+  const html = render(completeResume);
+  expect(html).toContain(completeResume.basics.name);
+});
+```
+
+Use the minimal fixture for fast, focused tests:
+
+```js
+import { minimalResume } from '@jsonresume/sample-data';
+
+expect(minimalResume.work).toHaveLength(1);
+expect(minimalResume.basics).toBeDefined();
+```
+
+Import the default export when you want everything at once:
+
+```js
+import samples from '@jsonresume/sample-data';
+
+const { completeResume, minimalResume, resumeSample } = samples;
+```
+
+## Ecosystem
+
+Part of the [JSON Resume](https://jsonresume.org) ecosystem. See the roadmap and related packages in [jsonresume/jsonresume.org#421](https://github.com/jsonresume/jsonresume.org/issues/421).
+
+## License
+
+MIT

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,85 @@
+# @jsonresume/types
+
+TypeScript types for the [JSON Resume](https://jsonresume.org) and Job schemas, generated from `@jsonresume/schema`.
+
+This is a **types-only** package: the runtime entry point is intentionally empty and the interfaces are emitted (as `.d.ts`) from the canonical schema, so they never drift from the spec.
+
+## Install
+
+```bash
+npm install --save-dev @jsonresume/types
+```
+
+## API
+
+A single root export (`.`) ships the following interfaces and type aliases.
+
+### Resume
+
+| Type | Description |
+| --- | --- |
+| `Resume` | The full JSON Resume document. All sections are optional; unknown keys are allowed. |
+| `ResumeBasics` | `basics` — name, label, email, phone, url, summary, location, profiles. |
+| `ResumeLocation` | The `basics.location` object (address, city, region, countryCode, postalCode). |
+| `ResumeProfile` | An entry in `basics.profiles` (network, username, url). |
+| `WorkItem` | An entry in `work`. |
+| `VolunteerItem` | An entry in `volunteer`. |
+| `EducationItem` | An entry in `education`. |
+| `AwardItem` | An entry in `awards`. |
+| `CertificateItem` | An entry in `certificates`. |
+| `PublicationItem` | An entry in `publications`. |
+| `SkillItem` | An entry in `skills`. |
+| `LanguageItem` | An entry in `languages`. |
+| `InterestItem` | An entry in `interests`. |
+| `ReferenceItem` | An entry in `references`. |
+| `ProjectItem` | An entry in `projects`. |
+| `ResumeMeta` | The `meta` object (canonical, version, lastModified). |
+| `Iso8601` | String alias for partial ISO-8601 dates, e.g. `2014-06-29` or `2023-04`. |
+
+### Job
+
+| Type | Description |
+| --- | --- |
+| `JobDescription` | A job posting in the JSON Resume Job schema (title, company, type, location, remote, salary, responsibilities, qualifications, skills, meta). |
+
+## Usage
+
+Type a resume object you load from disk or an API:
+
+```ts
+import type { Resume } from '@jsonresume/types';
+
+const resume: Resume = JSON.parse(await readFile('resume.json', 'utf8'));
+
+console.log(resume.basics?.name);
+```
+
+Annotate a function that operates on a single section:
+
+```ts
+import type { WorkItem } from '@jsonresume/types';
+
+function formatRole(job: WorkItem): string {
+  return `${job.position ?? 'Unknown'} @ ${job.name ?? 'Unknown'}`;
+}
+```
+
+Type a job posting with the Job schema:
+
+```ts
+import type { JobDescription } from '@jsonresume/types';
+
+const job: JobDescription = {
+  title: 'Web Developer',
+  company: 'Microsoft',
+  remote: 'Hybrid',
+};
+```
+
+## Ecosystem
+
+Part of the [JSON Resume](https://jsonresume.org) ecosystem. See the roadmap and related packages in [jsonresume/jsonresume.org#421](https://github.com/jsonresume/jsonresume.org/issues/421).
+
+## License
+
+MIT

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,0 +1,114 @@
+# @jsonresume/utils
+
+Framework-free pure utilities for [JSON Resume](https://jsonresume.org): date formatting, derived metrics, URL safety, and resume-shape helpers.
+
+No React, no styled-components, no side effects — safe to use anywhere: server, CLI, browser, or inside a theme.
+
+## Install
+
+```bash
+npm install @jsonresume/utils
+```
+
+## API
+
+Everything is re-exported from the root (`.`) for convenience, and also available via focused subpaths.
+
+### Root (`@jsonresume/utils`)
+
+Re-exports all of the functions below, plus two resume-shape helpers:
+
+| Function | Description |
+| --- | --- |
+| `formatLocation(location)` | Join `city, region, countryCode` into one display line (empty parts dropped). |
+| `normalizeResume(resume)` | Return a copy with all 12 standard sections present (`basics` as `{}`, arrays as `[]`); never mutates the input. |
+
+### Dates (`@jsonresume/utils/dates`)
+
+| Function | Description |
+| --- | --- |
+| `formatDateRange({ startDate, endDate, format?, locale?, numberingSystem?, presentLabel? })` | Locale-aware date range via `Intl.DateTimeFormat`. A `null` `endDate` renders `Present`; a missing `endDate` renders a single date. |
+| `getRelativeTime(date, ago?)` | Human relative time, e.g. `6 years ago`. |
+| `getDuration(startDate, endDate?)` | Duration between two dates, e.g. `2 years, 6 months` (`endDate` defaults to now). |
+| `normalizeDates(resume)` | Shallow copy with any `Date`-valued date fields stringified to `YYYY-MM-DD`. |
+
+### Metrics (`@jsonresume/utils/metrics`)
+
+| Function | Description |
+| --- | --- |
+| `calculateTotalExperience(work)` | Total years of professional experience (rounded to nearest year). |
+| `calculateCurrentRoleExperience(work)` | Years in the current/most-recent role (1 decimal). |
+| `countCareerPositions(work)` | Number of distinct `position` titles held. |
+| `getCareerProgressionRate(work)` | Average years per position. |
+| `countTotalHighlights(work)` | Total `highlights` across all work entries. |
+| `countCompanies(work)` | Number of unique company names. |
+| `countProjects(projects)` | Number of projects. |
+| `countPublications(publications)` | Number of publications. |
+| `countAwards(awards)` | Number of awards. |
+| `countTotalSkills(skills)` | Total skill `keywords` across all categories. |
+| `countSkillCategories(skills)` | Number of skill categories. |
+| `countLanguages(languages)` | Number of languages. |
+| `calculateEducationYears(education)` | Total years of education (rounded). |
+| `getHighestDegree(education)` | The highest degree by `studyType` ranking (e.g. `PhD`). |
+| `calculateVolunteerYears(volunteer)` | Total volunteer years (rounded). |
+| `getUniqueIndustries(work)` | Array of unique `industry` values. |
+| `getCurrentEmployer(work)` | The current (no `endDate`) or most-recent work entry, or `null`. |
+| `isCurrentlyEmployed(work)` | `true` if any work entry has no `endDate`. |
+| `calculateKeyMetrics(resume)` | Dashboard-ready array of `{ label, value }` summarizing the resume. |
+
+### URL safety (`@jsonresume/utils/url`)
+
+| Function | Description |
+| --- | --- |
+| `safeUrl(url)` | Block `javascript:`/`data:`/`vbscript:` schemes; return a safe URL or `null`. |
+| `getLinkRel(url, openInNewTab?)` | Return `noopener noreferrer` for external links opened in a new tab. |
+| `sanitizeHtml(html)` | Escape HTML-significant characters to prevent XSS. |
+| `isExternalUrl(url, currentOrigin?)` | `true` if the URL points to a different origin. |
+| `formatUrlForDisplay(url)` | Strip the protocol and trailing slash, e.g. `example.com/blog`. |
+
+## Usage
+
+Compute headline metrics from a resume:
+
+```js
+import {
+  calculateTotalExperience,
+  getHighestDegree,
+  formatDateRange,
+} from '@jsonresume/utils';
+
+const years = calculateTotalExperience(resume.work);
+const degree = getHighestDegree(resume.education);
+const range = formatDateRange({ startDate: '2020-01-15', endDate: null });
+// range === 'Jan 2020 - Present'
+```
+
+Import from a focused subpath to keep things tight:
+
+```js
+import { safeUrl, getLinkRel } from '@jsonresume/utils/url';
+
+const href = safeUrl(profile.url); // null if dangerous
+const rel = getLinkRel(href, true); // 'noopener noreferrer'
+```
+
+Build a dashboard summary:
+
+```js
+import { calculateKeyMetrics } from '@jsonresume/utils/metrics';
+
+for (const { label, value } of calculateKeyMetrics(resume)) {
+  console.log(`${label}: ${value}`);
+}
+// Years Experience: 8
+// Companies: 5
+// Projects: 12
+```
+
+## Ecosystem
+
+Part of the [JSON Resume](https://jsonresume.org) ecosystem. The styled date/link components in `@jsonresume/core` are built on top of these functions. See the roadmap and related packages in [jsonresume/jsonresume.org#421](https://github.com/jsonresume/jsonresume.org/issues/421).
+
+## License
+
+MIT


### PR DESCRIPTION
The newly-published `@jsonresume/types`, `@jsonresume/utils`, and `@jsonresume/sample-data` shipped with no README, so their npmjs.com pages render empty. This adds a proper README for each, documenting the **real** public API (read from source / `dist/index.d.ts`, no invented exports).

## What's in each README
- **types** — the exported interfaces (`Resume`, section item types, `JobDescription`, `Iso8601`) + TS usage examples.
- **utils** — every export grouped by subpath (`.`, `./dates`, `./metrics`, `./url`), with signatures and runnable examples (`calculateTotalExperience`, `formatDateRange`, `safeUrl`, `calculateKeyMetrics`, ...).
- **sample-data** — `completeResume`, `minimalResume`, `resumeSample`, plus a theme-test example using a named `render` import.

Each ships with a **patch** changeset so the README is published to npm.

Note: `README.md` is in `.prettierignore`, so formatting isn't gated — files were still run through pinned prettier 2.8.8 to keep them clean.

Verified: `pnpm turbo lint typecheck prettier` exit 0 (21/21 tasks).

Refs #421

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive READMEs for three ecosystem packages with installation instructions and usage examples
  * Documented available sample data fixtures and utility functions for developers
  * Improved npmjs.com package pages with API references and integration guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->