### PR TITLE
fix(registry): ensure utf-8 charset in rendered theme HTML (#471)

### DIFF
--- a/apps/registry/lib/formatters/template/ensureHtmlCharset.js
+++ b/apps/registry/lib/formatters/template/ensureHtmlCharset.js
@@ -1,0 +1,35 @@
+/**
+ * Guarantees rendered theme HTML declares UTF-8.
+ *
+ * Some external themes (e.g. jsonresume-theme-elegant, the registry
+ * default) emit HTML without a <meta charset> tag. Combined with a
+ * Content-Type header lacking a charset, browsers fall back to a
+ * platform-default encoding and multi-byte UTF-8 sequences render as
+ * mojibake ("é" -> "├⌐"). See issue #471.
+ */
+
+const CHARSET_DECLARATION =
+  /<meta[^>]+(?:charset\s*=|http-equiv\s*=\s*["']?content-type)/i;
+
+const META_CHARSET = '<meta charset="utf-8">';
+
+export function ensureHtmlCharset(html) {
+  if (typeof html !== 'string' || CHARSET_DECLARATION.test(html)) {
+    return html;
+  }
+
+  // Inject just inside <head> so the declaration sits within the first
+  // 1024 bytes; fall back to after <html> or the doctype, and finally
+  // to prepending for headless fragments.
+  const insertionPoint =
+    html.match(/<head(?:\s[^>]*)?>/i) ||
+    html.match(/<html(?:\s[^>]*)?>/i) ||
+    html.match(/<!doctype[^>]*>/i);
+
+  if (insertionPoint) {
+    const index = insertionPoint.index + insertionPoint[0].length;
+    return html.slice(0, index) + META_CHARSET + html.slice(index);
+  }
+
+  return META_CHARSET + html;
+}

--- a/apps/registry/lib/formatters/template/ensureHtmlCharset.test.js
+++ b/apps/registry/lib/formatters/template/ensureHtmlCharset.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { ensureHtmlCharset } from './ensureHtmlCharset';
+
+describe('ensureHtmlCharset', () => {
+  it('injects meta charset right after <head>', () => {
+    const html = '<!DOCTYPE html><html><head><title>x</title></head></html>';
+
+    expect(ensureHtmlCharset(html)).toBe(
+      '<!DOCTYPE html><html><head><meta charset="utf-8"><title>x</title></head></html>'
+    );
+  });
+
+  it('injects after <head> with attributes', () => {
+    const html = '<html><head lang="en"><title>x</title></head></html>';
+
+    expect(ensureHtmlCharset(html)).toBe(
+      '<html><head lang="en"><meta charset="utf-8"><title>x</title></head></html>'
+    );
+  });
+
+  it('injects after <html> when there is no head', () => {
+    const html = '<html><body>é</body></html>';
+
+    expect(ensureHtmlCharset(html)).toBe(
+      '<html><meta charset="utf-8"><body>é</body></html>'
+    );
+  });
+
+  it('injects after doctype when there is no head or html tag', () => {
+    const html = '<!DOCTYPE html><body>é</body>';
+
+    expect(ensureHtmlCharset(html)).toBe(
+      '<!DOCTYPE html><meta charset="utf-8"><body>é</body>'
+    );
+  });
+
+  it('prepends for bare fragments', () => {
+    expect(ensureHtmlCharset('<div>é</div>')).toBe(
+      '<meta charset="utf-8"><div>é</div>'
+    );
+  });
+
+  it('leaves html5 charset declarations untouched', () => {
+    const html = '<html><head><meta charset="UTF-8"></head></html>';
+
+    expect(ensureHtmlCharset(html)).toBe(html);
+  });
+
+  it('leaves http-equiv content-type declarations untouched', () => {
+    const html =
+      '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head></html>';
+
+    expect(ensureHtmlCharset(html)).toBe(html);
+  });
+
+  it('passes through non-string content unchanged', () => {
+    expect(ensureHtmlCharset(undefined)).toBe(undefined);
+    expect(ensureHtmlCharset(null)).toBe(null);
+    expect(ensureHtmlCharset(42)).toBe(42);
+  });
+
+  it('preserves multi-byte characters around the injection point', () => {
+    const html =
+      '<html><head></head><body>données métier ça œuvre</body></html>';
+
+    expect(ensureHtmlCharset(html)).toContain('données métier ça œuvre');
+    expect(ensureHtmlCharset(html)).toContain('<meta charset="utf-8">');
+  });
+});

--- a/apps/registry/lib/formatters/template/format.js
+++ b/apps/registry/lib/formatters/template/format.js
@@ -1,4 +1,5 @@
 import { getTheme } from './getTheme';
+import { ensureHtmlCharset } from './ensureHtmlCharset';
 import { normalizeDates } from '@jsonresume/utils/dates';
 
 /**
@@ -35,7 +36,9 @@ const THEME_PACKAGES = {
 
 function freshRequireTheme(themeName) {
   const packageName = THEME_PACKAGES[themeName];
-  if (!packageName) return null;
+  if (!packageName) {
+    return null;
+  }
 
   try {
     const hbsPath = nodeRequire.resolve('handlebars');
@@ -64,7 +67,7 @@ export const format = async function (resume, options) {
   const resumeHTML = themeRenderer.render(normalizeDates(resume));
 
   return {
-    content: resumeHTML,
+    content: ensureHtmlCharset(resumeHTML),
     headers: [
       {
         key: 'Cache-control',
@@ -72,7 +75,7 @@ export const format = async function (resume, options) {
       },
       {
         key: 'Content-Type',
-        value: 'text/html',
+        value: 'text/html; charset=utf-8',
       },
     ],
   };

--- a/apps/registry/lib/formatters/template/format.normalizeDates.test.js
+++ b/apps/registry/lib/formatters/template/format.normalizeDates.test.js
@@ -16,7 +16,9 @@ const renderSpy = vi.fn((resume) => JSON.stringify(resume));
 
 vi.mock('./getTheme', () => ({
   getTheme: vi.fn((theme) => {
-    if (theme === 'missing') return null;
+    if (theme === 'missing') {
+      return null;
+    }
     return { render: renderSpy };
   }),
 }));
@@ -183,7 +185,7 @@ describe('format() theme resolution and headers', () => {
     const { headers } = await format({ basics: { name: 'X' } }, {});
     expect(headers).toEqual([
       { key: 'Cache-control', value: 'public, max-age=90' },
-      { key: 'Content-Type', value: 'text/html' },
+      { key: 'Content-Type', value: 'text/html; charset=utf-8' },
     ]);
   });
 

--- a/apps/registry/lib/formatters/template/format.test.js
+++ b/apps/registry/lib/formatters/template/format.test.js
@@ -4,7 +4,9 @@ import { format } from './format';
 // Mock getTheme
 vi.mock('./getTheme', () => ({
   getTheme: vi.fn((theme) => {
-    if (theme === 'missing') return null;
+    if (theme === 'missing') {
+      return null;
+    }
     return {
       render: vi.fn(
         (resume) => `<html>${resume.basics?.name || 'Resume'}</html>`
@@ -20,7 +22,7 @@ describe('format', () => {
 
     const result = await format(resume, options);
 
-    expect(result.content).toBe('<html>John Doe</html>');
+    expect(result.content).toBe('<html><meta charset="utf-8">John Doe</html>');
   });
 
   it('renders resume with specified theme', async () => {
@@ -29,7 +31,9 @@ describe('format', () => {
 
     const result = await format(resume, options);
 
-    expect(result.content).toBe('<html>Jane Smith</html>');
+    expect(result.content).toBe(
+      '<html><meta charset="utf-8">Jane Smith</html>'
+    );
   });
 
   it('throws error when theme is missing', async () => {
@@ -52,7 +56,7 @@ describe('format', () => {
       },
       {
         key: 'Content-Type',
-        value: 'text/html',
+        value: 'text/html; charset=utf-8',
       },
     ]);
   });
@@ -72,7 +76,7 @@ describe('format', () => {
 
     const result = await format(resume, options);
 
-    expect(result.content).toBe('<html>Resume</html>');
+    expect(result.content).toBe('<html><meta charset="utf-8">Resume</html>');
   });
 
   it('returns content and headers object', async () => {


### PR DESCRIPTION
Root cause: some themes (e.g. jsonresume-theme-elegant) emit HTML with no `<meta charset>` tag, and the registry template formatter served it with `Content-Type: text/html` (no charset). Browsers fall back to a platform-default encoding, so multi-byte UTF-8 renders as mojibake.

Fix at the registry formatter layer so all themes are covered:
- `Content-Type` is now `text/html; charset=utf-8`
- new `ensureHtmlCharset` helper injects `<meta charset="utf-8">` into rendered HTML that lacks a charset declaration (also covers file downloads/local saves where headers do not apply)

Unit tests added for the helper; existing format tests updated.

Fixes #471

— AI