### PR TITLE
chore(deps): dependabot health — unblock fumadocs-mdx 15, guard next group, ignore broken packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       minor-and-patch:
         patterns:
           - '*'
+        # Excluded: apps/homepage2 pins next ^15 while the rest of the repo is
+        # on ^16; grouping next with the semver-major ignore below makes
+        # dependabot "resolve" the group by downgrading next 16 -> 15 repo-wide.
+        exclude-patterns:
+          - 'next'
         update-types:
           - 'minor'
           - 'patch'
@@ -29,6 +34,16 @@ updates:
       - dependency-name: 'next-auth'
         update-types:
           - 'version-update:semver-major'
+      # Deprecated upstream: 0.15.0 is a stub that removes
+      # createRouteHandlerClient. Ignore all updates until the registry
+      # migrates to @supabase/ssr (#480).
+      - dependency-name: '@supabase/auth-helpers-nextjs'
+      # 0.26.x dist requires the ESM-only @rbardini/html from CJS — upstream
+      # packaging bug breaks require(). Majors still surface for review.
+      - dependency-name: 'jsonresume-theme-even'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
 
   # GitHub Actions used by workflows
   - package-ecosystem: 'github-actions'

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,7 +18,8 @@
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "mermaid": "^11.0.0"
+    "mermaid": "^11.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,7 +148,7 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: ^16.0.0
-        version: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)
+        version: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^14.0.0
         version: 14.3.1(@types/mdx@2.0.13)(@types/react@19.2.2)(fumadocs-core@16.8.0)(next@16.2.9)(react@19.2.7)
@@ -167,6 +167,9 @@ importers:
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
@@ -15173,7 +15176,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /fumadocs-core@16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7):
+  /fumadocs-core@16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)(zod@4.4.3):
     resolution: {integrity: sha512-kO9DnhJ/8E2DNtsyDlvMFDBNH0A5V+OFJEFiGNNb/jM/zs7YdSszQ3LOPL66AnyUQ5aou7BmFyPvzJvyiDMyjg==}
     peerDependencies:
       '@mdx-js/mdx': '*'
@@ -15253,6 +15256,7 @@ packages:
       unified: 11.0.5
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15292,7 +15296,7 @@ packages:
       chokidar: 5.0.0
       esbuild: 0.28.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)
+      fumadocs-core: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)(zod@4.4.3)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -15306,7 +15310,7 @@ packages:
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -15345,7 +15349,7 @@ packages:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.2
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)
+      fumadocs-core: 16.8.0(@types/react@19.2.2)(next@16.2.9)(react-dom@19.2.7)(react@19.2.7)(zod@4.4.3)
       lucide-react: 1.8.0(react@19.2.7)
       motion: 12.38.0(react-dom@19.2.7)(react@19.2.7)
       next: 16.2.9(@babel/core@7.28.5)(@playwright/test@1.56.1)(react-dom@19.2.7)(react@19.2.7)
@@ -17999,7 +18003,7 @@ packages:
       typescript: 5.9.3
       unbash: 2.2.0
       yaml: 2.9.0
-      zod: 4.3.6
+      zod: 4.4.3
     dev: true
 
   /kolorist@1.8.0:
@@ -25246,8 +25250,8 @@ packages:
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  /zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  /zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   /zustand@4.5.7(@types/react@19.2.2)(react@19.2.7):
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}


### PR DESCRIPTION
Applies the dependabot-health fixes root-caused in the diagnostics on #470 and #456.

## Changes

1. **`apps/docs`: add `zod: ^4.4.3`** — unblocks #456 (fumadocs-mdx 15). fumadocs-core@16.8.0 declares peer `zod: 4.x.x`, which was unmet: the fumadocs-mdx CLI loaded fumadocs-core against hoisted zod v3 and crashed at postinstall with `z.looseObject is not a function`. Lockfile updated via plain `pnpm install`.
2. **`.github/dependabot.yml`: `exclude-patterns: ['next']` on the `minor-and-patch` group** — fixes #470's primary failure. apps/homepage2 pins next ^15 while root/registry/docs are on ^16; combined with the semver-major ignore, dependabot resolved the group by downgrading next 16 → 15.5.20 repo-wide, breaking `next build --webpack` (a 16-only flag).
3. **`.github/dependabot.yml`: ignore rules** —
   - `@supabase/auth-helpers-nextjs` (all updates): 0.15.0 is a deprecated stub that removes `createRouteHandlerClient`. Migration to `@supabase/ssr` tracked in #480.
   - `jsonresume-theme-even` (minor/patch): 0.26.x dist requires the ESM-only `@rbardini/html` from CJS — upstream packaging bug.

## Verification

- `pnpm install` completes; docs postinstall (`fumadocs-mdx`) runs cleanly; `z.looseObject` resolves and the fumadocs-core zod peer is met
- `pnpm --filter docs build` passes (41 static pages generated)
- docs lint passes; dependabot.yml parses as valid YAML

## Follow-ups

- After merge: comment `@dependabot rebase` on #456 and `@dependabot recreate` on #470
- #470 additionally needs a homepage2 next-16 upgrade (separate work) plus theme dist regeneration for the styled-components bump
- #480 tracks the `@supabase/ssr` migration; remove the ignore entry once done

— AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added enhanced validation support for the documentation experience.

- **Chores**
  - Refined update management to improve stability and control over routine maintenance changes.
  - Adjusted update handling for selected components while continuing to allow compatible non-breaking improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->