### PR TITLE
refactor(themes): migrate berlin-grid/clinical-precision/industrial-engineer/brutalist/art-deco onto @jsonresume/core/ssr (W3 pilot)

### DIFF
--- a/.changeset/ssr-art-deco.md
+++ b/.changeset/ssr-art-deco.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-art-deco': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/.changeset/ssr-berlin-grid.md
+++ b/.changeset/ssr-berlin-grid.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-berlin-grid': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/.changeset/ssr-brutalist.md
+++ b/.changeset/ssr-brutalist.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-brutalist': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/.changeset/ssr-clinical-precision.md
+++ b/.changeset/ssr-clinical-precision.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-clinical-precision': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/.changeset/ssr-industrial-engineer.md
+++ b/.changeset/ssr-industrial-engineer.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-industrial-engineer': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/packages/themes/jsonresume-theme-art-deco/index.jsx
+++ b/packages/themes/jsonresume-theme-art-deco/index.jsx
@@ -1,24 +1,15 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;700&family=Poiret+One&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: [
+      'Cinzel:wght@500;700',
+      'Poiret One',
+      'Cormorant Garamond:ital,wght@0,400;0,500;0,600;1,400',
+    ],
+    title,
+    includeTokensCss: false,
+  });
 }

--- a/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
@@ -1,5 +1,5 @@
 import { jsx, jsxs } from "react/jsx-runtime";
-import { renderToString } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server";
 import o, { useRef, useContext, useState, useMemo, useEffect, useDebugValue, createElement, createContext } from "react";
 var __assign = function() {
   __assign = Object.assign || function __assign2(t) {
@@ -1300,6 +1300,65 @@ var vt = /^\s*<\/[a-z]/i, gt = (function() {
 "production" !== process.env.NODE_ENV && "undefined" != typeof navigator && "ReactNative" === navigator.product && console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");
 var wt = "__sc-".concat(f, "__");
 "production" !== process.env.NODE_ENV && "test" !== process.env.NODE_ENV && "undefined" != typeof window && (window[wt] || (window[wt] = 0), 1 === window[wt] && console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."), window[wt] += 1);
+const CSS_RESET = "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>";
+const TOKENS_CSS_HREF = "https://unpkg.com/@jsonresume/core/dist/tokens.css";
+const FONTS_PRECONNECT = '<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith("<link");
+}
+function familyParam(family) {
+  const [name, ...rest] = String(family).split(":");
+  const encodedName = name.trim().replace(/\s+/g, "+");
+  return rest.length ? `${encodedName}:${rest.join(":")}` : encodedName;
+}
+function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return "";
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === "") continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+  const links = passthrough.map(
+    (href) => href.trim().startsWith("<link") ? href : `<link href="${href}" rel="stylesheet">`
+  );
+  if (names.length > 0) {
+    const query = names.map(familyParam).join("&family=");
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+  if (links.length === 0) return "";
+  return FONTS_PRECONNECT + links.join("");
+}
+function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = "en",
+    dir = "ltr",
+    reset = false,
+    head = "",
+    includeTokensCss = true,
+    bodyClass
+  } = options;
+  const sheet = new gt();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">` : "";
+  const resetTag = reset ? CSS_RESET : "";
+  const titleTag = title ? `<title>${title}</title>` : "";
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+}
 createContext({
   theme: "professional",
   setTheme: () => {
@@ -1477,7 +1536,9 @@ function formatDateRange({
     return formatter.format(date);
   };
   const start = formatDate(startDate);
-  if (endDate === void 0) return start;
+  if (endDate === void 0) {
+    return start;
+  }
   const end = formatDate(endDate);
   return `${start} - ${end}`;
 }
@@ -1598,7 +1659,6 @@ function safeUrl(url) {
   const trimmed = url.trim();
   const dangerousProtocols = /^(javascript|data|vbscript|file|about):/i;
   if (dangerousProtocols.test(trimmed)) {
-    console.warn(`[Security] Blocked dangerous URL: ${trimmed.slice(0, 50)}`);
     return null;
   }
   const safeProtocols = /^(https?|mailto|tel|sms|ftp):/i;
@@ -1614,7 +1674,6 @@ function safeUrl(url) {
   if (/^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmed)) {
     return `https://${trimmed}`;
   }
-  console.warn(`[Security] Uncertain URL safety: ${trimmed.slice(0, 50)}`);
   return trimmed;
 }
 function isExternalUrl(url, currentOrigin = null) {
@@ -6493,22 +6552,12 @@ function Resume({ resume }) {
   ] });
 }
 function render(resume) {
-  const sheet = new gt();
-  const html = renderToString(sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume })));
-  const styles = sheet.getStyleTags();
   const title = resume.basics && resume.basics.name || "Resume";
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(/* @__PURE__ */ jsx(Resume, { resume }), {
+    fonts: ["IBM Plex Sans:wght@400;500;600;700"],
+    title,
+    includeTokensCss: false
+  });
 }
 export {
   render

--- a/packages/themes/jsonresume-theme-berlin-grid/index.jsx
+++ b/packages/themes/jsonresume-theme-berlin-grid/index.jsx
@@ -1,23 +1,11 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: ['IBM Plex Sans:wght@400;500;600;700'],
+    title,
+    includeTokensCss: false,
+  });
 }

--- a/packages/themes/jsonresume-theme-brutalist/index.jsx
+++ b/packages/themes/jsonresume-theme-brutalist/index.jsx
@@ -1,24 +1,15 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Grotesk:wght@400;500;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: [
+      'Archivo Black',
+      'Space Grotesk:wght@400;500;700',
+      'Space Mono:wght@400;700',
+    ],
+    title,
+    includeTokensCss: false,
+  });
 }

--- a/packages/themes/jsonresume-theme-clinical-precision/dist/index.js
+++ b/packages/themes/jsonresume-theme-clinical-precision/dist/index.js
@@ -1,5 +1,5 @@
 import { jsx, jsxs } from "react/jsx-runtime";
-import { renderToString } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server";
 import o, { useRef, useContext, useState, useMemo, useEffect, useDebugValue, createElement, createContext } from "react";
 var __assign = function() {
   __assign = Object.assign || function __assign2(t) {
@@ -1300,6 +1300,65 @@ var vt = /^\s*<\/[a-z]/i, gt = (function() {
 "production" !== process.env.NODE_ENV && "undefined" != typeof navigator && "ReactNative" === navigator.product && console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");
 var wt = "__sc-".concat(f, "__");
 "production" !== process.env.NODE_ENV && "test" !== process.env.NODE_ENV && "undefined" != typeof window && (window[wt] || (window[wt] = 0), 1 === window[wt] && console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."), window[wt] += 1);
+const CSS_RESET = "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>";
+const TOKENS_CSS_HREF = "https://unpkg.com/@jsonresume/core/dist/tokens.css";
+const FONTS_PRECONNECT = '<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith("<link");
+}
+function familyParam(family) {
+  const [name, ...rest] = String(family).split(":");
+  const encodedName = name.trim().replace(/\s+/g, "+");
+  return rest.length ? `${encodedName}:${rest.join(":")}` : encodedName;
+}
+function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return "";
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === "") continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+  const links = passthrough.map(
+    (href) => href.trim().startsWith("<link") ? href : `<link href="${href}" rel="stylesheet">`
+  );
+  if (names.length > 0) {
+    const query = names.map(familyParam).join("&family=");
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+  if (links.length === 0) return "";
+  return FONTS_PRECONNECT + links.join("");
+}
+function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = "en",
+    dir = "ltr",
+    reset = false,
+    head = "",
+    includeTokensCss = true,
+    bodyClass
+  } = options;
+  const sheet = new gt();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">` : "";
+  const resetTag = reset ? CSS_RESET : "";
+  const titleTag = title ? `<title>${title}</title>` : "";
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+}
 createContext({
   theme: "professional",
   setTheme: () => {
@@ -1477,7 +1536,9 @@ function formatDateRange({
     return formatter.format(date);
   };
   const start = formatDate(startDate);
-  if (endDate === void 0) return start;
+  if (endDate === void 0) {
+    return start;
+  }
   const end = formatDate(endDate);
   return `${start} - ${end}`;
 }
@@ -1598,7 +1659,6 @@ function safeUrl(url) {
   const trimmed = url.trim();
   const dangerousProtocols = /^(javascript|data|vbscript|file|about):/i;
   if (dangerousProtocols.test(trimmed)) {
-    console.warn(`[Security] Blocked dangerous URL: ${trimmed.slice(0, 50)}`);
     return null;
   }
   const safeProtocols = /^(https?|mailto|tel|sms|ftp):/i;
@@ -1614,7 +1674,6 @@ function safeUrl(url) {
   if (/^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmed)) {
     return `https://${trimmed}`;
   }
-  console.warn(`[Security] Uncertain URL safety: ${trimmed.slice(0, 50)}`);
   return trimmed;
 }
 function isExternalUrl(url, currentOrigin = null) {
@@ -6673,23 +6732,15 @@ function Resume({ resume }) {
   ] });
 }
 function render(resume) {
-  const sheet = new gt();
-  const html = renderToString(sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume })));
-  const styles = sheet.getStyleTags();
   const title = resume.basics && resume.basics.name || "Resume";
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(/* @__PURE__ */ jsx(Resume, { resume }), {
+    fonts: [
+      "IBM Plex Mono:wght@400;500;600",
+      "IBM Plex Sans:wght@400;500;600;700"
+    ],
+    title,
+    includeTokensCss: false
+  });
 }
 export {
   render

--- a/packages/themes/jsonresume-theme-clinical-precision/index.jsx
+++ b/packages/themes/jsonresume-theme-clinical-precision/index.jsx
@@ -1,24 +1,14 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: [
+      'IBM Plex Mono:wght@400;500;600',
+      'IBM Plex Sans:wght@400;500;600;700',
+    ],
+    title,
+    includeTokensCss: false,
+  });
 }

--- a/packages/themes/jsonresume-theme-industrial-engineer/index.jsx
+++ b/packages/themes/jsonresume-theme-industrial-engineer/index.jsx
@@ -1,24 +1,14 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-  ${styles}
-</head>
-<body>${html}</body>
-</html>`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: [
+      'IBM Plex Mono:wght@400;500;600;700',
+      'IBM Plex Sans:wght@400;500;600;700',
+    ],
+    title,
+    includeTokensCss: false,
+  });
 }


### PR DESCRIPTION
## W3 pilot (#421): migrate 5 themes onto `@jsonresume/core/ssr`

Proves the `renderResumeDocument` pattern before the fan-out to all ~46 React themes.

**Pilot themes:** berlin-grid, clinical-precision, industrial-engineer, brutalist, art-deco

### Before / after render() shape

Each theme's render() previously hand-rolled the SSR boilerplate:

```js
const sheet = new ServerStyleSheet();
const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
const styles = sheet.getStyleTags();
return `<!DOCTYPE html><html lang="en"><head>...<link ...fonts...>${styles}</head><body>${html}</body></html>`;
```

Now it is a single call:

```js
const title = (resume.basics && resume.basics.name) || 'Resume';
return renderResumeDocument(<Resume resume={resume} />, {
  fonts: [/* the theme's exact Google font families */],
  title,
  includeTokensCss: false,
});
```

The element passed is the same `<Resume resume={resume} />` tree as before. Resume.jsx and styles are untouched. `includeTokensCss: false` because none of these themes linked the tokens stylesheet originally.

### Equivalence evidence

Rendered each theme BEFORE (origin/master) and AFTER against `@jsonresume/sample-data` `completeResume`, then diffed:

| Theme | styled-components rules | font families | font `<link>`s | body markup |
|---|---|---|---|---|
| berlin-grid | identical | identical | identical | identical after stripping `<!-- -->` |
| clinical-precision | identical | identical | identical | identical after stripping `<!-- -->` |
| industrial-engineer | identical | identical | identical | identical after stripping `<!-- -->` |
| brutalist | identical | identical | identical | identical after stripping `<!-- -->` |
| art-deco | identical | identical | identical | identical after stripping `<!-- -->` |

The only body delta is React's inert `<!-- -->` text-boundary comments: the helper uses `renderToStaticMarkup` (omits them) while themes used `renderToString` (emits them). These are invisible hydration delimiters with zero visual effect on statically-served documents; visible text is byte-identical. The doctype/head wrapper is normalized by the helper (whitespace collapsed, `dir="ltr"` added, and the `fonts.gstatic.com` preconnect is always emitted — berlin-grid gained it, the other four already had it).

### Verification

- `pnpm --filter registry test -- --run` — full suite green (1640 pass), `themeRenderQa` gate green for all 5 pilots
- Each theme builds via `vite build` (SSR) cleanly
- `pnpm turbo lint typecheck prettier` — EXIT 0 (22/22)

### Notes for the fan-out

- 2 of the 5 pilots (berlin-grid, clinical-precision) commit `dist/` build artifacts, and the release pipeline (`pnpm changeset publish`) has no pre-publish build step — so their `dist/index.js` was rebuilt + committed to stay in sync with source. The other three don't track `dist/`. The fan-out must rebuild + commit `dist/` for any theme that tracks it.
- All 5 fit the helper cleanly; no theme needed `reset`, `lang`, `dir`, `bodyClass`, or `head`.

Patch changeset per theme. Refs #421.

— AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server-side rendering implementation across five resume themes (Art Deco, Berlin Grid, Brutalist, Clinical Precision, and Industrial Engineer). Each theme received a patch-level update to consolidate and streamline their rendering mechanisms for improved consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->