### PR TITLE
ci(themes): guard against stale committed dist/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,26 @@ jobs:
           pnpm --filter registry test -- --run
           pnpm --filter ats-validator test
 
+  dist-sync:
+    # Theme packages commit a built dist/ and publish it as-is (changeset
+    # publish has no pre-publish build). This guard rebuilds every dist-tracked
+    # theme and fails if any committed dist/ has drifted from its source,
+    # preventing stale code from shipping to npm.
+    # RECOMMENDED: add to required status checks in branch protection.
+    name: Theme dist sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check:dist-sync
+
   knip:
     # Informational only - dead-code / unused-dependency report.
     # NOT a hard gate (continue-on-error + `|| true`): knip false-positives

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "check": "turbo run lint typecheck",
+    "check:dist-sync": "node scripts/check-theme-dist-sync.mjs",
     "format": "prettier -w .",
     "prettier": "prettier -c .",
     "prepare": "husky install",

--- a/packages/themes/jsonresume-theme-art-school-modern/dist/index.js
+++ b/packages/themes/jsonresume-theme-art-school-modern/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
+++ b/packages/themes/jsonresume-theme-berlin-grid/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-californian-warm/dist/index.js
+++ b/packages/themes/jsonresume-theme-californian-warm/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-clinical-precision/dist/index.js
+++ b/packages/themes/jsonresume-theme-clinical-precision/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
+++ b/packages/themes/jsonresume-theme-coastal-creative/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-community-garden/dist/index.js
+++ b/packages/themes/jsonresume-theme-community-garden/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-data-driven/dist/index.js
+++ b/packages/themes/jsonresume-theme-data-driven/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-field-researcher/dist/index.js
+++ b/packages/themes/jsonresume-theme-field-researcher/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-french-atelier/dist/index.js
+++ b/packages/themes/jsonresume-theme-french-atelier/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-investor-brief/dist/index.js
+++ b/packages/themes/jsonresume-theme-investor-brief/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-london-bureau/dist/index.js
+++ b/packages/themes/jsonresume-theme-london-bureau/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
+++ b/packages/themes/jsonresume-theme-new-york-editorial/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-pacific-horizon/dist/index.js
+++ b/packages/themes/jsonresume-theme-pacific-horizon/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/packages/themes/jsonresume-theme-reference/dist/index.js
+++ b/packages/themes/jsonresume-theme-reference/dist/index.js
@@ -1508,7 +1508,9 @@ function formatDateRange({
     return formatter.format(date);
   };
   const start = formatDate(startDate);
-  if (endDate === void 0) return start;
+  if (endDate === void 0) {
+    return start;
+  }
   const end = formatDate(endDate);
   return `${start} - ${end}`;
 }
@@ -1629,7 +1631,6 @@ function safeUrl(url) {
   const trimmed = url.trim();
   const dangerousProtocols = /^(javascript|data|vbscript|file|about):/i;
   if (dangerousProtocols.test(trimmed)) {
-    console.warn(`[Security] Blocked dangerous URL: ${trimmed.slice(0, 50)}`);
     return null;
   }
   const safeProtocols = /^(https?|mailto|tel|sms|ftp):/i;
@@ -1645,7 +1646,6 @@ function safeUrl(url) {
   if (/^[a-z0-9][a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmed)) {
     return `https://${trimmed}`;
   }
-  console.warn(`[Security] Uncertain URL safety: ${trimmed.slice(0, 50)}`);
   return trimmed;
 }
 function getLinkRel(url, openInNewTab = false) {

--- a/packages/themes/jsonresume-theme-urban-techno/dist/index.js
+++ b/packages/themes/jsonresume-theme-urban-techno/dist/index.js
@@ -1340,6 +1340,7 @@ function renderResumeDocument(element, options = {}) {
     dir = "ltr",
     reset = false,
     head = "",
+    headAfterStyles = "",
     includeTokensCss = true,
     bodyClass
   } = options;
@@ -1357,7 +1358,7 @@ function renderResumeDocument(element, options = {}) {
   const resetTag = reset ? CSS_RESET : "";
   const titleTag = title ? `<title>${title}</title>` : "";
   const bodyAttr = bodyClass ? ` class="${bodyClass}"` : "";
-  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
+  return `<!DOCTYPE html><html lang="${lang}" dir="${dir}"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">` + fontLinks + tokensLink + resetTag + head + styleTags + headAfterStyles + titleTag + `</head><body${bodyAttr}>${html}</body></html>`;
 }
 createContext({
   theme: "professional",

--- a/scripts/check-theme-dist-sync.mjs
+++ b/scripts/check-theme-dist-sync.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// check-theme-dist-sync.mjs
+//
+// Guards against stale committed theme dist/.
+//
+// ~46 theme packages under packages/themes/* commit a built dist/ and publish
+// with `main: ./dist/index.js`. The release pipeline (`pnpm changeset publish`)
+// has NO pre-publish build step, so whatever dist/ is committed is exactly what
+// ships to npm. If a contributor edits a theme's src/ without rebuilding dist/,
+// npm ships STALE code.
+//
+// This script rebuilds every dist-tracked theme from source and fails if any
+// theme's freshly built dist/ differs from what is committed in git. Run it in
+// CI on push(master) + pull_request + merge_group.
+//
+// Usage: node scripts/check-theme-dist-sync.mjs
+// Exit 0 = all committed dist/ in sync. Exit 1 = drift (listed) or error.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+
+function git(args, opts = {}) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    ...opts,
+  });
+}
+
+// Discover theme packages that (a) track files under dist/ in git and
+// (b) declare a build script. These are exactly the packages where stale
+// committed dist/ would ship to npm.
+function discoverThemes() {
+  const tracked = git(['ls-files', '--', 'packages/themes/*/dist/**'])
+    .split('\n')
+    .filter(Boolean);
+
+  const dirs = new Set();
+  for (const file of tracked) {
+    // packages/themes/<theme>/dist/...
+    const parts = file.split('/');
+    if (parts.length < 4 || parts[3] !== 'dist') continue;
+    dirs.add(parts.slice(0, 3).join('/'));
+  }
+
+  const themes = [];
+  for (const rel of [...dirs].sort()) {
+    const pkgPath = join(repoRoot, rel, 'package.json');
+    if (!existsSync(pkgPath)) continue;
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    } catch (err) {
+      console.error(`Failed to parse ${rel}/package.json: ${err.message}`);
+      continue;
+    }
+    if (!pkg.scripts || !pkg.scripts.build) continue;
+    themes.push({ rel, name: pkg.name });
+  }
+  return themes;
+}
+
+function distIsDirty(themeRel) {
+  // Untracked dist files (e.g. a newly emitted chunk) also count as drift.
+  const status = git([
+    'status',
+    '--porcelain',
+    '--',
+    `${themeRel}/dist`,
+  ]).trim();
+  return status.length > 0;
+}
+
+function main() {
+  const themes = discoverThemes();
+  if (themes.length === 0) {
+    console.error('No dist-tracked theme packages found — nothing to check.');
+    process.exit(1);
+  }
+
+  console.log(
+    `Checking committed dist/ for ${themes.length} theme package(s)...`
+  );
+
+  // Build all themes in one turbo pass: parallel + respects ^build so each
+  // theme's workspace deps (e.g. @jsonresume/core) are built first.
+  const filters = themes.flatMap((t) => ['--filter', t.name]);
+  const build = spawnSync(
+    'pnpm',
+    ['exec', 'turbo', 'run', 'build', ...filters],
+    { cwd: repoRoot, stdio: 'inherit', env: { ...process.env } }
+  );
+  if (build.status !== 0) {
+    console.error('\nTheme build failed — cannot verify dist sync.');
+    process.exit(build.status || 1);
+  }
+
+  const drifted = themes.filter((t) => distIsDirty(t.rel));
+
+  if (drifted.length === 0) {
+    console.log(
+      `\nAll ${themes.length} theme dist/ bundles are in sync with source.`
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `\nStale committed dist/ detected in ${drifted.length} theme(s):\n`
+  );
+  for (const t of drifted) {
+    console.error(
+      `  - ${t.name} (${relative(repoRoot, join(repoRoot, t.rel))})`
+    );
+  }
+  console.error(
+    '\nThe committed dist/ no longer matches a fresh build of src/.\n' +
+      'Because `changeset publish` ships dist/ as-is (no pre-publish build),\n' +
+      'this would publish stale code to npm.\n\n' +
+      'Fix: rebuild the affected theme(s) and commit dist/, e.g.\n' +
+      `  pnpm --filter <theme> build && git add <theme>/dist\n\n` +
+      'Drift diff (truncated):'
+  );
+  try {
+    const diff = git([
+      'diff',
+      '--stat',
+      '--',
+      ...drifted.map((t) => `${t.rel}/dist`),
+    ]);
+    console.error(diff);
+  } catch {
+    /* best-effort diagnostics */
+  }
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Problem

~46 theme packages under \`packages/themes/*\` commit a built \`dist/\` and publish with \`main: ./dist/index.js\`. The release pipeline (\`pnpm changeset publish\`) has **no pre-publish build step** — whatever \`dist/\` is committed is exactly what ships to npm. If a contributor edits a theme's \`src/\` (or a bundled-in \`@jsonresume/core\` change lands) without rebuilding \`dist/\`, npm ships **stale code**.

This was already happening: 15 themes' committed \`dist/\` bundled an older \`@jsonresume/core\` (missing \`renderResumeDocument\`'s \`headAfterStyles\`, and stale \`safeUrl\`/\`formatDateRange\`).

## Changes

- **\`scripts/check-theme-dist-sync.mjs\`** — discovers every dist-tracked theme with a build script, rebuilds them all via turbo, and fails (exit 1) listing any theme whose committed \`dist/\` drifted from a fresh build. Wired as root script \`check:dist-sync\`.
- **\`.github/workflows/ci.yml\`** — new \`dist-sync\` job (push/PR/merge_group) with the standard pnpm/turbo setup.
- **fix(themes)** — rebuilt the 15 stale \`dist/\` bundles (build output only; **no theme source changed**) so the guard is green on master.

## Verification

- \`node scripts/check-theme-dist-sync.mjs\` → exit 0, verifies all 46 themes in sync.
- Builds confirmed deterministic (same hash across repeated builds).
- \`pnpm turbo lint typecheck prettier\` → exit 0 (22/22).
- \`ci.yml\` parses as valid YAML.

## Maintainer action

Recommend adding **Theme dist sync** to required status checks in branch protection. (Not modified here.)

Refs #421

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated theme distribution sync validation to the CI pipeline to ensure committed theme dist files remain synchronized with source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->