### PR TITLE
fix(registry): salary parser range bugs + remove debug console.log spam

### DIFF
--- a/apps/registry/app/[username]/decisions/hooks/useDecisionTree.js
+++ b/apps/registry/app/[username]/decisions/hooks/useDecisionTree.js
@@ -97,11 +97,6 @@ export function useDecisionTree(resume, preferences = {}) {
     async (candidate, job) => {
       if (!candidate || !job) return;
 
-      console.log('=== CLIENT: Starting AI Evaluation ===');
-      console.log('Candidate:', candidate.basics?.name);
-      console.log('Job:', job.title, job.company);
-      console.log('Preferences:', preferences);
-
       resetHighlights();
 
       // Show loading state with animated messages
@@ -119,7 +114,6 @@ export function useDecisionTree(resume, preferences = {}) {
 
       try {
         const payload = { resume: candidate, job, preferences };
-        console.log('Sending payload with keys:', Object.keys(payload));
 
         // Call AI evaluation endpoint
         const response = await fetch('/api/decisions/evaluate', {
@@ -128,19 +122,11 @@ export function useDecisionTree(resume, preferences = {}) {
           body: JSON.stringify(payload),
         });
 
-        console.log('Response status:', response.status);
-
         if (!response.ok) {
           throw new Error('AI evaluation failed');
         }
 
         const result = await response.json();
-        console.log('Response data:', result);
-        console.log('Decisions object:', result.decisions);
-        console.log(
-          'Number of decisions:',
-          Object.keys(result.decisions || {}).length
-        );
 
         // Animate path based on AI decisions
         animateAIPath(result.decisions);

--- a/apps/registry/app/[username]/jobs-graph/utils/graphReconnection.js
+++ b/apps/registry/app/[username]/jobs-graph/utils/graphReconnection.js
@@ -23,22 +23,9 @@ export function reconnectEdges(
     nodes.filter((n) => !hiddenNodeIds.has(n.id)).map((n) => n.id)
   );
 
-  console.log('[reconnectEdges] Debug:', {
-    totalEdges: edges.length,
-    hiddenCount: hiddenNodeIds.size,
-    visibleCount: visibleNodeIds.size,
-    resumeNodeId,
-    resumeIsVisible: visibleNodeIds.has(resumeNodeId),
-    hasNearestNeighbors: Object.keys(nearestNeighbors).length,
-  });
-
   // Critical: if no resume node found, we can't reconnect orphans
   if (!resumeNodeId) {
-    console.error('[reconnectEdges] ERROR: Resume node not found in nodes!');
-    console.log(
-      '[reconnectEdges] Sample nodes:',
-      nodes.slice(0, 3).map((n) => ({ id: n.id, isResume: n.data?.isResume }))
-    );
+    console.error('[reconnectEdges] Resume node not found in nodes');
   }
 
   // Build parent lookup: nodeId -> parentNodeId
@@ -109,15 +96,6 @@ export function reconnectEdges(
         stats.reconnected++;
       } else {
         stats.failedReconnect++;
-        if (stats.failedReconnect <= 3) {
-          console.log('[reconnectEdges] Failed to reconnect:', {
-            target: edge.target,
-            connectionSource: connection.source,
-            reason: !connection.source
-              ? 'no source found'
-              : 'source equals target',
-          });
-        }
       }
     } else {
       // Both visible - keep edge as-is
@@ -126,7 +104,12 @@ export function reconnectEdges(
     }
   });
 
-  console.log('[reconnectEdges] Processing stats:', stats);
+  // Failed reconnections drop edges from the graph - surface them as a warning
+  if (stats.failedReconnect > 0) {
+    console.warn(
+      `[reconnectEdges] Failed to reconnect ${stats.failedReconnect} edge(s) with hidden sources`
+    );
+  }
 
   // Deduplicate edges (same source-target pair)
   const seen = new Set();
@@ -160,8 +143,6 @@ export function reconnectEdges(
   );
 
   if (orphanNodes.length > 0) {
-    console.log('[reconnectEdges] Found orphan nodes:', orphanNodes.length);
-
     // Connect each orphan to resume as fallback
     for (const orphanId of orphanNodes) {
       // Try to find best visible connected node from nearestNeighbors
@@ -192,15 +173,6 @@ export function reconnectEdges(
 
     stats.orphansReconnected = orphanNodes.length;
   }
-
-  console.log('[reconnectEdges] Result:', {
-    inputEdges: edges.length,
-    outputEdges: finalEdges.length,
-    orphansFixed: orphanNodes.length,
-    sample: finalEdges
-      .slice(0, 3)
-      .map((e) => ({ source: e.source, target: e.target })),
-  });
 
   return finalEdges;
 }

--- a/apps/registry/app/api/decisions/evaluate/route.js
+++ b/apps/registry/app/api/decisions/evaluate/route.js
@@ -2,6 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import { generateText, tool } from 'ai';
 import { z } from 'zod';
 import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 // Zod schemas for each decision criterion
 // AI SDK v5 uses tool() helper with inputSchema
@@ -122,10 +123,6 @@ export async function POST(request) {
   try {
     const { resume, job, preferences = {} } = await request.json();
 
-    console.log('=== AI EVALUATION DEBUG ===');
-    console.log('Resume basics:', resume.basics?.name, resume.basics?.label);
-    console.log('Job title:', job.title, 'Company:', job.company);
-
     if (!resume || !job) {
       return NextResponse.json(
         { error: 'Resume and job are required' },
@@ -135,11 +132,6 @@ export async function POST(request) {
 
     // Parse job GPT content if available
     const gptJob = job.gpt_content ? JSON.parse(job.gpt_content) : {};
-    console.log('GPT Job parsed:', {
-      hasContent: !!job.gpt_content,
-      skills: gptJob.skills?.length || 0,
-      title: gptJob.title,
-    });
 
     // Prepare FULL resume context for AI - send everything!
     const resumeContext = JSON.stringify(resume, null, 2);
@@ -162,10 +154,6 @@ export async function POST(request) {
       null,
       2
     );
-
-    console.log('Resume context length:', resumeContext.length);
-    console.log('Job context length:', jobContext.length);
-    console.log('User preferences:', preferences);
 
     // Build user preferences context
     const preferencesInfo = Object.entries(preferences)
@@ -237,11 +225,7 @@ Call ALL of these tools in order:
 
 Be thorough, honest, and realistic in your evaluation. Even if the candidate fails one check, continue evaluating all remaining criteria.`;
 
-    console.log('Prompt length:', prompt.length);
-    console.log('Number of tools:', Object.keys(tools).length);
-
     // Call AI with tool definitions
-    console.log('Calling generateText...');
     const result = await generateText({
       model: openai('gpt-4o-mini'),
       prompt,
@@ -249,30 +233,25 @@ Be thorough, honest, and realistic in your evaluation. Even if the candidate fai
       maxSteps: 10, // Allow multiple tool calls
     });
 
-    console.log('generateText result keys:', Object.keys(result));
-    console.log('toolCalls:', result.toolCalls);
-    console.log('toolCalls length:', result.toolCalls?.length || 0);
-    console.log('text response:', result.text?.substring(0, 200));
-
     // Process tool call results
     const decisions = {};
     if (result.toolCalls) {
-      console.log('Processing', result.toolCalls.length, 'tool calls');
       for (const toolCall of result.toolCalls) {
-        console.log('Tool call:', toolCall.toolName, 'Input:', toolCall.input);
         decisions[toolCall.toolName] = toolCall.input; // Use .input instead of .args
       }
     } else {
-      console.log('NO TOOL CALLS RETURNED!');
+      logger.warn(
+        { job: job.title, company: job.company },
+        'AI evaluation returned no tool calls'
+      );
     }
-
-    console.log('Final decisions:', JSON.stringify(decisions, null, 2));
-    console.log('=== END DEBUG ===');
 
     return NextResponse.json({ decisions });
   } catch (error) {
-    console.error('Error evaluating match:', error);
-    console.error('Error stack:', error.stack);
+    logger.error(
+      { error: error.message, stack: error.stack },
+      'Error evaluating match'
+    );
     return NextResponse.json(
       { error: 'Failed to evaluate match', details: error.message },
       { status: 500 }

--- a/apps/registry/app/api/pathways/route.js
+++ b/apps/registry/app/api/pathways/route.js
@@ -71,18 +71,6 @@ export async function POST(request) {
       // Enable multi-step tool loop (max 20 tool calls per request)
       maxSteps: 20,
 
-      // Log step completions for debugging/analytics
-      onStepFinish({ toolCalls, stepType }) {
-        if (toolCalls?.length) {
-          // Edge runtime doesn't support Pino - use console for streaming routes
-          // eslint-disable-next-line no-console
-          console.log(
-            '[Agent Step]',
-            toolCalls.map((t) => t.toolName)
-          );
-        }
-      },
-
       experimental_transform: smoothStream({
         delayInMs: 20,
         chunking: 'word',

--- a/apps/registry/scripts/jobs/salary-normalizer/index.js
+++ b/apps/registry/scripts/jobs/salary-normalizer/index.js
@@ -166,8 +166,12 @@ function normalizeObject(salary, rates) {
     max = single;
   }
 
-  if (min !== undefined) min = Number(min);
-  if (max !== undefined) max = Number(max);
+  if (min !== undefined) {
+    min = Number(min);
+  }
+  if (max !== undefined) {
+    max = Number(max);
+  }
 
   if ((min === undefined || isNaN(min)) && (max === undefined || isNaN(max))) {
     return { salaryUsd: null, confidence: 0 };
@@ -218,12 +222,24 @@ function detectCurrency(str) {
 
   // Check for prefixed $ symbols (US$, A$, AU$, C$, CA$, etc.)
   // IMPORTANT: Check longer prefixes first (CA$ before A$) to avoid false matches
-  if (/US\$/i.test(str)) return 'USD';
-  if (/CA\$|C\$/i.test(str)) return 'CAD';
-  if (/AU\$|A\$/i.test(str)) return 'AUD';
-  if (/NZ\$/i.test(str)) return 'NZD';
-  if (/HK\$/i.test(str)) return 'HKD';
-  if (/S\$/i.test(str)) return 'SGD';
+  if (/US\$/i.test(str)) {
+    return 'USD';
+  }
+  if (/CA\$|C\$/i.test(str)) {
+    return 'CAD';
+  }
+  if (/AU\$|A\$/i.test(str)) {
+    return 'AUD';
+  }
+  if (/NZ\$/i.test(str)) {
+    return 'NZD';
+  }
+  if (/HK\$/i.test(str)) {
+    return 'HKD';
+  }
+  if (/S\$/i.test(str)) {
+    return 'SGD';
+  }
 
   // Check for prefixed symbols (A$, C$, etc.) - must check before single $
   for (const [symbol, code] of Object.entries(CURRENCY_MAP)) {
@@ -233,26 +249,50 @@ function detectCurrency(str) {
   }
 
   // Check for single character symbols
-  if (str.includes('€')) return 'EUR';
-  if (str.includes('£')) return 'GBP';
-  if (str.includes('₹')) return 'INR';
-  if (str.includes('₩')) return 'KRW';
-  if (str.includes('₽')) return 'RUB';
-  if (str.includes('₱')) return 'PHP';
-  if (str.includes('฿')) return 'THB';
-  if (str.includes('₪')) return 'ILS';
+  if (str.includes('€')) {
+    return 'EUR';
+  }
+  if (str.includes('£')) {
+    return 'GBP';
+  }
+  if (str.includes('₹')) {
+    return 'INR';
+  }
+  if (str.includes('₩')) {
+    return 'KRW';
+  }
+  if (str.includes('₽')) {
+    return 'RUB';
+  }
+  if (str.includes('₱')) {
+    return 'PHP';
+  }
+  if (str.includes('฿')) {
+    return 'THB';
+  }
+  if (str.includes('₪')) {
+    return 'ILS';
+  }
   if (str.includes('¥')) {
     // Could be JPY or CNY - check for explicit indicator
-    if (/CNY|yuan|rmb/i.test(str)) return 'CNY';
+    if (/CNY|yuan|rmb/i.test(str)) {
+      return 'CNY';
+    }
     return 'JPY'; // Default to JPY
   }
-  if (str.includes('R') && /\bR\s*[\d,]+/.test(str)) return 'ZAR'; // South African Rand
+  if (str.includes('R') && /\bR\s*[\d,]+/.test(str)) {
+    return 'ZAR';
+  } // South African Rand
 
   // Check for LPA (Lakhs Per Annum - Indian)
-  if (/\d+\s*LPA/i.test(str)) return 'INR';
+  if (/\d+\s*LPA/i.test(str)) {
+    return 'INR';
+  }
 
   // Default to USD if $ or no currency
-  if (str.includes('$')) return 'USD';
+  if (str.includes('$')) {
+    return 'USD';
+  }
 
   return 'USD';
 }
@@ -320,9 +360,13 @@ function extractNumbers(str) {
     .replace(/(US|AU|CA|NZ|HK|SG?)\$/gi, '') // Remove prefixed $ symbols
     .replace(/\b(base|salary|total|comp|tc|ote|cash)\b:?/gi, '')
     .replace(
-      /\b(around|about|approximately|approx|up\s*to|starting\s*at|from|between|and|minimum|min|maximum|max|plus)\b/gi,
+      /\b(around|about|approximately|approx|up\s*to|starting\s*at|from|between|minimum|min|maximum|max|plus)\b/gi,
       ' '
     )
+    // Treat "and" as a range separator (not just noise) so word-separated
+    // plain numbers like "150000 and 100000" parse as a range instead of
+    // being concatenated by the greedy whitespace-tolerant number scan.
+    .replace(/\band\b/gi, ' - ')
     .replace(/[~≈]/g, '')
     .trim();
 
@@ -357,7 +401,7 @@ function extractNumbers(str) {
   if (lpaRangeMatch) {
     const min = parseFloat(lpaRangeMatch[1]) * 100000;
     const max = parseFloat(lpaRangeMatch[2]) * 100000;
-    return { min, max };
+    return orderRange(min, max);
   }
 
   // Handle single LPA
@@ -376,7 +420,7 @@ function extractNumbers(str) {
   if (lakhRangeBothMatch) {
     const min = parseFloat(lakhRangeBothMatch[1]) * 100000;
     const max = parseFloat(lakhRangeBothMatch[2]) * 100000;
-    return { min, max };
+    return orderRange(min, max);
   }
 
   // Pattern 2: Only second has L suffix (35-80L)
@@ -386,7 +430,7 @@ function extractNumbers(str) {
   if (lakhRangeMatch) {
     const min = parseFloat(lakhRangeMatch[1]) * 100000;
     const max = parseFloat(lakhRangeMatch[2]) * 100000;
-    return { min, max };
+    return orderRange(min, max);
   }
 
   // Handle single "XL" notation
@@ -404,7 +448,7 @@ function extractNumbers(str) {
   if (shorthandRange) {
     const min = parseFloat(shorthandRange[1]) * 1000;
     const max = parseFloat(shorthandRange[2]) * 1000;
-    return { min, max };
+    return orderRange(min, max);
   }
 
   // Handle K notation: 100k, 150K, etc.
@@ -421,7 +465,7 @@ function extractNumbers(str) {
     const min = parseNumber(rangeMatch[1]);
     const max = parseNumber(rangeMatch[2]);
     if (min !== null && max !== null) {
-      return { min, max };
+      return orderRange(min, max);
     }
   }
 
@@ -450,10 +494,20 @@ function extractNumbers(str) {
 }
 
 /**
+ * Order a pair of range endpoints so min <= max
+ * (handles descending inputs like "150,000 - 100,000")
+ */
+function orderRange(a, b) {
+  return a <= b ? { min: a, max: b } : { min: b, max: a };
+}
+
+/**
  * Parse a number string handling various formats
  */
 function parseNumber(str) {
-  if (!str) return null;
+  if (!str) {
+    return null;
+  }
 
   // Remove spaces, quotes, and normalize
   let cleaned = str.replace(/[\s']/g, '');
@@ -520,7 +574,9 @@ function smartAnnualize(amount, period) {
  * Round to nearest thousand
  */
 function roundToThousand(amount) {
-  if (amount === null || isNaN(amount)) return null;
+  if (amount === null || isNaN(amount)) {
+    return null;
+  }
   return Math.round(amount / 1000) * 1000;
 }
 

--- a/apps/registry/scripts/jobs/salary-normalizer/salaryHelpers.test.js
+++ b/apps/registry/scripts/jobs/salary-normalizer/salaryHelpers.test.js
@@ -119,36 +119,14 @@ describe('extractNumbers', () => {
     });
   });
 
-  // BUG (documented, not fixed in this PR): when a word separator such as
-  // "and"/"between"/"to" sits between two plain numbers, the cleaner replaces
-  // the word with a space, the greedy range regex captures BOTH numbers in its
-  // first group, and parseNumber strips the whitespace — concatenating them
-  // into one garbage value instead of producing a {min,max} range.
-  it('CURRENT BEHAVIOR: word-separated plain numbers are concatenated', () => {
-    expect(extractNumbers('150000 and 100000')).toEqual({
-      min: 150000100000,
-      max: 150000100000,
-    });
-  });
-
-  it.skip('EXPECTED: word-separated plain numbers should parse as a range', () => {
+  it('parses word-separated plain numbers as a range', () => {
     expect(extractNumbers('150000 and 100000')).toEqual({
       min: 100000,
       max: 150000,
     });
   });
 
-  // BUG (documented, not fixed in this PR): the dash/"to" range path returns
-  // numbers in their literal order and never sorts, so a descending range like
-  // "150,000 - 100,000" yields min > max.
-  it('CURRENT BEHAVIOR: descending dash range is not reordered (min > max)', () => {
-    expect(extractNumbers('150,000 - 100,000')).toEqual({
-      min: 150000,
-      max: 100000,
-    });
-  });
-
-  it.skip('EXPECTED: descending dash range should be reordered to min <= max', () => {
+  it('reorders a descending dash range to min <= max', () => {
     expect(extractNumbers('150,000 - 100,000')).toEqual({
       min: 100000,
       max: 150000,


### PR DESCRIPTION
Two registry code-quality fixes.

**Salary parser (`scripts/jobs/salary-normalizer`)**
- Word-separated plain numbers ("150000 and 100000") no longer concatenate into one garbage value: "and" is now translated to a dash separator during cleaning so the pair routes through the range path. LPA/lakh/k-suffix/"to" notations unaffected (LPA and lakh paths return before the range regex; "to" keeps its existing handling).
- Descending ranges ("150,000 - 100,000") are reordered via an `orderRange` helper applied at every range-producing return (LPA, both lakh patterns, shorthand-k, generic dash/to).
- Unskipped both EXPECTED tests, deleted the two CURRENT BEHAVIOR tests that locked in the bugs. No skipped tests remain in the salary suites.

**Debug console.log cleanup (Pino-only policy)**
- `app/api/decisions/evaluate/route.js`: deleted the "AI EVALUATION DEBUG" spam block; kept two useful signals as Pino (`logger.warn` when the AI returns no tool calls, `logger.error` in the catch), matching the chat route pattern.
- `app/api/pathways/route.js`: removed the `onStepFinish` handler that existed only for a `[Agent Step]` console.log (edge runtime, Pino unavailable).
- `[username]/decisions/hooks/useDecisionTree.js` (client): deleted debug logs; kept the catch-block `console.error`, the repo's established client-side failure pattern.
- `[username]/jobs-graph/utils/graphReconnection.js` (client): deleted debug dumps; kept the missing-resume-node `console.error` and replaced per-edge failure logs with one aggregated `console.warn` so dropped-edge visibility is preserved.
- Remaining `console.error` calls in app code are intentional catch-block error reporting, not leftovers; left untouched.

Tests: registry unit suite 1649 passed (110 files), salary suites 209 passed, 0 skipped. Registry lint clean (`eslint . --max-warnings=0`).

No changeset: apps/registry is not published.

— AI