### PR TITLE
refactor(themes): non-core themes adopt @jsonresume/utils

### DIFF
--- a/.changeset/themes-claude-adopt-utils.md
+++ b/.changeset/themes-claude-adopt-utils.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-claude': patch
+---
+
+adopt @jsonresume/utils formatLocation for the contact-line location join (output unchanged)

--- a/.changeset/themes-creative-confidence-adopt-utils.md
+++ b/.changeset/themes-creative-confidence-adopt-utils.md
@@ -1,0 +1,5 @@
+---
+'jsonresume-theme-creative-confidence': patch
+---
+
+adopt @jsonresume/utils sanitizeHtml + formatDateRange for HTML escaping and date formatting (output unchanged)

--- a/packages/themes/jsonresume-theme-claude/index.js
+++ b/packages/themes/jsonresume-theme-claude/index.js
@@ -1,4 +1,5 @@
 import markdownIt from 'markdown-it';
+import { formatLocation } from '@jsonresume/utils';
 
 const md = markdownIt({ html: false, breaks: true, linkify: false });
 
@@ -429,13 +430,9 @@ export function render(resume) {
       <div class="contact-row">
         ${
           location.city
-            ? `<span class="contact-item">${icon('location')}${[
-                location.city,
-                location.region,
-                location.countryCode,
-              ]
-                .filter(Boolean)
-                .join(', ')}</span>`
+            ? `<span class="contact-item">${icon('location')}${formatLocation(
+                location
+              )}</span>`
             : ''
         }
         ${

--- a/packages/themes/jsonresume-theme-claude/package.json
+++ b/packages/themes/jsonresume-theme-claude/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/rolandnsharp/jsonresume-theme-claude"
   },
   "dependencies": {
+    "@jsonresume/utils": "workspace:*",
     "markdown-it": "^14.1.1"
   },
   "license": "MIT"

--- a/packages/themes/jsonresume-theme-creative-confidence/index.js
+++ b/packages/themes/jsonresume-theme-creative-confidence/index.js
@@ -1,3 +1,5 @@
+import { formatDateRange, sanitizeHtml } from '@jsonresume/utils';
+
 const css = `:root {
   --text: #0f172a;
   --muted: #334155;
@@ -315,12 +317,7 @@ a {
 }`;
 
 function escapeHtml(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\"/g, '&quot;')
-    .replace(/'/g, '&#039;');
+  return sanitizeHtml(String(value ?? ''));
 }
 
 function formatDate(value) {
@@ -332,10 +329,7 @@ function formatDate(value) {
     /^\d{4}-\d{2}$/.test(normalized) ? `${normalized}-01` : normalized
   );
   if (Number.isNaN(parsed.getTime())) return escapeHtml(value);
-  return parsed.toLocaleDateString('en-US', {
-    month: 'short',
-    year: 'numeric',
-  });
+  return formatDateRange({ startDate: value });
 }
 
 function dateRange(start, end) {

--- a/packages/themes/jsonresume-theme-creative-confidence/package.json
+++ b/packages/themes/jsonresume-theme-creative-confidence/package.json
@@ -10,5 +10,8 @@
     "type": "git",
     "url": "https://github.com/scottlynde/jsonresume-theme-creative-confidence"
   },
+  "dependencies": {
+    "@jsonresume/utils": "workspace:*"
+  },
   "license": "MIT"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1200,6 +1200,9 @@ importers:
 
   packages/themes/jsonresume-theme-claude:
     dependencies:
+      '@jsonresume/utils':
+        specifier: workspace:*
+        version: link:../../utils
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -1298,7 +1301,11 @@ importers:
         specifier: ^5.4.21
         version: 5.4.21(@types/node@20.19.24)
 
-  packages/themes/jsonresume-theme-creative-confidence: {}
+  packages/themes/jsonresume-theme-creative-confidence:
+    dependencies:
+      '@jsonresume/utils':
+        specifier: workspace:*
+        version: link:../../utils
 
   packages/themes/jsonresume-theme-creative-studio:
     dependencies:


### PR DESCRIPTION
Now that `@jsonresume/utils` is published framework-free, the non-core (handlebars / plain-JS, non-React) themes can share its date/url/location helpers instead of reimplementing them. Refs #421.

## Changed (output verified byte-identical)

**jsonresume-theme-claude** — replaced the inline `[city, region, countryCode].filter(Boolean).join(', ')` contact-line join with `formatLocation`. Its date formatter (UTC-pinned) and `safeUrl` (returns `#`) were left alone because `formatDateRange`/`safeUrl` would change visible output (see below).

**jsonresume-theme-creative-confidence** — `escapeHtml` now delegates to `sanitizeHtml`, and the valid-date path of `formatDate` delegates to `formatDateRange`. The falsy/invalid fallbacks, the `dateRange` "Present" wrapper, and the address/postalCode location join are unchanged (no util matches them exactly).

Both added `@jsonresume/utils` as a `workspace:*` dependency; each gets a PATCH changeset. Neither ships a `dist/`, so nothing to rebuild.

## Left unchanged — no output-equivalent duplication (report-only)

- **flat** (handlebars) — renders raw ISO dates (`{{startDate}} — {{endDate}}`) and raw URLs; no protocol-strip or location join. Adopting utils would change visible output. Only helper it registers is `nl2br` (not in utils).
- **tailwind** (React) — `Date.jsx` renders the raw date string (`@todo - format date here`); location uses a single `city` field; `ProjectCard` URL-strip also drops `www.` and the first `/`. None are output-equivalent to utils.
- **stackoverflow** (React + moment) — `MY`/`Y`/`DMY` use `moment(...).format(...)` parsed in **local** time. `formatDateRange` parses ISO as UTC midnight then formats local, so it shifts first-of-month dates back a month/year in any timezone west of UTC (e.g. `2020-01-01` → "Dec 2019" in America/Los_Angeles). Swapping would change output for a large share of users. `Y` (year-only) and `DMY` have no util equivalent, and location/"Present" are rendered field-by-field in JSX. Left as-is.

## Verification

- Full before/after `render()` diff against `@jsonresume/sample-data` (`completeResume` + `resumeSample`): byte-identical for both changed themes, in `UTC` and `America/Los_Angeles`.
- `pnpm turbo lint typecheck prettier` — exit 0.
- `pnpm --filter registry test -- --run` — 1640 passed / 26 skipped (themeRenderQa covers both changed themes).

Do not merge.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Claude and Creative Confidence themes to adopt shared utilities, improving code consistency and maintainability across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->