### PR TITLE
feat(ecosystem): SSR renderResumeDocument helper + @jsonresume/theme-kit (W2)

### DIFF
--- a/.changeset/ecosystem-w2-core-ssr.md
+++ b/.changeset/ecosystem-w2-core-ssr.md
@@ -1,0 +1,11 @@
+---
+'@jsonresume/core': minor
+---
+
+Add a new `@jsonresume/core/ssr` subpath exporting `renderResumeDocument` and
+`googleFontsLinks`. `renderResumeDocument(element, options)` wraps the
+styled-components `ServerStyleSheet` boilerplate every JSX theme repeats
+(collectStyles + getStyleTags + always-seal) and returns a complete
+`<!DOCTYPE html>` document with Google Font links, optional CSS reset, tokens
+CSS link, title/lang/dir, and extra head HTML. Existing exports are unchanged.
+(#421)

--- a/.changeset/ecosystem-w2-theme-kit.md
+++ b/.changeset/ecosystem-w2-theme-kit.md
@@ -1,0 +1,11 @@
+---
+'@jsonresume/theme-kit': minor
+---
+
+New package: `@jsonresume/theme-kit`, the authoring kit for JSON Resume themes.
+Bundles the SSR document helper (`renderResumeDocument`, `googleFontsLinks`,
+re-exported from `@jsonresume/core/ssr`) with the permanent render +
+section-coverage QA gate (`runThemeRenderQa`, `assertThemeRender`,
+`findArtifacts`, `sectionCoverage`, and the `SECTION_SENTINELS` /
+`BASELINE_SECTIONS` / `HANDLEBARS_THEMES` constants) extracted verbatim from the
+registry gate. (#421)

--- a/apps/registry/lib/formatters/template/themeRenderQa.js
+++ b/apps/registry/lib/formatters/template/themeRenderQa.js
@@ -1,123 +1,25 @@
 /**
  * Shared helpers for the permanent all-theme render + section-coverage gate.
  *
- * Background: across development "waves" a throwaway harness repeatedly
- * rendered every registered theme against a complete fixture to catch crashes
- * (e.g. the consultant-polished Date-shadow crash) and missing-section
- * regressions (~30 coverage gaps). This module codifies that QA so the
- * registry vitest 'unit-test' job enforces it forever.
+ * The implementation now lives in @jsonresume/theme-kit (extracted in the W2
+ * ecosystem work, #421) so theme authors get the SAME gate the registry
+ * enforces. This module is a thin re-export shim: the existing registry suites
  *
- * Used by:
  *   - themeRenderQa.test.js            (ESM/JSX themes)
  *   - themeRenderQa.handlebars.test.js (Handlebars themes, module-isolated)
  *
- * See packages/test-fixtures/complete-resume.json for the fixture (every
- * JSON Resume section is populated). See docs reference in the test files.
+ * import the helpers/constants from this path unchanged. The assertions,
+ * regexes, sentinels, and baseline are defined once in @jsonresume/theme-kit
+ * and identical here.
+ *
+ * See packages/theme-kit/src/qa.js for the source and
+ * @jsonresume/sample-data complete-resume.json for the fixture.
  */
-
-// Handlebars-based themes share a single global Handlebars instance and
-// register colliding helpers (e.g. formatDate). In production this is handled
-// by format.js fresh-requiring the theme + handlebars from a clean cache; in
-// the vitest worker we keep these themes in their own isolated test file and
-// reset modules per render. Listed here so the ESM suite can exclude them.
-export const HANDLEBARS_THEMES = [
-  'macchiato',
-  'pumpkin',
-  'lucide',
-  'minyma',
-  'paper-plus-plus',
-];
-
-// Section -> sentinel strings that appear in complete-resume.json for exactly
-// that section. A section counts as "covered" if ANY of its sentinels appears
-// in the rendered HTML. Multiple sentinels are listed per section because
-// themes render different fields (e.g. one theme prints the work company name,
-// another only the position or summary) — an OR match makes coverage robust to
-// those legitimate design choices. Every sentinel below is section-distinct
-// within the fixture (it does not appear in any other section's content).
-export const SECTION_SENTINELS = {
-  basics: ['Jane Developer', 'Full Stack Software Engineer'],
-  work: ['Senior Software Engineer', 'microservices architecture serving'],
-  volunteer: [
-    'Code for America',
-    'Volunteer Software Engineer',
-    'benefits eligibility screener',
-  ],
-  education: [
-    'University of California, Berkeley',
-    'Bachelor of Science',
-    'Computer Science',
-  ],
-  awards: ['Top Contributor Award', 'top contributor to open source'],
-  certificates: [
-    'AWS Certified Solutions Architect',
-    'Amazon Web Services',
-    'Certified Kubernetes Administrator',
-  ],
-  publications: ['Scaling Microservices Without Losing Your Mind', 'ACM Queue'],
-  skills: ['PostgreSQL'],
-  languages: ['Spanish', 'Professional working proficiency', 'Native speaker'],
-  interests: ['Community Building', 'Web Performance'],
-  references: [
-    'Sarah Johnson, Founder at StartupXYZ',
-    'exceptional engineer who consistently',
-    'Working with Jane was a pleasure',
-  ],
-  projects: ['Open Source UI Library', '5,000+ GitHub stars'],
-};
-
-// Sections every theme MUST render. This is the hard coverage baseline:
-// themes legitimately omit niche sections (volunteer, certificates, etc.) by
-// design, but a resume theme that drops basics/work/education/skills is broken.
-export const BASELINE_SECTIONS = ['basics', 'work', 'education', 'skills'];
-
-// Raw render artifacts that must never appear in output HTML.
-const ARTIFACT_PATTERNS = [
-  { label: '[object Object]', test: (h) => h.includes('[object Object]') },
-  { label: 'undefined', test: (h) => /\bundefined\b/.test(h) },
-  { label: 'NaN', test: (h) => /\bNaN\b/.test(h) },
-];
-
-/** Returns the list of raw artifacts found in rendered HTML (empty = clean). */
-export function findArtifacts(html) {
-  return ARTIFACT_PATTERNS.filter((p) => p.test(html)).map((p) => p.label);
-}
-
-/**
- * Returns { [section]: boolean } indicating which sections are present in the
- * rendered HTML. A section is covered if ANY of its sentinel strings appears.
- */
-export function sectionCoverage(html) {
-  const cov = {};
-  for (const [section, sentinels] of Object.entries(SECTION_SENTINELS)) {
-    cov[section] = sentinels.some((sentinel) => html.includes(sentinel));
-  }
-  return cov;
-}
-
-/**
- * Hard assertions shared by both suites: render must not throw (caller awaits
- * format), must return non-empty HTML, and must contain no raw artifacts.
- * Returns the section-coverage map for snapshotting.
- */
-export function assertThemeRender(expect, themeName, html) {
-  expect(
-    typeof html === 'string' && html.length > 0,
-    `theme "${themeName}" rendered empty HTML`
-  ).toBe(true);
-
-  const artifacts = findArtifacts(html);
-  expect(
-    artifacts,
-    `theme "${themeName}" emitted raw artifacts: ${artifacts.join(', ')}`
-  ).toEqual([]);
-
-  const coverage = sectionCoverage(html);
-  for (const section of BASELINE_SECTIONS) {
-    expect(
-      coverage[section],
-      `theme "${themeName}" missing BASELINE section "${section}"`
-    ).toBe(true);
-  }
-  return coverage;
-}
+export {
+  HANDLEBARS_THEMES,
+  SECTION_SENTINELS,
+  BASELINE_SECTIONS,
+  findArtifacts,
+  sectionCoverage,
+  assertThemeRender,
+} from '@jsonresume/theme-kit/qa';

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -28,6 +28,7 @@
     "@jsonresume/jsonresume-theme-tokyo-modernist": "workspace:^",
     "@jsonresume/sample-data": "workspace:*",
     "@jsonresume/schema": "workspace:*",
+    "@jsonresume/theme-kit": "workspace:*",
     "@jsonresume/utils": "workspace:*",
     "@jsonresume/theme-stackoverflow": "^2",
     "@monaco-editor/react": "^4.6.0",

--- a/packages/resume-core/package.json
+++ b/packages/resume-core/package.json
@@ -6,6 +6,7 @@
   "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
+    "./ssr": "./src/ssr/index.js",
     "./helpers": "./src/helpers/index.js",
     "./tokens": "./src/tokens/index.js",
     "./primitives": "./src/primitives/index.js",

--- a/packages/resume-core/src/__tests__/ssr/renderResumeDocument.test.jsx
+++ b/packages/resume-core/src/__tests__/ssr/renderResumeDocument.test.jsx
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import styled from 'styled-components';
+import { renderResumeDocument, googleFontsLinks } from '../../ssr/index.js';
+
+const Box = styled.div`
+  color: rgb(1, 2, 3);
+`;
+
+describe('googleFontsLinks', () => {
+  it('returns empty string for no fonts', () => {
+    expect(googleFontsLinks()).toBe('');
+    expect(googleFontsLinks([])).toBe('');
+    expect(googleFontsLinks(null)).toBe('');
+  });
+
+  it('builds a single css2 request from family names', () => {
+    const out = googleFontsLinks(['Inter', 'IBM Plex Sans']);
+    expect(out).toContain('rel="preconnect"');
+    expect(out).toContain('fonts.gstatic.com');
+    expect(out).toContain(
+      'https://fonts.googleapis.com/css2?family=Inter&family=IBM+Plex+Sans&display=swap'
+    );
+  });
+
+  it('preserves axis/weight specs on a family name', () => {
+    const out = googleFontsLinks(['Inter:wght@400;700']);
+    expect(out).toContain('family=Inter:wght@400;700');
+  });
+
+  it('passes through a ready-made href', () => {
+    const href = 'https://fonts.googleapis.com/css2?family=Roboto&display=swap';
+    const out = googleFontsLinks([href]);
+    expect(out).toContain(`<link href="${href}" rel="stylesheet">`);
+    // No css2 family= request was synthesised on top of the href.
+    expect(out).not.toContain('family=Roboto&family');
+  });
+
+  it('passes through a ready-made <link> tag verbatim', () => {
+    const tag = '<link href="https://example.com/f.css" rel="stylesheet">';
+    expect(googleFontsLinks([tag])).toContain(tag);
+  });
+});
+
+describe('renderResumeDocument', () => {
+  it('emits a doctype, the element markup, and the collected styles', () => {
+    const out = renderResumeDocument(<Box>Hello</Box>);
+    expect(out.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(out).toContain('Hello');
+    // styled-components injected a <style> tag with the declared color.
+    expect(out).toContain('<style');
+    expect(out).toContain('color:rgb(1, 2, 3)');
+    expect(out.trimEnd().endsWith('</html>')).toBe(true);
+  });
+
+  it('includes the font links when fonts are given', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, { fonts: ['Inter'] });
+    expect(out).toContain(
+      'https://fonts.googleapis.com/css2?family=Inter&display=swap'
+    );
+  });
+
+  it('links the @jsonresume/core tokens.css by default', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>);
+    expect(out).toContain('@jsonresume/core/dist/tokens.css');
+  });
+
+  it('omits tokens.css when includeTokensCss is false', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, {
+      includeTokensCss: false,
+    });
+    expect(out).not.toContain('tokens.css');
+  });
+
+  it('honours title, lang and dir options', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, {
+      title: 'Jane Developer',
+      lang: 'ar',
+      dir: 'rtl',
+    });
+    expect(out).toContain('<title>Jane Developer</title>');
+    expect(out).toContain('<html lang="ar" dir="rtl">');
+  });
+
+  it('omits the title tag when no title is given', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>);
+    expect(out).not.toContain('<title>');
+  });
+
+  it('includes the minimal reset only when reset is true', () => {
+    const withReset = renderResumeDocument(<Box>Hi</Box>, { reset: true });
+    expect(withReset).toContain('box-sizing:border-box');
+    const without = renderResumeDocument(<Box>Hi</Box>);
+    expect(without).not.toContain('box-sizing:border-box');
+  });
+
+  it('injects extra head HTML and a body class', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, {
+      head: '<meta name="robots" content="noindex">',
+      bodyClass: 'theme-foo',
+    });
+    expect(out).toContain('<meta name="robots" content="noindex">');
+    expect(out).toContain('<body class="theme-foo">');
+  });
+
+  it('always seals the sheet — styles do not leak across calls', () => {
+    // Two different styled components rendered in separate calls. If the sheet
+    // were not sealed, the second document would carry the first's rules.
+    const A = styled.div`
+      color: rgb(10, 20, 30);
+    `;
+    const B = styled.div`
+      color: rgb(40, 50, 60);
+    `;
+    const first = renderResumeDocument(<A>a</A>);
+    const second = renderResumeDocument(<B>b</B>);
+    expect(first).toContain('color:rgb(10, 20, 30)');
+    expect(first).not.toContain('color:rgb(40, 50, 60)');
+    expect(second).toContain('color:rgb(40, 50, 60)');
+    expect(second).not.toContain('color:rgb(10, 20, 30)');
+  });
+});

--- a/packages/resume-core/src/ssr/index.js
+++ b/packages/resume-core/src/ssr/index.js
@@ -1,0 +1,152 @@
+/**
+ * @jsonresume/core/ssr
+ *
+ * Server-side render helpers for JSON Resume themes. Every JSX theme's
+ * `render(resume)` repeats the same boilerplate: spin up a styled-components
+ * ServerStyleSheet, collect styles while rendering, emit a full
+ * `<!DOCTYPE html>` document with Google Font <link>s in the <head>, and seal
+ * the sheet. This module factors that out so a theme's render() can be a single
+ * call to `renderResumeDocument(<Resume resume={resume} />, { fonts, title })`.
+ *
+ * SSR-safe: imports only react-dom/server + styled-components (both already
+ * core peer/deps) and touches no window/document at module load.
+ *
+ * @module @jsonresume/core/ssr
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ServerStyleSheet } from 'styled-components';
+
+/**
+ * Minimal, opt-in CSS reset (margin/padding zero + border-box). Themes that
+ * already ship their own reset leave this off (default); ATS-plain themes that
+ * want a clean slate pass `reset: true`.
+ */
+const CSS_RESET =
+  '<style>*,*::before,*::after{box-sizing:border-box}' +
+  'html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>';
+
+/** Stylesheet href for the @jsonresume/core design tokens (CSS custom props). */
+const TOKENS_CSS_HREF = 'https://unpkg.com/@jsonresume/core/dist/tokens.css';
+
+const FONTS_PRECONNECT =
+  '<link rel="preconnect" href="https://fonts.googleapis.com">' +
+  '<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+
+/** A value is a ready-made href if it already looks like a URL or <link> tag. */
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith('<link');
+}
+
+/** Turn a Google font family name into the css2 `family=` query fragment. */
+function familyParam(family) {
+  // Preserve any axis spec the caller appended (e.g. "Inter:wght@400;700"),
+  // only the family portion needs its spaces turned into '+'.
+  const [name, ...rest] = String(family).split(':');
+  const encodedName = name.trim().replace(/\s+/g, '+');
+  return rest.length ? `${encodedName}:${rest.join(':')}` : encodedName;
+}
+
+/**
+ * Build the Google Fonts <link> markup for the given families.
+ *
+ * Accepts either bare family names / `Family:axis@weights` specs (combined into
+ * a single css2 request) or fully-formed href strings / `<link>` tags (passed
+ * through verbatim). Returns an empty string when given nothing.
+ *
+ * @param {string[]} [families]
+ * @returns {string}
+ */
+export function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return '';
+
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === '') continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+
+  const links = passthrough.map((href) =>
+    href.trim().startsWith('<link')
+      ? href
+      : `<link href="${href}" rel="stylesheet">`
+  );
+
+  if (names.length > 0) {
+    const query = names.map(familyParam).join('&family=');
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+
+  if (links.length === 0) return '';
+  return FONTS_PRECONNECT + links.join('');
+}
+
+/**
+ * Render a React element to a complete, styled HTML document string using the
+ * same ServerStyleSheet path themes hand-roll today. The sheet is ALWAYS sealed
+ * in a finally block so collected styles never leak between renders.
+ *
+ * @param {import('react').ReactElement} element  Root resume element to render.
+ * @param {object} [options]
+ * @param {string[]} [options.fonts]            Google font families OR hrefs.
+ * @param {string}   [options.title]            <title> text (omitted if falsy).
+ * @param {string}   [options.lang='en']        <html lang> attribute.
+ * @param {string}   [options.dir='ltr']        <html dir> attribute.
+ * @param {boolean}  [options.reset=false]      Include the minimal CSS reset.
+ * @param {string}   [options.head='']          Extra raw HTML for the <head>.
+ * @param {boolean}  [options.includeTokensCss=true] Link @jsonresume/core tokens.
+ * @param {string}   [options.bodyClass]        class attribute on <body>.
+ * @returns {string} Full `<!DOCTYPE html>...` document.
+ */
+export function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = 'en',
+    dir = 'ltr',
+    reset = false,
+    head = '',
+    includeTokensCss = true,
+    bodyClass,
+  } = options;
+
+  const sheet = new ServerStyleSheet();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss
+    ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">`
+    : '';
+  const resetTag = reset ? CSS_RESET : '';
+  const titleTag = title ? `<title>${title}</title>` : '';
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : '';
+
+  return (
+    '<!DOCTYPE html>' +
+    `<html lang="${lang}" dir="${dir}">` +
+    '<head>' +
+    '<meta charset="utf-8">' +
+    '<meta name="viewport" content="width=device-width, initial-scale=1">' +
+    fontLinks +
+    tokensLink +
+    resetTag +
+    head +
+    styleTags +
+    titleTag +
+    '</head>' +
+    `<body${bodyAttr}>${html}</body>` +
+    '</html>'
+  );
+}
+
+export default { renderResumeDocument, googleFontsLinks };

--- a/packages/theme-kit/.eslintrc.cjs
+++ b/packages/theme-kit/.eslintrc.cjs
@@ -1,0 +1,23 @@
+/* eslint-disable */
+
+module.exports = {
+  root: true,
+  extends: ['@repo/eslint-config-custom'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  env: {
+    es2022: true,
+    node: true,
+    browser: true,
+  },
+  ignorePatterns: ['node_modules', 'dist'],
+  rules: {
+    // Library-grade: no console output is allowed.
+    'no-console': 'error',
+  },
+};

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@jsonresume/theme-kit",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Authoring kit for JSON Resume themes: the SSR document helper plus the all-theme render + section-coverage QA gate",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./qa": "./src/qa.js",
+    "./ssr": "./src/ssr.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src --cache --cache-location node_modules/.cache/.eslintcache"
+  },
+  "devDependencies": {
+    "@repo/eslint-config-custom": "workspace:^",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "styled-components": "^6.1.19",
+    "vitest": "^2"
+  },
+  "dependencies": {
+    "@jsonresume/sample-data": "workspace:*"
+  },
+  "peerDependencies": {
+    "@jsonresume/core": "workspace:*"
+  },
+  "keywords": [
+    "resume",
+    "cv",
+    "json-resume",
+    "theme",
+    "ssr",
+    "testing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jsonresume/jsonresume.org",
+    "directory": "packages/theme-kit"
+  },
+  "homepage": "https://github.com/jsonresume/jsonresume.org/tree/master/packages/theme-kit",
+  "bugs": {
+    "url": "https://github.com/jsonresume/jsonresume.org/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/packages/theme-kit/src/__tests__/qa.test.js
+++ b/packages/theme-kit/src/__tests__/qa.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { completeResume } from '@jsonresume/sample-data';
+import {
+  findArtifacts,
+  sectionCoverage,
+  assertThemeRender,
+  runThemeRenderQa,
+  BASELINE_SECTIONS,
+  SECTION_SENTINELS,
+  HANDLEBARS_THEMES,
+} from '../index.js';
+
+// A minimal "good" HTML string that satisfies the baseline gate: it contains a
+// section-distinct sentinel for each baseline section and no raw artifacts.
+const GOOD_HTML = [
+  '<h1>Jane Developer</h1>',
+  '<p>Senior Software Engineer</p>',
+  '<p>University of California, Berkeley</p>',
+  '<li>PostgreSQL</li>',
+].join('\n');
+
+describe('findArtifacts', () => {
+  it('returns no artifacts for clean HTML', () => {
+    expect(findArtifacts(GOOD_HTML)).toEqual([]);
+  });
+
+  it('detects [object Object]', () => {
+    expect(findArtifacts('<p>[object Object]</p>')).toEqual([
+      '[object Object]',
+    ]);
+  });
+
+  it('detects a bare "undefined" word', () => {
+    expect(findArtifacts('<p>undefined</p>')).toEqual(['undefined']);
+  });
+
+  it('detects a bare "NaN" word', () => {
+    expect(findArtifacts('<p>NaN years</p>')).toEqual(['NaN']);
+  });
+
+  it('does not flag "undefined"/"NaN" embedded inside larger words', () => {
+    // \b boundaries mean substrings inside identifiers are not artifacts.
+    expect(findArtifacts('<p>undefinedness</p>')).toEqual([]);
+    expect(findArtifacts('<p>NaNny</p>')).toEqual([]);
+  });
+
+  it('lists multiple artifacts when several are present', () => {
+    const out = findArtifacts('[object Object] undefined NaN');
+    expect(out).toEqual(['[object Object]', 'undefined', 'NaN']);
+  });
+});
+
+describe('sectionCoverage', () => {
+  it('marks baseline sections present in good HTML', () => {
+    const cov = sectionCoverage(GOOD_HTML);
+    for (const section of BASELINE_SECTIONS) {
+      expect(cov[section]).toBe(true);
+    }
+  });
+
+  it('marks sections absent when no sentinel appears', () => {
+    const cov = sectionCoverage('<h1>Nothing here</h1>');
+    expect(cov.basics).toBe(false);
+    expect(cov.work).toBe(false);
+    expect(cov.education).toBe(false);
+    expect(cov.skills).toBe(false);
+  });
+
+  it("matches on ANY of a section's sentinels (OR semantics)", () => {
+    // basics has two sentinels; either one alone counts as covered.
+    expect(sectionCoverage('Full Stack Software Engineer').basics).toBe(true);
+    expect(sectionCoverage('Jane Developer').basics).toBe(true);
+  });
+
+  it('reports every section key from SECTION_SENTINELS', () => {
+    const cov = sectionCoverage(GOOD_HTML);
+    expect(Object.keys(cov).sort()).toEqual(
+      Object.keys(SECTION_SENTINELS).sort()
+    );
+  });
+});
+
+describe('assertThemeRender', () => {
+  it('passes for good HTML and returns the coverage map', () => {
+    const cov = assertThemeRender(expect, 'good-theme', GOOD_HTML);
+    expect(cov.basics).toBe(true);
+  });
+
+  it('fails when HTML is empty', () => {
+    expect(() => assertThemeRender(expect, 'empty', '')).toThrow();
+  });
+
+  it('fails when a raw artifact leaks', () => {
+    expect(() =>
+      assertThemeRender(expect, 'artifact', GOOD_HTML + ' [object Object]')
+    ).toThrow();
+  });
+
+  it('fails when a baseline section is missing', () => {
+    // Drop the skills sentinel -> baseline gate should reject.
+    const noSkills = GOOD_HTML.replace('<li>PostgreSQL</li>', '');
+    expect(() => assertThemeRender(expect, 'no-skills', noSkills)).toThrow();
+  });
+});
+
+describe('runThemeRenderQa', () => {
+  it('runs a synchronous render against the default fixture', async () => {
+    const render = (resume) =>
+      [
+        resume.basics.name,
+        'Senior Software Engineer',
+        'University of California, Berkeley',
+        'PostgreSQL',
+      ].join(' ');
+    const cov = await runThemeRenderQa({ render, name: 'sync', expect });
+    expect(cov.basics).toBe(true);
+    expect(cov.work).toBe(true);
+  });
+
+  it('awaits an async render and accepts a custom fixture', async () => {
+    const render = async () => GOOD_HTML;
+    const cov = await runThemeRenderQa({
+      render,
+      name: 'async',
+      expect,
+      fixture: completeResume,
+    });
+    expect(cov.education).toBe(true);
+  });
+
+  it('surfaces a crashing render as a rejection', async () => {
+    const render = () => {
+      throw new Error('boom');
+    };
+    await expect(
+      runThemeRenderQa({ render, name: 'boom', expect })
+    ).rejects.toThrow('boom');
+  });
+});
+
+describe('exported constants', () => {
+  it('keeps the hard coverage baseline', () => {
+    expect(BASELINE_SECTIONS).toEqual([
+      'basics',
+      'work',
+      'education',
+      'skills',
+    ]);
+  });
+
+  it('lists the Handlebars themes', () => {
+    expect(HANDLEBARS_THEMES).toContain('macchiato');
+    expect(HANDLEBARS_THEMES).toContain('paper-plus-plus');
+  });
+});

--- a/packages/theme-kit/src/__tests__/ssr.test.jsx
+++ b/packages/theme-kit/src/__tests__/ssr.test.jsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import styled from 'styled-components';
+import { renderResumeDocument, googleFontsLinks } from '../index.js';
+
+const Box = styled.div`
+  color: rgb(7, 8, 9);
+`;
+
+describe('theme-kit SSR re-export', () => {
+  it('re-exports renderResumeDocument from @jsonresume/core/ssr', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, { fonts: ['Inter'] });
+    expect(out.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(out).toContain('Hi');
+    expect(out).toContain('color:rgb(7, 8, 9)');
+    expect(out).toContain('family=Inter');
+  });
+
+  it('re-exports googleFontsLinks', () => {
+    expect(googleFontsLinks(['Inter'])).toContain('family=Inter');
+  });
+});

--- a/packages/theme-kit/src/index.js
+++ b/packages/theme-kit/src/index.js
@@ -1,0 +1,27 @@
+/**
+ * @jsonresume/theme-kit
+ *
+ * The authoring kit for JSON Resume themes. Bundles the two things every theme
+ * author needs:
+ *
+ *  1. The SSR document helper (`renderResumeDocument`, `googleFontsLinks`),
+ *     re-exported from @jsonresume/core/ssr — turn a React element into a full
+ *     styled HTML document with the ServerStyleSheet boilerplate handled.
+ *  2. The permanent render + section-coverage QA gate (`runThemeRenderQa`,
+ *     `assertThemeRender`, `findArtifacts`, `sectionCoverage`, and the
+ *     `SECTION_SENTINELS` / `BASELINE_SECTIONS` / `HANDLEBARS_THEMES`
+ *     constants) — the exact gate the registry enforces across all themes.
+ *
+ * @module @jsonresume/theme-kit
+ */
+export {
+  HANDLEBARS_THEMES,
+  SECTION_SENTINELS,
+  BASELINE_SECTIONS,
+  findArtifacts,
+  sectionCoverage,
+  assertThemeRender,
+  runThemeRenderQa,
+} from './qa.js';
+
+export { renderResumeDocument, googleFontsLinks } from './ssr.js';

--- a/packages/theme-kit/src/qa.js
+++ b/packages/theme-kit/src/qa.js
@@ -1,0 +1,151 @@
+/**
+ * Shared helpers for the permanent all-theme render + section-coverage gate.
+ *
+ * Background: across development "waves" a throwaway harness repeatedly
+ * rendered every registered theme against a complete fixture to catch crashes
+ * (e.g. the consultant-polished Date-shadow crash) and missing-section
+ * regressions (~30 coverage gaps). This module codifies that QA so the
+ * registry vitest 'unit-test' job enforces it forever.
+ *
+ * Used by:
+ *   - themeRenderQa.test.js            (ESM/JSX themes)
+ *   - themeRenderQa.handlebars.test.js (Handlebars themes, module-isolated)
+ *
+ * See packages/test-fixtures/complete-resume.json for the fixture (every
+ * JSON Resume section is populated). See docs reference in the test files.
+ */
+
+// Handlebars-based themes share a single global Handlebars instance and
+// register colliding helpers (e.g. formatDate). In production this is handled
+// by format.js fresh-requiring the theme + handlebars from a clean cache; in
+// the vitest worker we keep these themes in their own isolated test file and
+// reset modules per render. Listed here so the ESM suite can exclude them.
+export const HANDLEBARS_THEMES = [
+  'macchiato',
+  'pumpkin',
+  'lucide',
+  'minyma',
+  'paper-plus-plus',
+];
+
+// Section -> sentinel strings that appear in complete-resume.json for exactly
+// that section. A section counts as "covered" if ANY of its sentinels appears
+// in the rendered HTML. Multiple sentinels are listed per section because
+// themes render different fields (e.g. one theme prints the work company name,
+// another only the position or summary) — an OR match makes coverage robust to
+// those legitimate design choices. Every sentinel below is section-distinct
+// within the fixture (it does not appear in any other section's content).
+export const SECTION_SENTINELS = {
+  basics: ['Jane Developer', 'Full Stack Software Engineer'],
+  work: ['Senior Software Engineer', 'microservices architecture serving'],
+  volunteer: [
+    'Code for America',
+    'Volunteer Software Engineer',
+    'benefits eligibility screener',
+  ],
+  education: [
+    'University of California, Berkeley',
+    'Bachelor of Science',
+    'Computer Science',
+  ],
+  awards: ['Top Contributor Award', 'top contributor to open source'],
+  certificates: [
+    'AWS Certified Solutions Architect',
+    'Amazon Web Services',
+    'Certified Kubernetes Administrator',
+  ],
+  publications: ['Scaling Microservices Without Losing Your Mind', 'ACM Queue'],
+  skills: ['PostgreSQL'],
+  languages: ['Spanish', 'Professional working proficiency', 'Native speaker'],
+  interests: ['Community Building', 'Web Performance'],
+  references: [
+    'Sarah Johnson, Founder at StartupXYZ',
+    'exceptional engineer who consistently',
+    'Working with Jane was a pleasure',
+  ],
+  projects: ['Open Source UI Library', '5,000+ GitHub stars'],
+};
+
+// Sections every theme MUST render. This is the hard coverage baseline:
+// themes legitimately omit niche sections (volunteer, certificates, etc.) by
+// design, but a resume theme that drops basics/work/education/skills is broken.
+export const BASELINE_SECTIONS = ['basics', 'work', 'education', 'skills'];
+
+// Raw render artifacts that must never appear in output HTML.
+const ARTIFACT_PATTERNS = [
+  { label: '[object Object]', test: (h) => h.includes('[object Object]') },
+  { label: 'undefined', test: (h) => /\bundefined\b/.test(h) },
+  { label: 'NaN', test: (h) => /\bNaN\b/.test(h) },
+];
+
+/** Returns the list of raw artifacts found in rendered HTML (empty = clean). */
+export function findArtifacts(html) {
+  return ARTIFACT_PATTERNS.filter((p) => p.test(html)).map((p) => p.label);
+}
+
+/**
+ * Returns { [section]: boolean } indicating which sections are present in the
+ * rendered HTML. A section is covered if ANY of its sentinel strings appears.
+ */
+export function sectionCoverage(html) {
+  const cov = {};
+  for (const [section, sentinels] of Object.entries(SECTION_SENTINELS)) {
+    cov[section] = sentinels.some((sentinel) => html.includes(sentinel));
+  }
+  return cov;
+}
+
+/**
+ * Hard assertions shared by both suites: render must not throw (caller awaits
+ * format), must return non-empty HTML, and must contain no raw artifacts.
+ * Returns the section-coverage map for snapshotting.
+ */
+export function assertThemeRender(expect, themeName, html) {
+  expect(
+    typeof html === 'string' && html.length > 0,
+    `theme "${themeName}" rendered empty HTML`
+  ).toBe(true);
+
+  const artifacts = findArtifacts(html);
+  expect(
+    artifacts,
+    `theme "${themeName}" emitted raw artifacts: ${artifacts.join(', ')}`
+  ).toEqual([]);
+
+  const coverage = sectionCoverage(html);
+  for (const section of BASELINE_SECTIONS) {
+    expect(
+      coverage[section],
+      `theme "${themeName}" missing BASELINE section "${section}"`
+    ).toBe(true);
+  }
+  return coverage;
+}
+
+/**
+ * Run the permanent QA gate against a single theme's `render` function.
+ *
+ * Calls `render(fixture)` (defaulting the fixture to the canonical complete
+ * resume from @jsonresume/sample-data) and applies {@link assertThemeRender}.
+ * This is the entry point theme authors use in their own test suite to prove a
+ * theme renders the complete fixture without crashing or dropping a baseline
+ * section — the identical gate the registry enforces across all themes.
+ *
+ * @param {object} opts
+ * @param {(resume: object) => (string|Promise<string>)} opts.render Theme render.
+ * @param {string} opts.name   Theme name (used in failure messages).
+ * @param {object} opts.expect The test framework's `expect` (e.g. vitest's).
+ * @param {object} [opts.fixture] Resume to render; defaults to completeResume.
+ * @returns {Promise<Record<string, boolean>>} the section-coverage map.
+ */
+export async function runThemeRenderQa({ render, name, expect, fixture }) {
+  // Lazy-load the fixture so importing the QA helpers never forces the
+  // sample-data dependency on consumers that pass their own fixture.
+  let resume = fixture;
+  if (!resume) {
+    const sampleData = await import('@jsonresume/sample-data');
+    resume = sampleData.completeResume;
+  }
+  const html = await render(resume);
+  return assertThemeRender(expect, name, html);
+}

--- a/packages/theme-kit/src/ssr.js
+++ b/packages/theme-kit/src/ssr.js
@@ -1,0 +1,10 @@
+/**
+ * Re-export of the @jsonresume/core SSR document helpers, so theme authors can
+ * `import { renderResumeDocument } from '@jsonresume/theme-kit'` (or
+ * '@jsonresume/theme-kit/ssr') as a single authoring entry point alongside the
+ * QA gate. The implementation lives in @jsonresume/core/ssr; @jsonresume/core
+ * is a peerDependency here so a theme's existing core install is reused.
+ *
+ * @module @jsonresume/theme-kit/ssr
+ */
+export { renderResumeDocument, googleFontsLinks } from '@jsonresume/core/ssr';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@jsonresume/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      '@jsonresume/theme-kit':
+        specifier: workspace:*
+        version: link:../../packages/theme-kit
       '@jsonresume/theme-stackoverflow':
         specifier: ^2
         version: link:../../packages/themes/stackoverflow
@@ -961,6 +964,31 @@ importers:
       '@repo/eslint-config-custom':
         specifier: workspace:^
         version: link:../eslint-config-custom
+
+  packages/theme-kit:
+    dependencies:
+      '@jsonresume/core':
+        specifier: workspace:*
+        version: link:../resume-core
+      '@jsonresume/sample-data':
+        specifier: workspace:*
+        version: link:../sample-data
+    devDependencies:
+      '@repo/eslint-config-custom':
+        specifier: workspace:^
+        version: link:../eslint-config-custom
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+      styled-components:
+        specifier: ^6.1.19
+        version: 6.1.19(react-dom@19.2.7)(react@19.2.7)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/node@20.19.24)(@vitest/ui@3.2.6)(jsdom@27.0.1)
 
   packages/themes/jsonresume-theme-academic-cv-lite:
     dependencies:


### PR DESCRIPTION
Wave 2 of the @jsonresume ecosystem (#421), on top of W1 (types/utils/sample-data/core). Scope: the SSR document helper + \`@jsonresume/theme-kit\` only — no theme refactors, no ats-validator/theme-config (later waves).

## @jsonresume/core/ssr (new subpath)
- \`renderResumeDocument(element, options)\` -> full \`<!DOCTYPE html>\` document. Wraps the \`ServerStyleSheet\` boilerplate every JSX theme repeats today: \`collectStyles\` + \`renderToStaticMarkup\` + \`getStyleTags\`, always \`seal()\` in \`finally\`. Options: \`fonts\`, \`title\`, \`lang='en'\`, \`dir='ltr'\`, \`reset=false\`, \`head=''\`, \`includeTokensCss=true\`, \`bodyClass\`.
- \`googleFontsLinks(families)\` -> preconnect + css2 \`<link>\`s; accepts bare family names (combined into one request) or ready-made hrefs/\`<link>\` tags (passed through).
- SSR-safe (no window/document at module load). New \`./ssr\` export only; existing exports unchanged.

## @jsonresume/theme-kit (new publishable package, 0.1.0)
- Extracts \`findArtifacts\`, \`sectionCoverage\`, \`assertThemeRender\` and the \`SECTION_SENTINELS\` / \`BASELINE_SECTIONS\` / \`HANDLEBARS_THEMES\` constants from the registry QA module **verbatim**.
- Adds \`runThemeRenderQa({ render, name, expect, fixture })\` (fixture defaults to \`completeResume\`).
- Re-exports \`renderResumeDocument\` + \`googleFontsLinks\` from \`@jsonresume/core/ssr\`.
- Deps: \`@jsonresume/sample-data\` (fixture); \`@jsonresume/core\` peer (ssr re-export). Subpath exports: \`./qa\`, \`./ssr\`.

## Registry shim
- \`apps/registry/lib/formatters/template/themeRenderQa.js\` now re-exports the helpers/constants from \`@jsonresume/theme-kit/qa\`. The three existing suites (\`themeRenderQa.test.js\`, \`.handlebars.test.js\`, \`.helpers.test.js\`) import from the old path unchanged and stay green. Added \`@jsonresume/theme-kit\` as a registry workspace dep.

## Verification
- Extraction is non-weakening: the assertion/constant/regex block is **byte-identical** to origin/master (sha256 \`0b1d20a5…cbafd119\` on both \`themeRenderQa.js\` and the new \`qa.js\`). Committed \`theme-coverage.json\` did not change.
- Green: \`pnpm --filter registry test -- --run\` (1640 passed; QA gate 59 ESM + 6 Handlebars + 19 helper tests via theme-kit), \`pnpm --filter @jsonresume/core test\` (100), \`pnpm --filter @jsonresume/theme-kit test\` (21), \`pnpm turbo lint typecheck prettier --force\` exit 0.
- Changesets: \`@jsonresume/theme-kit\` minor (new), \`@jsonresume/core\` minor (adds ./ssr).

Refs #421

— AI