### PR TITLE
feat(ecosystem): publish @jsonresume/theme-metadata (was @repo/theme-config)

### DIFF
--- a/.changeset/publish-theme-metadata.md
+++ b/.changeset/publish-theme-metadata.md
@@ -1,0 +1,5 @@
+---
+'@jsonresume/theme-metadata': minor
+---
+
+Publish theme registry metadata publicly as `@jsonresume/theme-metadata` (formerly the private `@repo/theme-config`). Exposes `THEME_METADATA`, `THEME_NAMES`, and `getRandomTheme` so external gallery/picker UIs and library developers can consume JSON Resume theme metadata. Internal consumers keep importing `@repo/theme-config` via a back-compat shim — no breaking changes.

--- a/packages/theme-config-compat/package.json
+++ b/packages/theme-config-compat/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@repo/theme-config",
+  "version": "0.2.0",
+  "private": true,
+  "description": "Back-compat shim: re-exports @jsonresume/theme-metadata under the legacy @repo/theme-config import specifier for internal monorepo consumers",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./metadata": "./src/metadata.js"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "lint": "eslint src --cache --cache-location node_modules/.cache/.eslintcache || exit 0"
+  },
+  "dependencies": {
+    "@jsonresume/theme-metadata": "workspace:*"
+  },
+  "devDependencies": {
+    "@repo/eslint-config-custom": "workspace:^"
+  },
+  "keywords": [
+    "json-resume",
+    "themes",
+    "config"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jsonresume/jsonresume.org",
+    "directory": "packages/theme-config-compat"
+  },
+  "license": "MIT"
+}

--- a/packages/theme-config-compat/src/index.js
+++ b/packages/theme-config-compat/src/index.js
@@ -1,0 +1,15 @@
+/**
+ * @repo/theme-config (back-compat shim)
+ *
+ * The theme metadata moved to the publicly published @jsonresume/theme-metadata
+ * package. This shim re-exports it under the legacy @repo/theme-config specifier
+ * so existing internal consumers (registry, homepage2) keep working unchanged.
+ *
+ * New code should import from '@jsonresume/theme-metadata' directly.
+ */
+
+export {
+  THEME_METADATA,
+  THEME_NAMES,
+  getRandomTheme,
+} from '@jsonresume/theme-metadata';

--- a/packages/theme-config-compat/src/metadata.js
+++ b/packages/theme-config-compat/src/metadata.js
@@ -1,0 +1,12 @@
+/**
+ * @repo/theme-config/metadata (back-compat shim)
+ *
+ * Re-exports the metadata subpath from @jsonresume/theme-metadata so the legacy
+ * '@repo/theme-config/metadata' import specifier keeps resolving.
+ */
+
+export {
+  THEME_METADATA,
+  THEME_NAMES,
+  getRandomTheme,
+} from '@jsonresume/theme-metadata/metadata';

--- a/packages/theme-config/CHANGELOG.md
+++ b/packages/theme-config/CHANGELOG.md
@@ -1,4 +1,6 @@
-# @repo/theme-config
+# @jsonresume/theme-metadata
+
+> Previously published internally as `@repo/theme-config`.
 
 ## 0.2.0
 

--- a/packages/theme-config/README.md
+++ b/packages/theme-config/README.md
@@ -1,23 +1,61 @@
-# @repo/theme-config
+# @jsonresume/theme-metadata
 
-Shared theme configuration and metadata for JSON Resume themes. This package exposes the theme metadata (names, display info, helpers like `getRandomTheme`) consumed by both the `registry` and `homepage2` apps in the monorepo.
+The theme registry metadata for [JSON Resume](https://jsonresume.org) themes — the single source of truth for theme display names, descriptions, tags, and authors used on jsonresume.org.
 
-This is a private, internal workspace package (`@repo/theme-config`) — it is not published to npm.
+Use it to build your own theme gallery, theme picker, or any UI/tooling that needs to list or describe the available JSON Resume themes, without depending on the (heavy) theme rendering packages.
 
-## Usage
+> Formerly the private `@repo/theme-config` workspace package. The metadata and exports are identical; it is now published publicly so external consumers can use it.
+
+## Install
+
+```
+npm install @jsonresume/theme-metadata
+```
+
+## Exports
 
 ```js
-import { THEME_METADATA, THEME_NAMES, getRandomTheme } from '@repo/theme-config';
+import {
+  THEME_METADATA,
+  THEME_NAMES,
+  getRandomTheme,
+} from '@jsonresume/theme-metadata';
 ```
 
-Metadata is also available directly via `@repo/theme-config/metadata`.
+- `THEME_METADATA` — an object keyed by theme slug. Each entry has:
+  - `name` — human-readable display name
+  - `description` — one-line summary of the look/intent
+  - `author` — theme author
+  - `tags` — string array for filtering/search
+- `THEME_NAMES` — `Object.keys(THEME_METADATA)`, the array of theme slugs.
+- `getRandomTheme()` — returns a random theme slug (useful for "surprise me" / preview UIs).
 
-## Development
+The metadata is also available directly via the `./metadata` subpath:
 
-From `packages/theme-config`:
-
+```js
+import { THEME_METADATA } from '@jsonresume/theme-metadata/metadata';
 ```
-pnpm lint   # run ESLint
+
+This package contains metadata only — it does not import or render any themes.
+
+## Example: a theme gallery
+
+```js
+import { THEME_METADATA, THEME_NAMES } from '@jsonresume/theme-metadata';
+
+function getGalleryItems() {
+  return THEME_NAMES.map((slug) => {
+    const { name, description, tags } = THEME_METADATA[slug];
+    return {
+      slug,
+      name,
+      description,
+      tags,
+      // render a live preview from the registry:
+      preview: `https://registry.jsonresume.org/thomasdavis?theme=${slug}`,
+    };
+  });
+}
 ```
 
 ## Part of the jsonresume.org monorepo

--- a/packages/theme-config/package.json
+++ b/packages/theme-config/package.json
@@ -1,14 +1,13 @@
 {
-  "name": "@repo/theme-config",
+  "name": "@jsonresume/theme-metadata",
   "version": "0.2.0",
-  "private": true,
-  "description": "Shared theme configuration and metadata for JSON Resume themes",
+  "private": false,
+  "description": "Theme registry metadata for JSON Resume themes — names, descriptions, tags, authors, and helpers (THEME_METADATA, THEME_NAMES, getRandomTheme) for building theme galleries and pickers",
+  "type": "module",
   "main": "./src/index.js",
-  "types": "./src/index.d.ts",
   "exports": {
     ".": "./src/index.js",
-    "./metadata": "./src/metadata.js",
-    "./themes": "./src/themes.js"
+    "./metadata": "./src/metadata.js"
   },
   "files": [
     "src"
@@ -21,13 +20,24 @@
   },
   "keywords": [
     "json-resume",
+    "resume",
+    "cv",
     "themes",
+    "theme-metadata",
+    "theme-gallery",
     "config"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jsonresume/jsonresume.org",
     "directory": "packages/theme-config"
+  },
+  "homepage": "https://github.com/jsonresume/jsonresume.org/tree/master/packages/theme-config",
+  "bugs": {
+    "url": "https://github.com/jsonresume/jsonresume.org/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "MIT"
 }

--- a/packages/theme-config/src/index.js
+++ b/packages/theme-config/src/index.js
@@ -1,8 +1,9 @@
 /**
- * @repo/theme-config
+ * @jsonresume/theme-metadata
  *
- * Shared theme configuration and metadata for JSON Resume themes
- * This package provides theme metadata that can be used by both the registry and homepage apps
+ * Theme registry metadata for JSON Resume themes.
+ * Provides theme metadata (names, descriptions, tags, authors) plus helpers,
+ * usable by the registry/homepage apps and any external gallery or picker UI.
  */
 
 export { THEME_METADATA, THEME_NAMES, getRandomTheme } from './metadata.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,7 +197,7 @@ importers:
         version: 4.16.2(prisma@4.16.2)
       '@repo/theme-config':
         specifier: workspace:*
-        version: link:../../packages/theme-config
+        version: link:../../packages/theme-config-compat
       '@vercel/analytics':
         specifier: ^1.3.1
         version: 1.5.0(next@15.5.19)(react@19.2.7)
@@ -306,7 +306,7 @@ importers:
         version: 6.18.0(prisma@6.18.0)(typescript@5.9.3)
       '@repo/theme-config':
         specifier: workspace:*
-        version: link:../../packages/theme-config
+        version: link:../../packages/theme-config-compat
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -960,6 +960,16 @@ importers:
         version: 4.17.0
 
   packages/theme-config:
+    devDependencies:
+      '@repo/eslint-config-custom':
+        specifier: workspace:^
+        version: link:../eslint-config-custom
+
+  packages/theme-config-compat:
+    dependencies:
+      '@jsonresume/theme-metadata':
+        specifier: workspace:*
+        version: link:../theme-config
     devDependencies:
       '@repo/eslint-config-custom':
         specifier: workspace:^


### PR DESCRIPTION
Refs #421

Publishes the theme registry metadata publicly so external gallery/picker UIs and lib developers can consume it.

## What
- Rename `packages/theme-config`'s package to **`@jsonresume/theme-metadata`** — `private:false`, `publishConfig.access:public`. Source + exports (`THEME_METADATA`, `THEME_NAMES`, `getRandomTheme`; root `.` + `./metadata`) unchanged.
- Add **`packages/theme-config-compat`** (private, name `@repo/theme-config`) that re-exports the new package via `workspace:*`. Existing internal consumers (`apps/registry/lib/formatters/template/themeConfig.js`, `apps/homepage2/app/themes/data/themes.js`) keep importing `@repo/theme-config` **unchanged** — no consumer edits.
- Drop the dangling `./themes` and `types` export entries (those files never existed in the package).
- New README (install + theme-gallery example) and a minor changeset.

## Why the shim approach
A package can have only one `name`, so to publish publicly the directory's package must be renamed. The tiny compat package preserves the legacy `@repo/theme-config` import specifier without touching any consumer, leaving registry/homepage2 builds green.

## Verification
- `pnpm --filter registry build` — green
- `pnpm --filter homepage2 build` — green
- `pnpm --filter registry test -- --run` — 1640 passed (themeConfig.js resolves metadata through the shim)
- `pnpm turbo lint typecheck prettier` — lint + prettier + all other tasks green. `registry#typecheck` OOMs (exit 137 / SIGABRT, V8 heap) — environmental, pre-existing for this app; `tsc` with a 12GB heap emits **zero** `error TS` lines. The change touches no TypeScript and import resolution is identical to before.
- Runtime: `@repo/theme-config` and `@jsonresume/theme-metadata/metadata` both resolve to the 62-theme metadata.

Do not merge — for review.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme registry metadata is now publicly available for external tools and interfaces to browse themes, retrieve metadata, and access random theme selection.

* **Chores**
  * Maintained backward compatibility for existing internal imports with no breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->