### PR TITLE
refactor(themes): SSR migration final batch 2 (adds <html> wrapper)

### DIFF
--- a/.changeset/ssr-professional.md
+++ b/.changeset/ssr-professional.md
@@ -1,0 +1,5 @@
+---
+'@jsonresume/jsonresume-theme-professional': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/.changeset/ssr-tokyo-modernist.md
+++ b/.changeset/ssr-tokyo-modernist.md
@@ -1,0 +1,5 @@
+---
+'@jsonresume/jsonresume-theme-tokyo-modernist': patch
+---
+
+use @jsonresume/core/ssr renderResumeDocument

--- a/packages/themes/jsonresume-theme-professional/dist/index.mjs
+++ b/packages/themes/jsonresume-theme-professional/dist/index.mjs
@@ -1,5 +1,5 @@
 import { jsxs, Fragment, jsx } from "react/jsx-runtime";
-import { renderToString } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server";
 import o, { useState, useMemo, useEffect, useContext, useDebugValue, createElement, useRef } from "react";
 import { marked } from "marked";
 import { FaMapPin, FaEnvelope, FaPhoneAlt, FaLink, FaLinkedin, FaGithub, FaTwitter } from "react-icons/fa";
@@ -1271,6 +1271,66 @@ var vt = /^\s*<\/[a-z]/i, gt = (function() {
 "production" !== process.env.NODE_ENV && "undefined" != typeof navigator && "ReactNative" === navigator.product && console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");
 var wt = "__sc-".concat(f, "__");
 "production" !== process.env.NODE_ENV && "test" !== process.env.NODE_ENV && "undefined" != typeof window && (window[wt] || (window[wt] = 0), 1 === window[wt] && console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."), window[wt] += 1);
+const CSS_RESET = "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>";
+const TOKENS_CSS_HREF = "https://unpkg.com/@jsonresume/core/dist/tokens.css";
+const FONTS_PRECONNECT = '<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith("<link");
+}
+function familyParam(family) {
+  const [name, ...rest] = String(family).split(":");
+  const encodedName = name.trim().replace(/\s+/g, "+");
+  return rest.length ? `${encodedName}:${rest.join(":")}` : encodedName;
+}
+function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return "";
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === "") continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+  const links = passthrough.map(
+    (href) => href.trim().startsWith("<link") ? href : `<link href="${href}" rel="stylesheet">`
+  );
+  if (names.length > 0) {
+    const query = names.map(familyParam).join("&family=");
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+  if (links.length === 0) return "";
+  return FONTS_PRECONNECT + links.join("");
+}
+function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = "en",
+    dir = "ltr",
+    reset = false,
+    head = "",
+    headAfterStyles = "",
+    includeTokensCss = true,
+    bodyClass
+  } = options;
+  const sheet = new gt();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">` : "";
+  const resetTag = reset ? CSS_RESET : "";
+  const titleTag = title ? `<title>${title}</title>` : "";
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+}
 const Section = dt.div`
   max-width: 700px;
   margin: 0 auto 18px;
@@ -1687,14 +1747,10 @@ const Resume = ({ resume }) => {
   ] });
 };
 const render = (resume) => {
-  const sheet = new gt();
-  const html = renderToString(sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume })));
-  const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><html lang="en"><head>
-  <title>${resume.basics.name} - Resume</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
+  return renderResumeDocument(
+    /* @__PURE__ */ jsx("main", { children: /* @__PURE__ */ jsx(Resume, { resume }) }),
+    {
+      head: `<style>
     @font-face {
       font-family: LatinModern;
       font-style: normal;
@@ -1781,8 +1837,13 @@ const render = (resume) => {
 
 
 
-  </style>
-  ${styles}</head><body><main>${html}</main></body></html>`;
+  </style>`,
+      lang: "en",
+      dir: "ltr",
+      title: `${resume.basics.name} - Resume`,
+      includeTokensCss: false
+    }
+  );
 };
 export {
   Resume,

--- a/packages/themes/jsonresume-theme-professional/package.json
+++ b/packages/themes/jsonresume-theme-professional/package.json
@@ -20,6 +20,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@jsonresume/core": "workspace:*",
     "marked": "^16.3.0",
     "prismjs": "^1.29.0",
     "react-icons": "^5.0.1"

--- a/packages/themes/jsonresume-theme-professional/src/index.jsx
+++ b/packages/themes/jsonresume-theme-professional/src/index.jsx
@@ -1,16 +1,13 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './ui/Resume';
 
 export const render = (resume) => {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><html lang="en"><head>
-  <title>${resume.basics.name} - Resume</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <style>
+  return renderResumeDocument(
+    <main>
+      <Resume resume={resume} />
+    </main>,
+    {
+      head: `<style>
     @font-face {
       font-family: LatinModern;
       font-style: normal;
@@ -97,8 +94,13 @@ export const render = (resume) => {
 
 
 
-  </style>
-  ${styles}</head><body><main>${html}</main></body></html>`;
+  </style>`,
+      lang: 'en',
+      dir: 'ltr',
+      title: `${resume.basics.name} - Resume`,
+      includeTokensCss: false,
+    }
+  );
 };
 
 export { Resume };

--- a/packages/themes/jsonresume-theme-tokyo-modernist/dist/index.js
+++ b/packages/themes/jsonresume-theme-tokyo-modernist/dist/index.js
@@ -1,5 +1,5 @@
 import { jsx, jsxs } from "react/jsx-runtime";
-import { renderToString } from "react-dom/server";
+import { renderToStaticMarkup } from "react-dom/server";
 import o, { useRef, useContext, useState, useMemo, useEffect, useDebugValue, createElement, createContext } from "react";
 var __assign = function() {
   __assign = Object.assign || function __assign2(t) {
@@ -1300,6 +1300,66 @@ var vt = /^\s*<\/[a-z]/i, gt = (function() {
 "production" !== process.env.NODE_ENV && "undefined" != typeof navigator && "ReactNative" === navigator.product && console.warn("It looks like you've imported 'styled-components' on React Native.\nPerhaps you're looking to import 'styled-components/native'?\nRead more about this at https://www.styled-components.com/docs/basics#react-native");
 var wt = "__sc-".concat(f, "__");
 "production" !== process.env.NODE_ENV && "test" !== process.env.NODE_ENV && "undefined" != typeof window && (window[wt] || (window[wt] = 0), 1 === window[wt] && console.warn("It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles to not render properly, errors during the rehydration process, a missing theme prop, and makes your application bigger without good reason.\n\nSee https://s-c.sh/2BAXzed for more info."), window[wt] += 1);
+const CSS_RESET = "<style>*,*::before,*::after{box-sizing:border-box}html,body{margin:0;padding:0}body{-webkit-font-smoothing:antialiased}</style>";
+const TOKENS_CSS_HREF = "https://unpkg.com/@jsonresume/core/dist/tokens.css";
+const FONTS_PRECONNECT = '<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>';
+function isHref(value) {
+  return /^(https?:)?\/\//.test(value) || value.trim().startsWith("<link");
+}
+function familyParam(family) {
+  const [name, ...rest] = String(family).split(":");
+  const encodedName = name.trim().replace(/\s+/g, "+");
+  return rest.length ? `${encodedName}:${rest.join(":")}` : encodedName;
+}
+function googleFontsLinks(families) {
+  if (!Array.isArray(families) || families.length === 0) return "";
+  const passthrough = [];
+  const names = [];
+  for (const entry of families) {
+    if (entry == null || entry === "") continue;
+    if (isHref(entry)) passthrough.push(entry);
+    else names.push(entry);
+  }
+  const links = passthrough.map(
+    (href) => href.trim().startsWith("<link") ? href : `<link href="${href}" rel="stylesheet">`
+  );
+  if (names.length > 0) {
+    const query = names.map(familyParam).join("&family=");
+    links.unshift(
+      `<link href="https://fonts.googleapis.com/css2?family=${query}&display=swap" rel="stylesheet">`
+    );
+  }
+  if (links.length === 0) return "";
+  return FONTS_PRECONNECT + links.join("");
+}
+function renderResumeDocument(element, options = {}) {
+  const {
+    fonts,
+    title,
+    lang = "en",
+    dir = "ltr",
+    reset = false,
+    head = "",
+    headAfterStyles = "",
+    includeTokensCss = true,
+    bodyClass
+  } = options;
+  const sheet = new gt();
+  let html;
+  let styleTags;
+  try {
+    html = renderToStaticMarkup(sheet.collectStyles(element));
+    styleTags = sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+  const fontLinks = googleFontsLinks(fonts);
+  const tokensLink = includeTokensCss ? `<link rel="stylesheet" href="${TOKENS_CSS_HREF}">` : "";
+  const resetTag = reset ? CSS_RESET : "";
+  const titleTag = title ? `<title>${title}</title>` : "";
+  const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+}
 createContext({
   theme: "professional",
   setTheme: () => {
@@ -1477,7 +1537,9 @@ function formatDateRange({
     return formatter.format(date);
   };
   const start = formatDate(startDate);
-  if (endDate === void 0) return start;
+  if (endDate === void 0) {
+    return start;
+  }
   const end = formatDate(endDate);
   return `${start} - ${end}`;
 }
@@ -1562,7 +1624,6 @@ function safeUrl(url) {
   const trimmed = url.trim();
   const dangerousProtocols = /^(javascript|data|vbscript|file|about):/i;
   if (dangerousProtocols.test(trimmed)) {
-    console.warn(`[Security] Blocked dangerous URL: ${trimmed.slice(0, 50)}`);
     return null;
   }
   const safeProtocols = /^(https?|mailto|tel|sms|ftp):/i;
@@ -1578,7 +1639,6 @@ function safeUrl(url) {
   if (/^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmed)) {
     return `https://${trimmed}`;
   }
-  console.warn(`[Security] Uncertain URL safety: ${trimmed.slice(0, 50)}`);
   return trimmed;
 }
 const ContactContainer = dt.div`
@@ -6441,17 +6501,11 @@ function Resume({ resume }) {
   ] });
 }
 const render = (resume) => {
-  const sheet = new gt();
-  const html = renderToString(sheet.collectStyles(/* @__PURE__ */ jsx(Resume, { resume })));
-  const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><head>
-  <title>${resume.basics.name} - Resume</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <style>
+  return renderResumeDocument(/* @__PURE__ */ jsx(Resume, { resume }), {
+    fonts: [
+      "https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap"
+    ],
+    head: `<style>
     html {
       font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: #fafbfc;
@@ -6521,8 +6575,12 @@ const render = (resume) => {
         background: white;
       }
     }
-  </style>
-  ${styles}</head><body>${html}</body></html>`;
+  </style>`,
+    lang: "en",
+    dir: "ltr",
+    title: `${resume.basics.name} - Resume`,
+    includeTokensCss: false
+  });
 };
 export {
   Resume,

--- a/packages/themes/jsonresume-theme-tokyo-modernist/src/index.jsx
+++ b/packages/themes/jsonresume-theme-tokyo-modernist/src/index.jsx
@@ -1,19 +1,12 @@
-import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './ui/Resume';
 
 export const render = (resume) => {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
-  return `<!DOCTYPE html><head>
-  <title>${resume.basics.name} - Resume</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <style>
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: [
+      'https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap',
+    ],
+    head: `<style>
     html {
       font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: #fafbfc;
@@ -83,8 +76,12 @@ export const render = (resume) => {
         background: white;
       }
     }
-  </style>
-  ${styles}</head><body>${html}</body></html>`;
+  </style>`,
+    lang: 'en',
+    dir: 'ltr',
+    title: `${resume.basics.name} - Resume`,
+    includeTokensCss: false,
+  });
 };
 
 export { Resume };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1841,6 +1841,9 @@ importers:
 
   packages/themes/jsonresume-theme-professional:
     dependencies:
+      '@jsonresume/core':
+        specifier: workspace:*
+        version: link:../../resume-core
       marked:
         specifier: ^16.3.0
         version: 16.4.1


### PR DESCRIPTION
Final SSR migration batch (refs #421). Moves the remaining deferred themes onto `@jsonresume/core/ssr` `renderResumeDocument`.

## Migrated
- **professional** — inline `<style>` (LatinModern @font-face + base rules) kept on the before-styled cascade side via `head`; Resume wrapped in `<main>` to preserve `<body><main>…</main></body>`. No Google fonts.
- **tokyo-modernist** — Outfit font via `fonts` (reproduces the preconnect + css2 link exactly); inline `<style>` via `head`.

Both: `includeTokensCss: false`, `lang: 'en'`, `dir: 'ltr'`. Dist rebuilt; per-theme patch changesets added.

## Equivalence (BEFORE vs AFTER against `@jsonresume/sample-data` completeResume)
- Google fonts loaded: identical
- inline `<style>` CSS: byte-identical, correct cascade side (before styled tags)
- styled-components CSS: byte-identical
- `<body>` markup: identical (modulo React `<!-- -->` comments)
- Only `<head>`-structure deltas are the accepted normalizations: added `<html lang dir>` wrapper, `<meta charset>` first, `<title>` last

## Deferred
- **reference** — STOP/deferred. It already emits `<html lang dir>` (not the missing-`<html>` precondition) and exposes a `render(resume, options)` API with `structured` output mode and `data-theme` on `<html>`. `renderResumeDocument` cannot reproduce those, so migrating would be a regression, not the intended normalization. Left unchanged.

## Verification
- `pnpm --filter registry test -- --run` → 1640 passed (incl. theme render QA gate; professional rendered via migrated source)
- `pnpm turbo lint typecheck prettier` → exit 0

Do not merge without review.

— AI