### PR TITLE
feat(dx): scaffolder generates ecosystem-native themes (renderResumeDocument + theme-kit)

### DIFF
--- a/docs/AGENT_THEME_DEVELOPMENT.md
+++ b/docs/AGENT_THEME_DEVELOPMENT.md
@@ -1,11 +1,17 @@
 # AI Agent Guide: JSON Resume Theme Development
 
 > **Start here:** scaffold a correct-by-construction theme with
-> `pnpm gen:theme <slug> "Display Name"`. It mirrors a known-good template,
-> renders all sections, and passes the `themeRenderQa` gate out of the box. See
-> [`docs/CREATING_A_THEME.md`](./CREATING_A_THEME.md) for the generator usage,
-> the registration checklist, the SSR-inline rule, and the render gate. This
-> document covers the design/iteration process once the package exists.
+> `pnpm gen:theme <slug> "Display Name"`. The generated theme is
+> **ecosystem-native** — its `index.jsx` calls `renderResumeDocument` from
+> `@jsonresume/core/ssr`, `src/Resume.jsx` uses `@jsonresume/utils` helpers
+> (`formatDateRange`, `formatLocation`, `safeUrl`), and it ships a
+> `tests/theme.test.js` that dogfoods `runThemeRenderQa` from
+> `@jsonresume/theme-kit` against `completeResume` from `@jsonresume/sample-data`.
+> It renders all sections and passes the render-QA gate out of the box. See
+> [`docs/CREATING_A_THEME.md`](./CREATING_A_THEME.md) for the ecosystem packages,
+> the generator usage, the registration checklist, the SSR-inline rule, and the
+> render gate. This document covers the design/iteration process once the
+> package exists.
 
 ## Critical Rules
 

--- a/docs/CREATING_A_THEME.md
+++ b/docs/CREATING_A_THEME.md
@@ -1,9 +1,24 @@
 # Creating a JSON Resume Theme
 
 The fastest, correct way to start a new theme is the scaffolding generator. It
-mirrors a known-good template (`berlin-grid`) and bakes in the lessons that
-historically broke contributed themes, so a freshly scaffolded theme renders
-all sections and passes CI on the first try.
+emits an **ecosystem-native** theme built on the published `@jsonresume/*`
+suite and bakes in the lessons that historically broke contributed themes, so a
+freshly scaffolded theme renders all sections and passes CI on the first try.
+
+## The ecosystem packages
+
+A scaffolded theme is wired to the shared suite instead of reinventing it:
+
+| Package                   | Role in a theme                                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `@jsonresume/core`        | `renderResumeDocument` (the SSR document helper) + structural primitives              |
+| `@jsonresume/core/ssr`    | the `renderResumeDocument` / `googleFontsLinks` entry used by `index.jsx`             |
+| `@jsonresume/utils`       | pure, framework-free helpers: `formatDateRange`, `formatLocation`, `safeUrl`, …       |
+| `@jsonresume/theme-kit`   | `runThemeRenderQa` — the exact registry render-QA gate, run from the theme's own test |
+| `@jsonresume/sample-data` | `completeResume` — the canonical every-section fixture the gate renders against       |
+
+`@jsonresume/core` and `@jsonresume/utils` are runtime deps;
+`@jsonresume/theme-kit` and `@jsonresume/sample-data` are devDeps (test only).
 
 ## 1. Scaffold
 
@@ -19,30 +34,35 @@ pnpm gen:theme harbor-light "Harbor Light"
 
 This creates `packages/themes/jsonresume-theme-<slug>/`:
 
-| File             | Purpose                                                                                                                                                           |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `package.json`   | `private:false`, `version 0.1.0`, public `publishConfig`, peer deps `react 18\|\|19` + `react-dom`, deps `@jsonresume/core` + `styled-components`, Vite SSR build |
-| `vite.config.js` | SSR library build (`vite build` -> `dist/index.js`)                                                                                                               |
-| `index.jsx`      | `ServerStyleSheet` render entry; inlines CSS + Google Fonts CDN                                                                                                   |
-| `src/Resume.jsx` | Complete starter rendering **all** JSON Resume sections                                                                                                           |
-| `README.md`      | Per-theme dev/build notes                                                                                                                                         |
+| File                  | Purpose                                                                                                                                                                                                                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `package.json`        | `private:false`, `version 0.1.0`, public `publishConfig`, peer deps `@jsonresume/core` + `react 18\|\|19` + `react-dom`, deps `@jsonresume/core` + `@jsonresume/utils` + `styled-components`, devDeps `@jsonresume/theme-kit` + `@jsonresume/sample-data`, Vite SSR build, `test` script |
+| `vite.config.js`      | SSR library build (`vite build` -> `dist/index.js`)                                                                                                                                                                                                                                      |
+| `vitest.config.js`    | test config (node env, automatic JSX runtime)                                                                                                                                                                                                                                            |
+| `index.jsx`           | SSR render entry — calls `renderResumeDocument` from `@jsonresume/core/ssr` (no hand-rolled `ServerStyleSheet`/`<!DOCTYPE>` boilerplate)                                                                                                                                                 |
+| `src/Resume.jsx`      | Complete starter rendering **all** JSON Resume sections with inline styled-components + `@jsonresume/utils` helpers                                                                                                                                                                      |
+| `tests/theme.test.js` | render-QA test dogfooding `runThemeRenderQa` (theme-kit) against `completeResume` (sample-data)                                                                                                                                                                                          |
+| `README.md`           | Per-theme dev/build/test notes                                                                                                                                                                                                                                                           |
 
 The generator does **not** edit any shared files — it prints the exact manual
 registration steps (see below) so you wire the theme in deliberately.
 
-## 2. Build and develop
+## 2. Build, test, and develop
 
 ```bash
 pnpm install                                   # picks up the new workspace
 pnpm --filter jsonresume-theme-<slug> build    # confirm it vite-builds
+pnpm --filter jsonresume-theme-<slug> test     # run the theme-kit render gate
 
 cd apps/registry && pnpm dev                    # dev server on :3000
 open http://localhost:3000/thomasdavis?theme=<slug>
 ```
 
 Redesign the styled-components in `src/Resume.jsx` into your own **visually
-distinct** layout. See `docs/AGENT_THEME_DEVELOPMENT.md` for the layout-first
-design process and the hyper-critical screenshot review checklist.
+distinct** layout. Reach for the `@jsonresume/utils` helpers
+(`formatDateRange`, `formatLocation`, `safeUrl`) instead of reimplementing date,
+location, or URL handling. See `docs/AGENT_THEME_DEVELOPMENT.md` for the
+layout-first design process and the hyper-critical screenshot review checklist.
 
 ## 3. Registration checklist
 
@@ -78,33 +98,43 @@ The generator prints these with your slug filled in. You must do them by hand:
 Themes are rendered **server-side with no client hydration**. The scaffold is
 already correct; keep it that way:
 
+- **`index.jsx` calls `renderResumeDocument`** from `@jsonresume/core/ssr`. That
+  helper owns the `ServerStyleSheet` collection, the Google Fonts `<link>`s, and
+  the full `<!DOCTYPE html>` document — pass it the React tree plus the
+  `{ fonts, title, includeTokensCss }` options. Do **not** reintroduce
+  hand-rolled `renderToString` + `ServerStyleSheet` boilerplate.
 - **styled-components must be declared inline** in `src/Resume.jsx`. No
-  `fs.readFileSync`, no external `.css` files. `index.jsx` collects them via
-  `ServerStyleSheet` and inlines the result into `<head>`.
+  `fs.readFileSync`, no external `.css` files — `renderResumeDocument` collects
+  and inlines them into `<head>`.
+- **Use `@jsonresume/utils` helpers** (`formatDateRange`, `formatLocation`,
+  `safeUrl`) instead of reimplementing date/location/URL logic.
 - **`<ContactInfo basics={basics} />` takes a single `basics` prop.** The
   component destructures `email`/`phone`/`url`/`location`/`profiles` off
   `basics` itself — do not spread those as individual props.
 - **Never name a styled-component `Date`.** It shadows the global `Date` and
   crashes SSR. Use `MetaDate` / `DateLabel` / `Period`.
-- **Load fonts via the Google Fonts CDN** in `index.jsx` (already wired).
+- **Set `fonts` in `index.jsx`** to the family used by your `src/Resume.jsx`
+  `font-family` — they load from the Google Fonts CDN.
 - **Render every JSON Resume section** so the theme is complete.
 
-## 5. The permanent `themeRenderQa` gate
+## 5. The render-QA gate (theme-kit + registry)
 
-Every registered theme is rendered against
-`packages/test-fixtures/complete-resume.json` (every section populated) by the
-registry vitest job. The gate asserts the render does not throw, returns
-non-empty HTML, emits no raw artifacts (`[object Object]`, `undefined`, `NaN`),
-and covers the baseline sections `basics` / `work` / `education` / `skills`.
+A scaffolded theme ships its **own** render-QA test at `tests/theme.test.js`. It
+dogfoods `runThemeRenderQa` from `@jsonresume/theme-kit` against `completeResume`
+from `@jsonresume/sample-data` — the **identical** gate the registry enforces.
+It asserts the render does not throw, returns non-empty HTML, emits no raw
+artifacts (`[object Object]`, `undefined`, `NaN`), and covers the baseline
+sections `basics` / `work` / `education` / `skills`.
 
-Run it before opening a PR:
+Run the theme's own test, then the registry's all-theme gate, before a PR:
 
 ```bash
-pnpm --filter registry test -- --run themeRenderQa
+pnpm --filter jsonresume-theme-<slug> test         # this theme's theme-kit gate
+pnpm --filter registry test -- --run themeRenderQa  # every registered theme
 ```
 
-A scaffolded theme passes this gate out of the box. If you ever see a failure,
-it almost always traces back to one of the SSR-inline rules above.
+A scaffolded theme passes both out of the box. If you ever see a failure, it
+almost always traces back to one of the SSR-inline rules above.
 
 ## 6. Quality gates before pushing
 

--- a/scripts/create-theme.mjs
+++ b/scripts/create-theme.mjs
@@ -2,11 +2,21 @@
 /**
  * Theme scaffolding generator for jsonresume.org.
  *
- * Spins up a new, correct-by-construction theme package under
- * packages/themes/jsonresume-theme-<slug>/ by mirroring the known-good
- * berlin-grid template. It bakes in the hard-won lessons (SSR-inline
- * styled-components, ContactInfo single-basics prop, no styled-component
- * named Date, Google Fonts via CDN, render ALL JSON Resume sections).
+ * Spins up a new, ECOSYSTEM-NATIVE theme package under
+ * packages/themes/jsonresume-theme-<slug>/ built on the published
+ * @jsonresume/* suite:
+ *
+ *   - index.jsx calls renderResumeDocument from '@jsonresume/core/ssr' — no
+ *     hand-rolled ServerStyleSheet / <!DOCTYPE> boilerplate.
+ *   - src/Resume.jsx renders ALL JSON Resume sections with INLINE
+ *     styled-components and leans on @jsonresume/utils helpers
+ *     (formatDateRange, formatLocation, safeUrl) instead of reimplementing them.
+ *   - a theme.test.js dogfoods runThemeRenderQa from '@jsonresume/theme-kit'
+ *     against completeResume from '@jsonresume/sample-data', so a new theme
+ *     ships with the exact registry render-QA gate out of the box.
+ *
+ * It bakes in the hard-won lessons (SSR-inline styled-components, ContactInfo
+ * single-basics prop, no styled-component named Date, render ALL sections).
  *
  * It does NOT edit shared files (themeConfig.js, theme-config metadata,
  * registry package.json, changesets) — instead it PRINTS the manual
@@ -65,15 +75,19 @@ function packageJson(slug) {
       type: 'module',
       main: './index.jsx',
       peerDependencies: {
+        '@jsonresume/core': 'workspace:*',
         react: '^18.0.0 || ^19.0.0',
         'react-dom': '^18.0.0 || ^19.0.0',
       },
       dependencies: {
         '@jsonresume/core': 'workspace:*',
+        '@jsonresume/utils': 'workspace:*',
         'styled-components': '^6.1.19',
       },
       scripts: {
         build: 'vite build',
+        test: 'vitest run',
+        'test:watch': 'vitest',
       },
       publishConfig: {
         access: 'public',
@@ -89,8 +103,11 @@ function packageJson(slug) {
         },
       },
       devDependencies: {
+        '@jsonresume/sample-data': 'workspace:*',
+        '@jsonresume/theme-kit': 'workspace:*',
         '@vitejs/plugin-react': '^4.3.4',
         vite: '^5.4.21',
+        vitest: '^2',
       },
     },
     null,
@@ -133,32 +150,84 @@ export default defineConfig({
 });
 `;
 
+const VITEST_CONFIG = `import { defineConfig } from 'vitest/config';
+
+// The theme renders JSX in its test, so esbuild needs automatic JSX runtime.
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});
+`;
+
+function themeTest(displayName, slug) {
+  return `import { describe, it, expect } from 'vitest';
+import { runThemeRenderQa } from '@jsonresume/theme-kit';
+import { completeResume } from '@jsonresume/sample-data';
+import { render } from '../index.jsx';
+
+/*
+ * ${displayName} render-QA — the exact gate the registry enforces across every
+ * theme, dogfooded here via @jsonresume/theme-kit. runThemeRenderQa renders the
+ * canonical every-section fixture from @jsonresume/sample-data through this
+ * theme's render() and asserts:
+ *   - render() returns non-empty HTML and does not throw,
+ *   - no raw artifacts leak ([object Object] / undefined / NaN),
+ *   - the baseline sections (basics / work / education / skills) all appear.
+ *
+ * Keep this test green as you redesign src/Resume.jsx — if it fails it almost
+ * always traces back to one of the SSR-inline rules in src/Resume.jsx.
+ */
+describe('jsonresume-theme-${slug}', () => {
+  it('passes the theme-kit render QA against the complete sample resume', async () => {
+    await runThemeRenderQa({
+      render,
+      name: '${slug}',
+      expect,
+      fixture: completeResume,
+    });
+  });
+
+  it('renders a complete HTML document', () => {
+    const html = render(completeResume);
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+    expect(html).toContain('</html>');
+    expect(html).toContain(completeResume.basics.name);
+  });
+});
+`;
+}
+
 function indexJsx(displayName) {
-  return `import { renderToString } from 'react-dom/server';
-import { ServerStyleSheet } from 'styled-components';
+  return `import { renderResumeDocument } from '@jsonresume/core/ssr';
 import Resume from './src/Resume.jsx';
 
-// SSR render entry. styled-components MUST be collected via ServerStyleSheet
-// so the generated CSS is inlined into <head> — the registry renders themes
-// server-side with no client hydration.
+/*
+ * ${displayName} — SSR render entry.
+ *
+ * renderResumeDocument (from @jsonresume/core/ssr) handles ALL the boilerplate
+ * a theme used to hand-roll: it spins up the styled-components ServerStyleSheet,
+ * collects styles while rendering, links the requested Google Fonts, and emits
+ * the full <!DOCTYPE html> document. We just hand it the React tree + options.
+ *
+ *   - fonts: Google font families (or "Family:wght@400;700" specs). Loaded via
+ *     the Fonts CDN in <head>. Match these to the font-family in src/Resume.jsx.
+ *   - title: the <title> text.
+ *   - includeTokensCss: false — this starter ships its own inline styles and
+ *     does not depend on the @jsonresume/core design-token CSS. Flip to true
+ *     (or drop it) if you start using the --resume-* custom properties.
+ */
 export function render(resume) {
-  const sheet = new ServerStyleSheet();
-  const html = renderToString(sheet.collectStyles(<Resume resume={resume} />));
-  const styles = sheet.getStyleTags();
   const title = (resume.basics && resume.basics.name) || 'Resume';
-
-  return \`<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>\${title}</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  \${styles}
-</head>
-<body>\${html}</body>
-</html>\`;
+  return renderResumeDocument(<Resume resume={resume} />, {
+    fonts: ['Inter:wght@400;500;600;700'],
+    title,
+    includeTokensCss: false,
+  });
 }
 `;
 }
@@ -166,33 +235,40 @@ export function render(resume) {
 function resumeJsx(displayName, slug) {
   return `import React from 'react';
 import styled from 'styled-components';
+// Structural primitives come from @jsonresume/core...
 import {
   Section,
   SectionTitle,
-  DateRange,
   Badge,
   BadgeList,
   ContactInfo,
   Link,
-  safeUrl,
 } from '@jsonresume/core';
+// ...and the pure (framework-free) formatters from @jsonresume/utils. Lean on
+// these instead of reimplementing date / location / url logic in every theme.
+import { formatDateRange, formatLocation, safeUrl } from '@jsonresume/utils';
 
 /*
  * ${displayName} — starter theme scaffolded by scripts/create-theme.mjs.
  *
- * This is a COMPLETE, correct-by-construction starting point: it renders
- * every JSON Resume section and passes the permanent themeRenderQa gate.
- * Redesign the styled-components below into your own distinct layout, but
- * keep these baked-in lessons intact:
+ * This is a COMPLETE, ecosystem-native starting point: it renders every JSON
+ * Resume section and passes the permanent themeRenderQa gate. Redesign the
+ * styled-components below into your own distinct layout, but keep these
+ * baked-in lessons intact:
  *
  *   1. styled-components are declared INLINE in this single file (no fs reads,
- *      no external CSS) — the SSR pipeline collects them via ServerStyleSheet.
- *   2. <ContactInfo basics={basics} /> takes a SINGLE basics prop. Do NOT
+ *      no external CSS). index.jsx feeds this tree to renderResumeDocument
+ *      from '@jsonresume/core/ssr', which collects the styles via the
+ *      ServerStyleSheet and inlines them — themes render server-side with no
+ *      client hydration.
+ *   2. Use the @jsonresume/utils helpers (formatDateRange, formatLocation,
+ *      safeUrl) rather than rolling your own — they are tested, i18n-aware,
+ *      and shared with the rest of the ecosystem.
+ *   3. <ContactInfo basics={basics} /> takes a SINGLE basics prop. Do NOT
  *      spread individual email/phone/url props — the component destructures
  *      them off basics itself.
- *   3. NEVER name a styled-component "Date" — it shadows the global Date and
+ *   4. NEVER name a styled-component "Date" — it shadows the global Date and
  *      crashes SSR. Use DateLabel / MetaDate / Period instead.
- *   4. Load fonts via the Google Fonts CDN in index.jsx (already wired up).
  *   5. Render ALL sections so the theme is complete and passes themeRenderQa.
  */
 
@@ -228,6 +304,12 @@ const Tagline = styled.div\`
   font-size: 16px;
   color: #4a4a4a;
   font-weight: 500;
+  margin-bottom: 8px;
+\`;
+
+const Location = styled.div\`
+  font-size: 13px;
+  color: #6a6a6a;
   margin-bottom: 16px;
 \`;
 
@@ -381,11 +463,14 @@ function Resume({ resume }) {
     references = [],
   } = resume;
 
+  const location = formatLocation(basics.location);
+
   return (
     <Layout>
       <Header>
         {basics.name && <Name>{basics.name}</Name>}
         {basics.label && <Tagline>{basics.label}</Tagline>}
+        {location && <Location>{location}</Location>}
         {basics.summary && <Summary>{basics.summary}</Summary>}
         <StyledContactInfo basics={basics} />
       </Header>
@@ -403,7 +488,10 @@ function Resume({ resume }) {
                   )}
                 </div>
                 <MetaDate>
-                  <DateRange startDate={job.startDate} endDate={job.endDate} />
+                  {formatDateRange({
+                    startDate: job.startDate,
+                    endDate: job.endDate,
+                  })}
                 </MetaDate>
               </ItemHead>
               {job.summary && <ItemDescription>{job.summary}</ItemDescription>}
@@ -434,7 +522,10 @@ function Resume({ resume }) {
                   )}
                 </div>
                 <MetaDate>
-                  <DateRange startDate={edu.startDate} endDate={edu.endDate} />
+                  {formatDateRange({
+                    startDate: edu.startDate,
+                    endDate: edu.endDate,
+                  })}
                 </MetaDate>
               </ItemHead>
               {edu.score && <ItemDescription>GPA: {edu.score}</ItemDescription>}
@@ -484,10 +575,10 @@ function Resume({ resume }) {
                   )}
                 </ItemTitle>
                 <MetaDate>
-                  <DateRange
-                    startDate={project.startDate}
-                    endDate={project.endDate}
-                  />
+                  {formatDateRange({
+                    startDate: project.startDate,
+                    endDate: project.endDate,
+                  })}
                 </MetaDate>
               </ItemHead>
               {project.description && (
@@ -518,7 +609,10 @@ function Resume({ resume }) {
                   )}
                 </div>
                 <MetaDate>
-                  <DateRange startDate={vol.startDate} endDate={vol.endDate} />
+                  {formatDateRange({
+                    startDate: vol.startDate,
+                    endDate: vol.endDate,
+                  })}
                 </MetaDate>
               </ItemHead>
               {vol.summary && <ItemDescription>{vol.summary}</ItemDescription>}
@@ -655,17 +749,29 @@ function readme(displayName, slug) {
 
 > ${displayName} — a theme for [JSON Resume](https://jsonresume.org).
 
-Scaffolded with \`pnpm gen:theme\`. It renders every JSON Resume section and
-passes the permanent \`themeRenderQa\` gate out of the box. Make it your own by
+Scaffolded with \`pnpm gen:theme\`. It is **ecosystem-native**: built on the
+published \`@jsonresume/*\` suite, it renders every JSON Resume section and ships
+with the permanent \`themeRenderQa\` gate as its own test. Make it your own by
 editing the styled-components in \`src/Resume.jsx\`.
+
+## Built on
+
+| Package                 | Used for                                                          |
+| ----------------------- | ----------------------------------------------------------------- |
+| \`@jsonresume/core\`      | \`renderResumeDocument\` (SSR doc) + structural primitives          |
+| \`@jsonresume/utils\`     | \`formatDateRange\` / \`formatLocation\` / \`safeUrl\` (pure helpers)   |
+| \`@jsonresume/theme-kit\` | \`runThemeRenderQa\` render-QA gate (dev)                           |
+| \`@jsonresume/sample-data\` | \`completeResume\` fixture for the test (dev)                     |
 
 ## Structure
 
-| File              | Purpose                                                          |
-| ----------------- | ---------------------------------------------------------------- |
-| \`index.jsx\`       | SSR render entry — collects styled-components, inlines fonts/CSS |
-| \`src/Resume.jsx\`  | The theme: all sections + inline styled-components               |
-| \`vite.config.js\`  | SSR library build (\`vite build\` -> \`dist/\`)                      |
+| File                 | Purpose                                                      |
+| -------------------- | ------------------------------------------------------------ |
+| \`index.jsx\`          | SSR entry — calls \`renderResumeDocument\` from core/ssr       |
+| \`src/Resume.jsx\`     | The theme: all sections + inline styled-components           |
+| \`tests/theme.test.js\`| theme-kit render-QA gate against the sample resume           |
+| \`vite.config.js\`     | SSR library build (\`vite build\` -> \`dist/\`)                  |
+| \`vitest.config.js\`   | test config (node env, automatic JSX)                        |
 
 ## Develop
 
@@ -674,6 +780,12 @@ editing the styled-components in \`src/Resume.jsx\`.
 cd apps/registry && pnpm dev
 # Preview at:
 open http://localhost:3000/thomasdavis?theme=${slug}
+\`\`\`
+
+## Test
+
+\`\`\`bash
+pnpm --filter jsonresume-theme-${slug} test
 \`\`\`
 
 ## Build
@@ -685,9 +797,12 @@ pnpm --filter jsonresume-theme-${slug} build
 ## Rules baked in (keep these)
 
 - styled-components are declared **inline** in \`src/Resume.jsx\` — no \`fs\` reads.
+  \`index.jsx\` hands the tree to \`renderResumeDocument\`, which collects + inlines
+  the CSS server-side.
+- Reach for **\`@jsonresume/utils\`** helpers instead of reimplementing dates,
+  location, or URL handling.
 - \`<ContactInfo basics={basics} />\` takes a **single** \`basics\` prop.
 - Never name a styled-component \`Date\` (it shadows the global and crashes SSR).
-- Fonts load via the **Google Fonts CDN** in \`index.jsx\`.
 - Render **all** JSON Resume sections so the theme stays complete.
 
 See \`docs/CREATING_A_THEME.md\` for the full registration checklist.
@@ -719,30 +834,39 @@ async function main() {
   }
 
   await mkdir(join(dir, 'src'), { recursive: true });
+  await mkdir(join(dir, 'tests'), { recursive: true });
 
   await Promise.all([
     writeFile(join(dir, 'package.json'), packageJson(slug)),
     writeFile(join(dir, 'vite.config.js'), VITE_CONFIG),
+    writeFile(join(dir, 'vitest.config.js'), VITEST_CONFIG),
     writeFile(join(dir, 'index.jsx'), indexJsx(displayName)),
     writeFile(join(dir, 'src', 'Resume.jsx'), resumeJsx(displayName, slug)),
+    writeFile(
+      join(dir, 'tests', 'theme.test.js'),
+      themeTest(displayName, slug)
+    ),
     writeFile(join(dir, 'README.md'), readme(displayName, slug)),
   ]);
 
   const ident = importIdent(slug);
 
   console.log(`
-  Scaffolded jsonresume-theme-${slug}
+  Scaffolded jsonresume-theme-${slug}  (ecosystem-native)
   -> packages/themes/${pkgName}/
        package.json
        vite.config.js
+       vitest.config.js
        index.jsx
        src/Resume.jsx
+       tests/theme.test.js
        README.md
 
-  Next: install workspaces, then build to confirm it renders.
+  Next: install workspaces, then build + test to confirm it renders.
 
     pnpm install
     pnpm --filter ${pkgName} build
+    pnpm --filter ${pkgName} test
 
   -----------------------------------------------------------------
   MANUAL REGISTRATION (the generator does NOT touch shared files)
@@ -780,13 +904,16 @@ async function main() {
      - select ${pkgName}, choose "minor", describe the theme,
        and end the summary with "Refs #275."
 
-  5) verify the permanent render gate stays green:
+  5) verify the render gates stay green:
 
+         pnpm --filter ${pkgName} test            # this theme's own theme-kit gate
          pnpm --filter registry test -- --run themeRenderQa
 
-     This renders EVERY registered theme against the complete fixture and
-     asserts no crashes, no raw artifacts ([object Object]/undefined/NaN),
-     and that basics/work/education/skills all render.
+     The theme ships its OWN render-QA test (tests/theme.test.js, dogfooding
+     runThemeRenderQa from @jsonresume/theme-kit). The registry gate then
+     renders EVERY registered theme against the complete fixture and asserts no
+     crashes, no raw artifacts ([object Object]/undefined/NaN), and that
+     basics/work/education/skills all render.
 
   Preview while developing (registry dev server must be running):
 


### PR DESCRIPTION
The theme scaffolder (`scripts/create-theme.mjs`) still generated the OLD hand-rolled-SSR theme shape. This updates it so NEW themes are born ecosystem-native on the published `@jsonresume/*` suite — making the refactor self-perpetuating.

## Scaffolded theme is now ecosystem-native

- **`index.jsx`** — `render()` calls `renderResumeDocument` from `@jsonresume/core/ssr` (`fonts` / `title` / `includeTokensCss:false`). No hand-rolled `ServerStyleSheet` / `<!DOCTYPE>` boilerplate.
- **`src/Resume.jsx`** — renders all JSON Resume sections with inline styled-components and uses `@jsonresume/utils` helpers (`formatDateRange`, `formatLocation`, `safeUrl`) instead of reimplementing them. Keeps the baked-in lessons (single `basics` prop on `ContactInfo`, never a styled `Date`).
- **`tests/theme.test.js`** (new) — dogfoods `runThemeRenderQa` from `@jsonresume/theme-kit` against `completeResume` from `@jsonresume/sample-data`, plus a `vitest.config.js` and `test` script, so a new theme ships the registry render-QA gate out of the box.
- **`package.json`** — deps `@jsonresume/core` + `@jsonresume/utils`, peerDep `@jsonresume/core`, devDeps `@jsonresume/theme-kit` + `@jsonresume/sample-data`; `private:false`, public `publishConfig`; vite SSR build.
- README + the printed manual-registration checklist updated (themeConfig.js + theme-metadata + registry dep + changeset). The generator still edits **no** shared files.

## Docs

`docs/CREATING_A_THEME.md` and `docs/AGENT_THEME_DEVELOPMENT.md` now describe the ecosystem packages, the new generated shape, how to test with theme-kit, and the registration checklist.

## Verification

Scaffolded a throwaway slug, confirmed it vite-builds, its generated theme-kit test passes, and it renders all 12 sections with no artifacts (`[object Object]`/`undefined`/`NaN`) — then deleted it. **This PR adds only the generator + docs, no junk theme.**

- `pnpm turbo lint typecheck prettier` — EXIT 0
- `pnpm --filter registry test -- --run` — green (1640 passed, `themeRenderQa` unaffected)

Refs #421

— AI