### PR TITLE
fix(registry): isolate theme import failures from the render pipeline

### DIFF
--- a/apps/registry/lib/formatters/template/format.js
+++ b/apps/registry/lib/formatters/template/format.js
@@ -56,9 +56,11 @@ function freshRequireTheme(themeName) {
 export const format = async function (resume, options) {
   const theme = options.theme ?? 'elegant';
 
+  // getTheme lazily imports the theme module; a module that throws at import
+  // time rejects here for THIS theme only (see themeConfig.js / #476).
   const themeRenderer = THEME_PACKAGES[theme]
     ? freshRequireTheme(theme)
-    : getTheme(theme);
+    : await getTheme(theme);
 
   if (!themeRenderer) {
     throw new Error('theme-missing');

--- a/apps/registry/lib/formatters/template/getTheme.js
+++ b/apps/registry/lib/formatters/template/getTheme.js
@@ -1,12 +1,51 @@
 import { THEMES } from './themeConfig';
+import logger from '../../logger';
 
-export const getTheme = (theme) => {
+// Successful loads are cached so each theme module is evaluated at most once
+// per process. Failures are NOT cached: a broken theme errors per-request
+// (logged below) without poisoning the cache for a later fixed deploy.
+const loaded = new Map();
+
+/**
+ * dynamic import() interop: ESM themes expose render() on the namespace,
+ * CJS themes (elegant, even, ...) expose it on default (module.exports).
+ */
+const resolveRenderable = (mod) => {
+  if (mod && typeof mod.render === 'function') {
+    return mod;
+  }
+  if (mod?.default && typeof mod.default.render === 'function') {
+    return mod.default;
+  }
+  return mod?.default ?? mod;
+};
+
+/**
+ * Lazily load a theme module by slug (#476).
+ *
+ * - unknown slug -> null (format.js maps this to "theme-missing")
+ * - module throws at import time -> throws "theme-load-failed: <slug>", which
+ *   formatResume.js catches and turns into a per-theme error response, so one
+ *   broken theme can no longer take down every theme's rendering.
+ */
+export const getTheme = async (theme) => {
+  const load = THEMES[theme];
+  if (typeof load !== 'function') {
+    return null;
+  }
+  if (loaded.has(theme)) {
+    return loaded.get(theme);
+  }
+
   try {
-    return THEMES[theme];
+    const themeModule = resolveRenderable(await load());
+    loaded.set(theme, themeModule);
+    return themeModule;
   } catch (e) {
-    return {
-      e: e.toString(),
-      error: 'Theme is not supported.',
-    };
+    logger.error(
+      { theme, error: e.message, stack: e.stack },
+      'Theme module failed to load'
+    );
+    throw new Error(`theme-load-failed: ${theme}: ${e.message}`, { cause: e });
   }
 };

--- a/apps/registry/lib/formatters/template/getTheme.test.js
+++ b/apps/registry/lib/formatters/template/getTheme.test.js
@@ -1,72 +1,103 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getTheme } from './getTheme';
+import { format } from './format';
+import { THEMES } from './themeConfig';
 
+// THEMES values are lazy loader thunks (see themeConfig.js / #476).
 vi.mock('./themeConfig', () => ({
   THEMES: {
-    default: { name: 'default', template: 'default-template' },
-    elegant: { name: 'elegant', template: 'elegant-template' },
-    professional: { name: 'professional', template: 'pro-template' },
+    // ESM-shaped module: render on the namespace.
+    elegant: vi.fn(async () => ({
+      render: (resume) => `<html>elegant:${resume?.basics?.name}</html>`,
+    })),
+    // CJS-shaped module: render on default (module.exports).
+    kendall: vi.fn(async () => ({
+      default: { render: () => '<html>kendall</html>' },
+    })),
+    // Module that throws at import time (the PR #472 failure mode).
+    broken: vi.fn(async () => {
+      throw new Error('boom at import time');
+    }),
   },
 }));
 
-describe('getTheme', () => {
-  it('returns theme when it exists', () => {
-    const theme = getTheme('default');
+vi.mock('../../logger', () => ({
+  default: { error: vi.fn() },
+}));
 
-    expect(theme).toBeDefined();
-    expect(theme.name).toBe('default');
+describe('getTheme (lazy loader)', () => {
+  it('loads an ESM-shaped theme module', async () => {
+    const theme = await getTheme('elegant');
+    expect(typeof theme.render).toBe('function');
   });
 
-  it('returns correct theme configuration', () => {
-    const theme = getTheme('elegant');
-
-    expect(theme.name).toBe('elegant');
-    expect(theme.template).toBe('elegant-template');
+  it('unwraps default export for CJS-shaped theme modules', async () => {
+    const theme = await getTheme('kendall');
+    expect(theme.render()).toBe('<html>kendall</html>');
   });
 
-  it('returns undefined for non-existent theme', () => {
-    const theme = getTheme('nonexistent');
-
-    expect(theme).toBeUndefined();
+  it('caches loaded modules (loader invoked once)', async () => {
+    await getTheme('elegant');
+    await getTheme('elegant');
+    expect(THEMES.elegant.mock.calls.length).toBe(1);
   });
 
-  it('handles null theme name', () => {
-    const theme = getTheme(null);
-
-    expect(theme).toBeUndefined();
+  it('returns null for unknown themes', async () => {
+    expect(await getTheme('nonexistent')).toBeNull();
+    expect(await getTheme('')).toBeNull();
+    expect(await getTheme(null)).toBeNull();
+    expect(await getTheme(undefined)).toBeNull();
+    expect(await getTheme('ELEGANT')).toBeNull(); // case sensitive
   });
 
-  it('handles undefined theme name', () => {
-    const theme = getTheme(undefined);
-
-    expect(theme).toBeUndefined();
+  it('throws a per-theme "theme-load-failed" error when the module throws at import time', async () => {
+    await expect(getTheme('broken')).rejects.toThrow(
+      'theme-load-failed: broken: boom at import time'
+    );
   });
 
-  it('returns professional theme', () => {
-    const theme = getTheme('professional');
-
-    expect(theme.name).toBe('professional');
-    expect(theme.template).toBe('pro-template');
+  it('logs load failures via the structured logger', async () => {
+    const logger = (await import('../../logger')).default;
+    await expect(getTheme('broken')).rejects.toThrow('theme-load-failed');
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: 'broken' }),
+      'Theme module failed to load'
+    );
   });
 
-  it('is case sensitive', () => {
-    const theme = getTheme('DEFAULT');
+  it('isolates failures: other themes keep loading after a broken one', async () => {
+    await expect(getTheme('broken')).rejects.toThrow('theme-load-failed');
+    const theme = await getTheme('elegant');
+    expect(typeof theme.render).toBe('function');
+  });
+});
 
-    expect(theme).toBeUndefined();
+describe('format() with lazy theme loading (end-to-end isolation)', () => {
+  const resume = { basics: { name: 'John Doe' } };
+
+  it('renders a healthy theme through the lazy path', async () => {
+    const { content } = await format(resume, { theme: 'elegant' });
+    expect(content).toContain('elegant:John Doe');
   });
 
-  it('handles empty string', () => {
-    const theme = getTheme('');
-
-    expect(theme).toBeUndefined();
+  it('a theme whose module throws rejects with theme-load-failed (per-theme 500)', async () => {
+    // formatResume.js catches this and builds a per-theme error response.
+    await expect(format(resume, { theme: 'broken' })).rejects.toThrow(
+      'theme-load-failed: broken'
+    );
   });
 
-  it('retrieves themes from THEMES config', () => {
-    const defaultTheme = getTheme('default');
-    const elegantTheme = getTheme('elegant');
+  it('other themes still render after a broken theme is requested', async () => {
+    await expect(format(resume, { theme: 'broken' })).rejects.toThrow(
+      'theme-load-failed'
+    );
+    const { content } = await format(resume, { theme: 'elegant' });
+    expect(content).toContain('elegant:John Doe');
+  });
 
-    expect(defaultTheme).not.toBe(elegantTheme);
-    expect(defaultTheme.name).toBe('default');
-    expect(elegantTheme.name).toBe('elegant');
+  it('unknown themes still throw theme-missing', async () => {
+    await expect(format(resume, { theme: 'nonexistent' })).rejects.toThrow(
+      'theme-missing'
+    );
   });
 });

--- a/apps/registry/lib/formatters/template/themeConfig.js
+++ b/apps/registry/lib/formatters/template/themeConfig.js
@@ -1,58 +1,22 @@
-import * as professional from '@jsonresume/jsonresume-theme-professional';
-// import * as tailwind from 'jsonresume-theme-tailwind';
-import * as flat from 'jsonresume-theme-flat';
-import * as stackoverflow from '@jsonresume/theme-stackoverflow';
-import * as reference from 'jsonresume-theme-reference';
-import * as sidebar from 'jsonresume-theme-sidebar';
-import * as modernclassic from 'jsonresume-theme-modern-classic';
-import * as executiveslate from 'jsonresume-theme-executive-slate';
-import * as productmanagercanvas from 'jsonresume-theme-product-manager-canvas';
-// styled-components moved inline to fix webpack resolution
-import * as governmentstandard from 'jsonresume-theme-government-standard'; // FIXED
-import * as developermono from 'jsonresume-theme-developer-mono'; // TESTING
-import * as minimalistgrid from 'jsonresume-theme-minimalist-grid'; // TESTING
-import * as creativestudio from '@jsonresume/jsonresume-theme-creative-studio'; // FIXED
-import * as datadriven from 'jsonresume-theme-data-driven'; // TESTING
-import * as consultantpolished from '@jsonresume/jsonresume-theme-consultant-polished'; // FIXED
-import * as universityfirst from 'jsonresume-theme-university-first'; // TESTING
-import * as academiccvlite from 'jsonresume-theme-academic-cv-lite'; // TESTING
-import * as saleshunter from 'jsonresume-theme-sales-hunter'; // TESTING
-import * as marketingnarrative from 'jsonresume-theme-marketing-narrative'; // FIXED
-import * as operationsprecision from 'jsonresume-theme-operations-precision'; // TESTING
-import * as writersportfolio from 'jsonresume-theme-writers-portfolio'; // NEW
-// import * as tokyomodernist from '@jsonresume/jsonresume-theme-tokyo-modernist'; // DISABLED - styled-components resolution issue
-import * as nordicminimal from 'jsonresume-theme-nordic-minimal'; // NEW
-import * as graphpapergrid from 'jsonresume-theme-graph-paper-grid'; // NEW
-import * as monochrome from 'jsonresume-theme-monochrome-noir'; // NEW
-import * as twocolumnmodernist from 'jsonresume-theme-two-column-modernist'; // NEW
-import * as sidebarphotostrip from 'jsonresume-theme-sidebar-photo-strip'; // NEW
-import * as architectsportfolio from 'jsonresume-theme-architects-portfolio'; // NEW
-import * as diagonalaccentbar from 'jsonresume-theme-diagonal-accent-bar'; // NEW
-import * as asymmetrictimeline from 'jsonresume-theme-asymmetric-timeline'; // NEW
-import * as midcenturyresume from 'jsonresume-theme-mid-century-resume'; // NEW
-import * as boldheaderstatement from 'jsonresume-theme-bold-header-statement'; // NEW
-import * as typewritermodern from 'jsonresume-theme-typewriter-modern'; // NEW
-import * as newyorkeditorial from 'jsonresume-theme-new-york-editorial'; // NEW
-import * as berlingrid from 'jsonresume-theme-berlin-grid'; // NEW
-import * as californianwarm from 'jsonresume-theme-californian-warm'; // NEW
-import * as londonbureau from 'jsonresume-theme-london-bureau'; // NEW
-import * as pacifichorizon from 'jsonresume-theme-pacific-horizon'; // NEW
-import * as frenchatelier from 'jsonresume-theme-french-atelier'; // NEW
-import * as urbantechno from 'jsonresume-theme-urban-techno'; // NEW
-import * as coastalcreative from 'jsonresume-theme-coastal-creative'; // NEW
-import * as investorbrief from 'jsonresume-theme-investor-brief'; // NEW
-import * as claude from 'jsonresume-theme-claude'; // NEW
-import * as colophon from 'jsonresume-theme-colophon';
-import * as communitygarden from 'jsonresume-theme-community-garden'; // NEW
-import * as creativeconfidence from 'jsonresume-theme-creative-confidence'; // NEW
-import * as artschoolmodern from 'jsonresume-theme-art-school-modern'; // NEW
-import * as fieldresearcher from 'jsonresume-theme-field-researcher'; // NEW
-import * as clinicalprecision from 'jsonresume-theme-clinical-precision'; // NEW
-import * as industrialengineer from 'jsonresume-theme-industrial-engineer'; // NEW
-import * as brutalist from 'jsonresume-theme-brutalist'; // NEW
-import * as artdeco from 'jsonresume-theme-art-deco'; // NEW
+/**
+ * Theme registry: maps theme slugs to LAZY module loaders (#476).
+ *
+ * Every value is a thunk with a STATIC import specifier:
+ *   slug: () => import('jsonresume-theme-x')
+ *
+ * Static specifiers keep webpack able to resolve and bundle each theme at
+ * build time, while module EVALUATION is deferred until the thunk is invoked
+ * (first render of that theme). A theme whose module throws at import time
+ * therefore fails only its own renders instead of crashing this module — and
+ * with it /api/[username] — for every user and every theme.
+ *
+ * Consumers:
+ * - getTheme.js invokes + caches the loaders (with a try/catch) for rendering.
+ * - Theme listings use Object.keys(THEMES) or @repo/theme-config metadata,
+ *   neither of which evaluates any theme module.
+ */
 
-// Import theme metadata from shared package
+// Theme metadata from the shared package (no theme imports).
 export {
   THEME_METADATA,
   THEME_NAMES,
@@ -60,69 +24,72 @@ export {
 } from '@repo/theme-config';
 
 export const THEMES = {
-  professional,
-  // tailwind,
-  elegant: require('jsonresume-theme-elegant'),
-  flat,
-  even: require('jsonresume-theme-even'),
-  jacrys: require('jsonresume-theme-jacrys'),
-  kendall: require('jsonresume-theme-kendall'),
-  lucide: require('jsonresume-theme-lucide'),
-  macchiato: require('jsonresume-theme-macchiato'),
-  // mantra: require('jsonresume-theme-mantra'), // REMOVED - causes build failure due to ansi-colors dependency
-  minyma: require('jsonresume-theme-minyma'),
-  'paper-plus-plus': require('jsonresume-theme-paper-plus-plus'),
-  pumpkin: require('jsonresume-theme-pumpkin'),
-  rickosborne: require('jsonresume-theme-rickosborne'),
-  stackoverflow,
-  'tan-responsive': require('jsonresume-theme-tan-responsive'),
-  reference,
-  sidebar,
-  'modern-classic': modernclassic,
-  'executive-slate': executiveslate,
-  'product-manager-canvas': productmanagercanvas,
-  // styled-components moved inline to fix webpack resolution
-  'government-standard': governmentstandard, // FIXED
-  'developer-mono': developermono, // TESTING
-  'minimalist-grid': minimalistgrid, // TESTING
-  'creative-studio': creativestudio, // FIXED
-  'data-driven': datadriven, // TESTING
-  'consultant-polished': consultantpolished, // FIXED
-  'university-first': universityfirst, // TESTING
-  'academic-cv-lite': academiccvlite, // TESTING
-  'sales-hunter': saleshunter, // TESTING
-  'marketing-narrative': marketingnarrative, // FIXED
-  'operations-precision': operationsprecision, // TESTING
-  'writers-portfolio': writersportfolio, // NEW
-  // 'tokyo-modernist': tokyomodernist, // DISABLED - styled-components resolution issue
-  'nordic-minimal': nordicminimal, // NEW
-  'graph-paper-grid': graphpapergrid, // NEW
-  'monochrome-noir': monochrome, // NEW
-  'two-column-modernist': twocolumnmodernist, // NEW
-  'sidebar-photo-strip': sidebarphotostrip, // NEW
-  'architects-portfolio': architectsportfolio, // NEW
-  'diagonal-accent-bar': diagonalaccentbar, // NEW
-  'asymmetric-timeline': asymmetrictimeline, // NEW
-  'mid-century-resume': midcenturyresume, // NEW
-  'bold-header-statement': boldheaderstatement, // NEW
-  'typewriter-modern': typewritermodern, // NEW
-  'new-york-editorial': newyorkeditorial, // NEW
-  'berlin-grid': berlingrid, // NEW
-  'californian-warm': californianwarm, // NEW
-  'london-bureau': londonbureau, // NEW
-  'pacific-horizon': pacifichorizon, // NEW
-  'french-atelier': frenchatelier, // NEW
-  'urban-techno': urbantechno, // NEW
-  'coastal-creative': coastalcreative, // NEW
-  'investor-brief': investorbrief, // NEW
-  claude: claude, // NEW
-  colophon,
-  'community-garden': communitygarden, // NEW
-  'creative-confidence': creativeconfidence, // NEW
-  'art-school-modern': artschoolmodern, // NEW
-  'field-researcher': fieldresearcher, // NEW
-  'clinical-precision': clinicalprecision, // NEW
-  'industrial-engineer': industrialengineer, // NEW
-  brutalist, // NEW
-  'art-deco': artdeco, // NEW
+  professional: () => import('@jsonresume/jsonresume-theme-professional'),
+  // tailwind: () => import('jsonresume-theme-tailwind'),
+  elegant: () => import('jsonresume-theme-elegant'),
+  flat: () => import('jsonresume-theme-flat'),
+  even: () => import('jsonresume-theme-even'),
+  jacrys: () => import('jsonresume-theme-jacrys'),
+  kendall: () => import('jsonresume-theme-kendall'),
+  lucide: () => import('jsonresume-theme-lucide'),
+  macchiato: () => import('jsonresume-theme-macchiato'),
+  // mantra: REMOVED - causes build failure due to ansi-colors dependency
+  minyma: () => import('jsonresume-theme-minyma'),
+  'paper-plus-plus': () => import('jsonresume-theme-paper-plus-plus'),
+  pumpkin: () => import('jsonresume-theme-pumpkin'),
+  rickosborne: () => import('jsonresume-theme-rickosborne'),
+  stackoverflow: () => import('@jsonresume/theme-stackoverflow'),
+  'tan-responsive': () => import('jsonresume-theme-tan-responsive'),
+  reference: () => import('jsonresume-theme-reference'),
+  sidebar: () => import('jsonresume-theme-sidebar'),
+  'modern-classic': () => import('jsonresume-theme-modern-classic'),
+  'executive-slate': () => import('jsonresume-theme-executive-slate'),
+  'product-manager-canvas': () =>
+    import('jsonresume-theme-product-manager-canvas'),
+  'government-standard': () => import('jsonresume-theme-government-standard'),
+  'developer-mono': () => import('jsonresume-theme-developer-mono'),
+  'minimalist-grid': () => import('jsonresume-theme-minimalist-grid'),
+  'creative-studio': () =>
+    import('@jsonresume/jsonresume-theme-creative-studio'),
+  'data-driven': () => import('jsonresume-theme-data-driven'),
+  'consultant-polished': () =>
+    import('@jsonresume/jsonresume-theme-consultant-polished'),
+  'university-first': () => import('jsonresume-theme-university-first'),
+  'academic-cv-lite': () => import('jsonresume-theme-academic-cv-lite'),
+  'sales-hunter': () => import('jsonresume-theme-sales-hunter'),
+  'marketing-narrative': () => import('jsonresume-theme-marketing-narrative'),
+  'operations-precision': () => import('jsonresume-theme-operations-precision'),
+  'writers-portfolio': () => import('jsonresume-theme-writers-portfolio'),
+  // 'tokyo-modernist': DISABLED - styled-components resolution issue
+  'nordic-minimal': () => import('jsonresume-theme-nordic-minimal'),
+  'graph-paper-grid': () => import('jsonresume-theme-graph-paper-grid'),
+  'monochrome-noir': () => import('jsonresume-theme-monochrome-noir'),
+  'two-column-modernist': () => import('jsonresume-theme-two-column-modernist'),
+  'sidebar-photo-strip': () => import('jsonresume-theme-sidebar-photo-strip'),
+  'architects-portfolio': () => import('jsonresume-theme-architects-portfolio'),
+  'diagonal-accent-bar': () => import('jsonresume-theme-diagonal-accent-bar'),
+  'asymmetric-timeline': () => import('jsonresume-theme-asymmetric-timeline'),
+  'mid-century-resume': () => import('jsonresume-theme-mid-century-resume'),
+  'bold-header-statement': () =>
+    import('jsonresume-theme-bold-header-statement'),
+  'typewriter-modern': () => import('jsonresume-theme-typewriter-modern'),
+  'new-york-editorial': () => import('jsonresume-theme-new-york-editorial'),
+  'berlin-grid': () => import('jsonresume-theme-berlin-grid'),
+  'californian-warm': () => import('jsonresume-theme-californian-warm'),
+  'london-bureau': () => import('jsonresume-theme-london-bureau'),
+  'pacific-horizon': () => import('jsonresume-theme-pacific-horizon'),
+  'french-atelier': () => import('jsonresume-theme-french-atelier'),
+  'urban-techno': () => import('jsonresume-theme-urban-techno'),
+  'coastal-creative': () => import('jsonresume-theme-coastal-creative'),
+  'investor-brief': () => import('jsonresume-theme-investor-brief'),
+  claude: () => import('jsonresume-theme-claude'),
+  colophon: () => import('jsonresume-theme-colophon'),
+  'community-garden': () => import('jsonresume-theme-community-garden'),
+  'creative-confidence': () => import('jsonresume-theme-creative-confidence'),
+  'art-school-modern': () => import('jsonresume-theme-art-school-modern'),
+  'field-researcher': () => import('jsonresume-theme-field-researcher'),
+  'clinical-precision': () => import('jsonresume-theme-clinical-precision'),
+  'industrial-engineer': () => import('jsonresume-theme-industrial-engineer'),
+  brutalist: () => import('jsonresume-theme-brutalist'),
+  'art-deco': () => import('jsonresume-theme-art-deco'),
 };


### PR DESCRIPTION
Fixes #476

themeConfig.js eagerly imported all ~60 theme packages, so one theme throwing at module-evaluation time (e.g. PR #472's styled-components interop crash) killed /api/[username] for every user and every theme.

Mechanism:
- THEMES values are now lazy thunks with STATIC specifiers: `slug: () => import('jsonresume-theme-x')`. Webpack still statically resolves and bundles each theme (proved: `turbo build --filter=registry --force` passes and `next start` renders ESM + CJS themes from the built bundle), but module evaluation is deferred to first render of that theme.
- getTheme() is now an async cached loader: try/catch around the thunk, dynamic-import interop (namespace .render for ESM, .default.render for CJS), Pino error log, and a wrapped `theme-load-failed: <slug>` error. formatResume already catches render-path errors and returns a per-theme UNKNOWN_TEMPLATE_ERROR, so a broken theme now degrades to a per-theme error response while all other themes keep rendering.
- Theme listing paths (/api/themes, QA suites, @repo/theme-config metadata) only use Object.keys(THEMES) / metadata, so they never evaluate theme modules.

Behavior changes:
- getTheme is async (only caller was format.js, updated).
- A theme that fails to import returns the standard per-theme template error instead of crashing the route; failures are logged, not cached, so a fixed deploy recovers.

Tests:
- getTheme.test.js rewritten for the loader: interop shapes, caching, per-theme theme-load-failed, isolation (broken theme rejects, others render), end-to-end through format().
- themeRenderQa suites: 84/84 pass — all registered themes render through the lazy path.
- Full registry suite: 1651 passed, 24 skipped.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Themes now load only when needed, improving startup efficiency.
  * Successfully loaded themes are cached for faster subsequent rendering.

* **Bug Fixes**
  * Theme-loading failures are isolated to the affected theme.
  * Improved support for different theme module formats.
  * Unknown themes now return a clear missing-theme error, while loading failures provide actionable error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->