### PR TITLE
feat(core): renderResumeDocument headAfterStyles option (unblocks inline-style theme migration)

### DIFF
--- a/.changeset/core-head-after-styles.md
+++ b/.changeset/core-head-after-styles.md
@@ -1,0 +1,10 @@
+---
+'@jsonresume/core': patch
+---
+
+`renderResumeDocument` gains a composable `headAfterStyles` option: raw HTML
+inserted in `<head>` AFTER the styled-components tags (for inline `<style>` that
+must override component styles — global resets, body backgrounds, `@media print`
+/ `@page` rules). Composes with the existing `head` option (before the styled
+tags), so a theme can reproduce inline-style blocks on either side of the
+component CSS cascade. Backward-compatible (default empty).

--- a/packages/resume-core/src/__tests__/ssr/renderResumeDocument.test.jsx
+++ b/packages/resume-core/src/__tests__/ssr/renderResumeDocument.test.jsx
@@ -103,6 +103,26 @@ describe('renderResumeDocument', () => {
     expect(out).toContain('<body class="theme-foo">');
   });
 
+  it('places head before, and headAfterStyles after, the styled-components tags', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>, {
+      head: '<style id="before">:root{--x:1}</style>',
+      headAfterStyles: '<style id="after">@page{margin:1cm}</style>',
+    });
+    const before = out.indexOf('id="before"');
+    const styled = out.indexOf('data-styled');
+    const after = out.indexOf('id="after"');
+    expect(before).toBeGreaterThan(-1);
+    expect(after).toBeGreaterThan(-1);
+    // cascade order: head -> styled-components -> headAfterStyles
+    expect(before).toBeLessThan(styled);
+    expect(styled).toBeLessThan(after);
+  });
+
+  it('omits headAfterStyles when not provided', () => {
+    const out = renderResumeDocument(<Box>Hi</Box>);
+    expect(out).not.toContain('id="after"');
+  });
+
   it('always seals the sheet — styles do not leak across calls', () => {
     // Two different styled components rendered in separate calls. If the sheet
     // were not sealed, the second document would carry the first's rules.

--- a/packages/resume-core/src/ssr/index.js
+++ b/packages/resume-core/src/ssr/index.js
@@ -96,7 +96,13 @@ export function googleFontsLinks(families) {
  * @param {string}   [options.lang='en']        <html lang> attribute.
  * @param {string}   [options.dir='ltr']        <html dir> attribute.
  * @param {boolean}  [options.reset=false]      Include the minimal CSS reset.
- * @param {string}   [options.head='']          Extra raw HTML for the <head>.
+ * @param {string}   [options.head='']          Raw HTML inserted in <head> BEFORE the
+ *   styled-components tags (base styles a theme's components then override — e.g. a
+ *   `:root` design-token block or a CSS reset).
+ * @param {string}   [options.headAfterStyles=''] Raw HTML inserted in <head> AFTER the
+ *   styled-components tags (styles that must OVERRIDE component styles — e.g. a global
+ *   reset, body background, or `@media print`/`@page` rules). Composes with `head`:
+ *   a theme can pass both to reproduce an inline-style block on each side.
  * @param {boolean}  [options.includeTokensCss=true] Link @jsonresume/core tokens.
  * @param {string}   [options.bodyClass]        class attribute on <body>.
  * @returns {string} Full `<!DOCTYPE html>...` document.
@@ -109,6 +115,7 @@ export function renderResumeDocument(element, options = {}) {
     dir = 'ltr',
     reset = false,
     head = '',
+    headAfterStyles = '',
     includeTokensCss = true,
     bodyClass,
   } = options;
@@ -142,6 +149,7 @@ export function renderResumeDocument(element, options = {}) {
     resetTag +
     head +
     styleTags +
+    headAfterStyles +
     titleTag +
     '</head>' +
     `<body${bodyAttr}>${html}</body>` +


### PR DESCRIPTION
Adds a composable `headAfterStyles` option to `renderResumeDocument` — raw `<head>` HTML inserted AFTER the styled-components tags (for inline `<style>` that must override component styles: resets, body backgrounds, `@media print`/`@page`). Composes with the existing `head` (before-styles) option, so themes like `elegant-pink` can reproduce inline-style blocks straddling the component-CSS cascade.

Found by the W3c migration pilot (#435): 4 of 5 inline-style themes place their inline `<style>` after the styled tags, which the `head`-only API couldn't reproduce without a cascade regression. Backward-compatible (default empty); `@jsonresume/theme-kit` re-export inherits it. Unblocks the ~27-theme inline-style fan-out.

Refs #421

— AI