### PR TITLE
feat(ats-validator): public getGrade + ./constants subpath

### DIFF
--- a/.changeset/ats-validator-public-constants.md
+++ b/.changeset/ats-validator-public-constants.md
@@ -1,0 +1,10 @@
+---
+'@jsonresume/ats-validator': minor
+---
+
+Promote internal pure pieces to the public API for reuse by library authors:
+
+- Export `getGrade` from the package root (maps a 0-100 score to an A-F letter grade).
+- Add a new `@jsonresume/ats-validator/constants` subpath exporting the reusable tables and regexes used by the checks: `ATS_FRIENDLY_FONTS`, `ATS_BAD_FONTS`, `ICON_FONT_TOKENS`, `ICON_FONT_FAMILIES`, `EMOJI_RE`, `PRIVATE_USE_RE`, `EMAIL_RE`, `PHONE_RE`, and the `countDigits` helper.
+
+`validateATS` and `getRecommendations` are unchanged. The constants are re-exported from the existing check modules, so they never drift from what the validator actually uses.

--- a/packages/ats-validator/README.md
+++ b/packages/ats-validator/README.md
@@ -95,6 +95,47 @@ const recs = getRecommendations(result);
 // ]
 ```
 
+### `getGrade(percentage: number): 'A' | 'B' | 'C' | 'D' | 'F'`
+
+Maps a 0-100 score to the same letter grade `validateATS` reports. Useful when
+you compute a score yourself, or want to grade an arbitrary percentage.
+
+```javascript
+import { getGrade } from '@jsonresume/ats-validator';
+
+getGrade(95); // 'A'  (>= 90)
+getGrade(82); // 'B'  (80-89)
+getGrade(74); // 'C'  (70-79)
+getGrade(63); // 'D'  (60-69)
+getGrade(40); // 'F'  (< 60)
+```
+
+## Reusable constants (`@jsonresume/ats-validator/constants`)
+
+The building blocks that power the individual checks are exported from a
+dedicated `./constants` subpath so library authors can reuse them (e.g. to lint
+or highlight ATS issues) without running the full validator. These are
+re-exported from the check modules — the values never drift from what
+`validateATS` actually uses.
+
+```javascript
+import {
+  ATS_FRIENDLY_FONTS, // string[] — lowercase ATS-safe font names
+  ATS_BAD_FONTS, // string[] — lowercase decorative fonts to avoid
+  ICON_FONT_TOKENS, // string[] — icon-font class tokens (fa, material-icons, …)
+  ICON_FONT_FAMILIES, // string[] — icon-font family names referenced in CSS
+  EMOJI_RE, // RegExp (global) — emoji / dingbat ranges
+  PRIVATE_USE_RE, // RegExp — Private Use Area code points (leaked icon glyphs)
+  EMAIL_RE, // RegExp — email-address detection
+  PHONE_RE, // RegExp — phone-number detection
+  countDigits, // (str: string) => number — digit count helper for phone checks
+} from '@jsonresume/ats-validator/constants';
+```
+
+> `EMOJI_RE` carries the global (`g`) flag, so it is stateful via `lastIndex`.
+> Use `String#match` / `String#matchAll`, or reset `lastIndex` before reusing it
+> with `RegExp#test` / `RegExp#exec`.
+
 ## Validation Checks
 
 ### 1. Semantic HTML (10 points)

--- a/packages/ats-validator/package.json
+++ b/packages/ats-validator/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "./src/index.js",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./constants": "./src/constants.js"
   },
   "files": [
     "src"

--- a/packages/ats-validator/src/checks/contact-info.js
+++ b/packages/ats-validator/src/checks/contact-info.js
@@ -10,15 +10,15 @@
 
 // Matches the vast majority of real-world email addresses without being so
 // permissive that prose like "see me @ the office" registers as a match.
-const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+export const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
 
 // Matches common phone formats: +1 (555) 123-4567, 555-123-4567,
 // 555.123.4567, +44 20 7946 0958, etc. Requires at least 7 digits overall so
 // short numeric strings (dates, zip codes) do not trigger a false positive.
-const PHONE_RE =
+export const PHONE_RE =
   /(?:\+?\d{1,3}[\s.-]?)?(?:\(\d{2,4}\)[\s.-]?)?\d{2,4}[\s.-]?\d{2,4}[\s.-]?\d{0,4}/;
 
-function countDigits(str) {
+export function countDigits(str) {
   return (str.match(/\d/g) || []).length;
 }
 

--- a/packages/ats-validator/src/checks/fonts.js
+++ b/packages/ats-validator/src/checks/fonts.js
@@ -1,3 +1,29 @@
+// Standard ATS-friendly fonts (lowercase for case-insensitive matching).
+export const ATS_FRIENDLY_FONTS = [
+  'helvetica',
+  'arial',
+  'calibri',
+  'cambria',
+  'georgia',
+  'times new roman',
+  'verdana',
+  'tahoma',
+  'trebuchet',
+  '-apple-system',
+  'system-ui',
+  'segoe ui',
+];
+
+// Decorative / non-standard fonts that hurt ATS parsing.
+export const ATS_BAD_FONTS = [
+  'comic sans',
+  'papyrus',
+  'brush script',
+  'impact',
+  'lucida handwriting',
+  'chalkboard',
+];
+
 /**
  * Check for ATS-friendly fonts
  */
@@ -9,30 +35,8 @@ export function checkFonts($) {
   const styleText = $('style').text() || '';
   const inlineStyles = $('[style*="font"]').length;
 
-  // Standard ATS-friendly fonts
-  const goodFonts = [
-    'helvetica',
-    'arial',
-    'calibri',
-    'cambria',
-    'georgia',
-    'times new roman',
-    'verdana',
-    'tahoma',
-    'trebuchet',
-    '-apple-system',
-    'system-ui',
-    'segoe ui',
-  ];
-
-  const badFonts = [
-    'comic sans',
-    'papyrus',
-    'brush script',
-    'impact',
-    'lucida handwriting',
-    'chalkboard',
-  ];
+  const goodFonts = ATS_FRIENDLY_FONTS;
+  const badFonts = ATS_BAD_FONTS;
 
   // Check for bad fonts
   const foundBadFonts = badFonts.filter((font) =>

--- a/packages/ats-validator/src/checks/special-characters.js
+++ b/packages/ats-validator/src/checks/special-characters.js
@@ -11,7 +11,7 @@
 // Icon-font class tokens commonly placed on empty <i>/<span> elements.
 // Matched as whole space-delimited class tokens (exact, or `<token>-*`) so we
 // do not accidentally match unrelated classes like "fancy" or "biography".
-const ICON_FONT_TOKENS = [
+export const ICON_FONT_TOKENS = [
   'fa', // Font Awesome base
   'fas', // Font Awesome solid
   'far', // Font Awesome regular
@@ -26,7 +26,7 @@ const ICON_FONT_TOKENS = [
 ];
 
 // Icon-font families referenced from CSS.
-const ICON_FONT_FAMILIES = [
+export const ICON_FONT_FAMILIES = [
   'font awesome',
   'fontawesome',
   'material icons',
@@ -39,12 +39,12 @@ const ICON_FONT_FAMILIES = [
 // Emoji + common decorative/dingbat ranges. Kept narrow so ordinary
 // punctuation (bullets •, en/em dashes, smart quotes) is NOT flagged — those
 // are well supported by ATS parsers.
-const EMOJI_RE =
+export const EMOJI_RE =
   /[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}\u{1F1E6}-\u{1F1FF}]/gu;
 
 // Private Use Area code points — where icon fonts map their glyphs. Real text
 // never contains these, so any occurrence is a strong icon-font signal.
-const PRIVATE_USE_RE = /[\u{E000}-\u{F8FF}\u{F0000}-\u{FFFFD}]/u;
+export const PRIVATE_USE_RE = /[\u{E000}-\u{F8FF}\u{F0000}-\u{FFFFD}]/u;
 
 export function checkSpecialCharacters($) {
   const issues = [];

--- a/packages/ats-validator/src/constants.js
+++ b/packages/ats-validator/src/constants.js
@@ -1,0 +1,27 @@
+/**
+ * @jsonresume/ats-validator/constants
+ *
+ * Public, reusable building blocks that power the individual ATS checks.
+ * These are re-exported (not redefined) from the check modules so the values
+ * never drift from what `validateATS` actually uses. Useful for library
+ * authors who want to lint or highlight ATS issues without running the full
+ * validator.
+ *
+ * NOTE: `EMOJI_RE` carries the global (`g`) flag, so it is stateful via
+ * `lastIndex`. Use `String#match` / `String#matchAll`, or reset `lastIndex`
+ * before reusing it with `RegExp#test` / `RegExp#exec`.
+ */
+
+// Fonts
+export { ATS_FRIENDLY_FONTS, ATS_BAD_FONTS } from './checks/fonts.js';
+
+// Icon fonts, emoji and decorative special characters
+export {
+  ICON_FONT_TOKENS,
+  ICON_FONT_FAMILIES,
+  EMOJI_RE,
+  PRIVATE_USE_RE,
+} from './checks/special-characters.js';
+
+// Contact information detection
+export { EMAIL_RE, PHONE_RE, countDigits } from './checks/contact-info.js';

--- a/packages/ats-validator/src/index.js
+++ b/packages/ats-validator/src/index.js
@@ -74,5 +74,6 @@ export function validateATS(html) {
 }
 
 export { getRecommendations };
+export { getGrade };
 
-export default { validateATS, getRecommendations };
+export default { validateATS, getRecommendations, getGrade };

--- a/packages/ats-validator/tests/public-surface.test.js
+++ b/packages/ats-validator/tests/public-surface.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { getGrade, validateATS, getRecommendations } from '../src/index.js';
+import {
+  ATS_FRIENDLY_FONTS,
+  ATS_BAD_FONTS,
+  ICON_FONT_TOKENS,
+  ICON_FONT_FAMILIES,
+  EMOJI_RE,
+  PRIVATE_USE_RE,
+  EMAIL_RE,
+  PHONE_RE,
+  countDigits,
+} from '../src/constants.js';
+
+describe('public getGrade export', () => {
+  it('is exported from the package root', () => {
+    expect(typeof getGrade).toBe('function');
+  });
+
+  it('maps percentages to letter grades A..F at the documented thresholds', () => {
+    // A: >= 90
+    expect(getGrade(100)).toBe('A');
+    expect(getGrade(90)).toBe('A');
+    // B: 80-89
+    expect(getGrade(89)).toBe('B');
+    expect(getGrade(80)).toBe('B');
+    // C: 70-79
+    expect(getGrade(79)).toBe('C');
+    expect(getGrade(70)).toBe('C');
+    // D: 60-69
+    expect(getGrade(69)).toBe('D');
+    expect(getGrade(60)).toBe('D');
+    // F: < 60
+    expect(getGrade(59)).toBe('F');
+    expect(getGrade(0)).toBe('F');
+  });
+
+  it('matches the grade computed by validateATS', () => {
+    const html = '<html lang="en"><body><h1>Test</h1></body></html>';
+    const result = validateATS(html);
+    expect(result.grade).toBe(getGrade(result.score));
+  });
+});
+
+describe('./constants subpath exports', () => {
+  it('still exposes the original validator entrypoints alongside', () => {
+    expect(typeof validateATS).toBe('function');
+    expect(typeof getRecommendations).toBe('function');
+  });
+
+  it('exposes non-empty, lowercase font tables', () => {
+    expect(Array.isArray(ATS_FRIENDLY_FONTS)).toBe(true);
+    expect(ATS_FRIENDLY_FONTS.length).toBeGreaterThan(0);
+    expect(ATS_FRIENDLY_FONTS).toContain('arial');
+    expect(ATS_FRIENDLY_FONTS).toContain('helvetica');
+    expect(ATS_FRIENDLY_FONTS.every((f) => f === f.toLowerCase())).toBe(true);
+
+    expect(Array.isArray(ATS_BAD_FONTS)).toBe(true);
+    expect(ATS_BAD_FONTS.length).toBeGreaterThan(0);
+    expect(ATS_BAD_FONTS).toContain('comic sans');
+    expect(ATS_BAD_FONTS.every((f) => f === f.toLowerCase())).toBe(true);
+  });
+
+  it('exposes the icon-font token and family tables', () => {
+    expect(Array.isArray(ICON_FONT_TOKENS)).toBe(true);
+    expect(ICON_FONT_TOKENS.length).toBeGreaterThan(0);
+    expect(ICON_FONT_TOKENS).toContain('fa');
+    expect(ICON_FONT_TOKENS).toContain('material-icons');
+
+    expect(Array.isArray(ICON_FONT_FAMILIES)).toBe(true);
+    expect(ICON_FONT_FAMILIES.length).toBeGreaterThan(0);
+    expect(ICON_FONT_FAMILIES).toContain('fontawesome');
+  });
+
+  it('exposes regexes with the expected shape', () => {
+    expect(EMOJI_RE).toBeInstanceOf(RegExp);
+    expect(EMOJI_RE.global).toBe(true); // stateful — used with match/matchAll
+    expect(PRIVATE_USE_RE).toBeInstanceOf(RegExp);
+    expect(EMAIL_RE).toBeInstanceOf(RegExp);
+    expect(PHONE_RE).toBeInstanceOf(RegExp);
+  });
+
+  it('EMAIL_RE matches a real email and not plain prose', () => {
+    expect(EMAIL_RE.test('jane.doe@example.com')).toBe(true);
+    expect(EMAIL_RE.test('see me @ the office tomorrow')).toBe(false);
+  });
+
+  it('PRIVATE_USE_RE flags private-use glyphs but not ordinary text', () => {
+    const glyph = String.fromCharCode(0xe001);
+    expect(PRIVATE_USE_RE.test(`Contact ${glyph}`)).toBe(true);
+    expect(PRIVATE_USE_RE.test('Plain resume text')).toBe(false);
+  });
+
+  it('EMOJI_RE matches emoji via String#match', () => {
+    expect('Skills 🚀 ✨'.match(EMOJI_RE)?.length).toBeGreaterThan(0);
+    expect('plain text — no emoji'.match(EMOJI_RE)).toBeNull();
+  });
+
+  it('countDigits counts only digit characters', () => {
+    expect(typeof countDigits).toBe('function');
+    expect(countDigits('+1 (555) 123-4567')).toBe(11);
+    expect(countDigits('no digits here')).toBe(0);
+  });
+
+  it('constants are the same references the checks use (no duplication)', async () => {
+    const fonts = await import('../src/checks/fonts.js');
+    const special = await import('../src/checks/special-characters.js');
+    const contact = await import('../src/checks/contact-info.js');
+    expect(ATS_FRIENDLY_FONTS).toBe(fonts.ATS_FRIENDLY_FONTS);
+    expect(ATS_BAD_FONTS).toBe(fonts.ATS_BAD_FONTS);
+    expect(ICON_FONT_TOKENS).toBe(special.ICON_FONT_TOKENS);
+    expect(EMAIL_RE).toBe(contact.EMAIL_RE);
+  });
+});


### PR DESCRIPTION
Promotes currently-internal pure pieces of `@jsonresume/ats-validator` to public so library authors can reuse them. No file moves — only new exports.

## What
- Export `getGrade` from the package root (0-100 score -> A..F).
- New `@jsonresume/ats-validator/constants` subpath surfacing the reusable tables/regexes the checks already use:
  - `ATS_FRIENDLY_FONTS`, `ATS_BAD_FONTS` (hoisted to module scope in `checks/fonts.js`, value unchanged)
  - `ICON_FONT_TOKENS`, `ICON_FONT_FAMILIES`, `EMOJI_RE`, `PRIVATE_USE_RE`
  - `EMAIL_RE`, `PHONE_RE`, `countDigits`
- `src/constants.js` re-exports from the check modules (no duplicated values, so they can't drift from what `validateATS` uses).
- `validateATS` / `getRecommendations` behavior unchanged.

## Tests
- New `tests/public-surface.test.js`: `getGrade` thresholds A..F, constants non-empty + expected shape, `getGrade` matches `validateATS`, and identity check that the constants are the same references the checks consume.
- All 37 tests pass (25 existing + 12 new).

## Notes
- `EMOJI_RE` keeps its global flag (stateful `lastIndex`); documented in README + the constants module.
- MINOR changeset added.

Verified: `pnpm --filter @jsonresume/ats-validator test` green; `pnpm turbo lint typecheck prettier` exit 0.

Refs #421

— AI
