### PR TITLE
refactor(themes): SSR migration inline-style pilot (data-driven; 4 blocked)

### DIFF
--- a/.changeset/ssr-data-driven.md
+++ b/.changeset/ssr-data-driven.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-data-driven': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/packages/themes/jsonresume-theme-data-driven/dist/index.js
+++ b/packages/themes/jsonresume-theme-data-driven/dist/index.js
@@ -1,5 +1,5 @@
 import { jsxs, Fragment, jsx } from "react/jsx-runtime";
-import { renderToString } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server";
 import o, { useRef, useContext, useState, useMemo, useEffect, useDebugValue, createElement, createContext } from "react";
 var __assign = function() {
   __assign = Object.assign || function __assign2(t) {
@@ -1300,6 +1300,65 @@ var vt = /^\s*<\/[a-z]/i, gt = (function() {
 "production" !== process.env.NODE_ENV && "undefined" != typeof navigator && "ReactNative" === navigator.product && console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");
 var wt = "__sc-".concat(f, "__");
 "production" !== process.env.NODE_ENV && "test" !== process.env.NODE_ENV && "undefined" != typeof window && (window[wt] || (window[wt] = 0), 1 === window[wt] && console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."), window[wt] += 1);
+const CSS_RESET = "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>";
+const TOKENS_CSS_HREF = "https://unpkg.com/@jsonresume/core/dist/tokens.css";
+const FONTS_PRECONNECT = '<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith("<link");
+}
+function familyParam(family) {
+  const [name, ...rest] = String(family).split(":");
+  const encodedName = name.trim().replace(/\s+/g, "+");
+  return rest.length ? `${encodedName}:${rest.join(":")}` : encodedName;
+}
+function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return "";
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === "") continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+  const links = passthrough.map(
+    (href) => href.trim().startsWith("<link") ? href : `<link href="${href}" rel="stylesheet">`
+  );
+  if (names.length > 0) {
+    const query = names.map(familyParam).join("&family=");
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+  if (links.length === 0) return "";
+  return FONTS_PRECONNECT + links.join("");
+}
+function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = "en",
+    dir = "ltr",
+    reset = false,
+    head = "",
+    includeTokensCss = true,
+    bodyClass
+  } = options;
+  const sheet = new gt();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">` : "";
+  const resetTag = reset ? CSS_RESET : "";
+  const titleTag = title ? `<title>${title}</title>` : "";
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+}
 createContext({
   theme: "professional",
   setTheme: () => {
@@ -1446,7 +1505,9 @@ function formatDateRange({
     return formatter.format(date);
   };
   const start = formatDate(startDate);
-  if (endDate === void 0) return start;
+  if (endDate === void 0) {
+    return start;
+  }
   const end = formatDate(endDate);
   return `${start} - ${end}`;
 }
@@ -6313,29 +6374,10 @@ function Resume({ resume }) {
     ] })
   ] });
 }
-const render = (resume) => {
-  const sheet = new gt();
-  try {
-    const html = renderToString(
-      sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume }))
-    );
-    const styles = sheet.getStyleTags();
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${resume.basics?.name || "Resume"}</title>
-  ${styles}
-</head>
-<body>
-  ${html}
-</body>
-</html>`;
-  } finally {
-    sheet.seal();
-  }
-};
+const render = (resume) => renderResumeDocument(/* @__PURE__ */ jsx(Resume, { resume }), {
+  title: resume.basics?.name || "Resume",
+  includeTokensCss: false
+});
 const index = { render };
 export {
   Resume,

--- a/packages/themes/jsonresume-theme-data-driven/src/index.jsx
+++ b/packages/themes/jsonresume-theme-data-driven/src/index.jsx
@@ -4,33 +4,14 @@
  * Built with @jsonresume/core primitives and React SSR
  */
 
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './ui/Resume.jsx';
 
-export const render = (resume) => {
-  const sheet = new ServerStyleSheet();
-  try {
-    const html = renderToString(
-      sheet.collectStyles(<Resume resume={resume} />)
-    );
-    const styles = sheet.getStyleTags();
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${resume.basics?.name || 'Resume'}</title>
-  ${styles}
-</head>
-<body>
-  ${html}
-</body>
-</html>`;
-  } finally {
-    sheet.seal();
-  }
-};
+export const render = (resume) =>
+  renderResumeDocument(<Resume resume={resume} />, {
+    title: resume.basics?.name || 'Resume',
+    includeTokensCss: false,
+  });
 
 export { Resume };
 export default { render };

--- a/packages/themes/jsonresume-theme-data-driven/tests/theme.test.js
+++ b/packages/themes/jsonresume-theme-data-driven/tests/theme.test.js
@@ -73,7 +73,7 @@ describe('Data-Driven Theme', () => {
     const html = render(completeResume);
 
     expect(html).toContain('<!DOCTYPE html>');
-    expect(html).toContain('<html lang="en">');
+    expect(html).toContain('<html lang="en" dir="ltr">');
     expect(html).toContain('</html>');
   });
 


### PR DESCRIPTION
Pilot for #421 — migrate the harder theme cohort (inline <style> in <head> and/or dynamic lang/dir) onto \`@jsonresume/core/ssr\` renderResumeDocument.

## Result: 1 of 5 migrated; 4 blocked by a real cascade gap

**Migrated:** \`data-driven\` — no inline <style>, no fonts, no dynamic lang/dir. Mechanical migration. Against \`@jsonresume/sample-data\` completeResume: styled-components CSS byte-identical, <body> markup identical, html \`lang="en"\` preserved. The helper adds its canonical \`dir="ltr"\` and emits \`<title>\` after the styled tags — both are the already-shipped helper convention (matches batch-A/B themes e.g. pacific-horizon) and are inert (title vs style has no cascade). Updated the theme’s own HTML-string assertion accordingly. dist/ rebuilt + committed.

**Blocked (left unmigrated): \`elegant-pink\`, \`academic-cv-lite\`, \`modern-classic\`, \`government-standard\`.**
Each ships an inline <style> (reset \`*{}\`, \`body\` bg, \`@media print\`, \`@page\`) placed AFTER \`sheet.getStyleTags()\`, so it overrides component styles. renderResumeDocument places its \`head\` option BEFORE the styled tags, which cannot reproduce that ordering — migrating would be a cascade regression and a head-ORDER change. elegant-pink is worse: it has split <style> blocks straddling the styled tags (:root tokens before, globalStyles after) plus dynamic lang/dir.

## Fan-out blocker
The remaining ~27-theme fan-out needs a new renderResumeDocument option, e.g. \`headAfterStyles\` (raw HTML inserted AFTER styleTags), before the AFTER-cascade cohort can migrate. The current \`head\` (before-styles) option only covers themes whose inline <style> was already before getStyleTags().

## Verification (EXIT 0)
- \`pnpm --filter registry test -- --run\` → 1640 passed (themeRenderQa gate green)
- \`jsonresume-theme-data-driven\` vitest → 13 passed
- data-driven vite build OK
- \`pnpm turbo lint typecheck prettier\` → 22/22 successful

Per-theme PATCH changeset added. Do not merge; for review.
— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated server-side rendering to use standardized approach from core library for improved consistency and reliability.
  * HTML documents now include proper text direction attributes for enhanced internationalization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->