### PR TITLE
refactor(registry): migrate @supabase/auth-helpers-nextjs to @supabase/ssr

### DIFF
--- a/apps/registry/app/api/my-jobs/mark/route.js
+++ b/apps/registry/app/api/my-jobs/mark/route.js
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL } from '@/lib/supabaseConfig';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@/lib/supabaseServer';
 import { logger } from '@/lib/logger';
 
 export const dynamic = 'force-dynamic';
@@ -18,8 +17,7 @@ function getServiceSupabase() {
  * Body: { jobId, state }
  */
 export async function POST(request) {
-  const cookieStore = cookies();
-  const authClient = createRouteHandlerClient({ cookies: () => cookieStore });
+  const authClient = await createRouteHandlerClient();
 
   const {
     data: { session },

--- a/apps/registry/app/api/my-jobs/route.js
+++ b/apps/registry/app/api/my-jobs/route.js
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { SUPABASE_URL } from '@/lib/supabaseConfig';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@/lib/supabaseServer';
 import { embed } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { logger } from '@/lib/logger';
@@ -40,8 +39,7 @@ async function getResumeEmbedding(resume) {
  * GET /api/my-jobs — matched jobs for the logged-in user (cookie session auth)
  */
 export async function GET() {
-  const cookieStore = cookies();
-  const authClient = createRouteHandlerClient({ cookies: () => cookieStore });
+  const authClient = await createRouteHandlerClient();
 
   const {
     data: { session },

--- a/apps/registry/app/api/privacy/delete-cache/route.test.ts
+++ b/apps/registry/app/api/privacy/delete-cache/route.test.ts
@@ -2,16 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DELETE } from './route';
 
 // Mock dependencies
-vi.mock('@supabase/auth-helpers-nextjs', () => ({
-  createRouteHandlerClient: vi.fn(() => ({
+vi.mock('@/lib/supabaseServer', () => ({
+  createRouteHandlerClient: vi.fn(async () => ({
     auth: {
       getSession: vi.fn(),
     },
   })),
-}));
-
-vi.mock('next/headers', () => ({
-  cookies: vi.fn(() => ({})),
 }));
 
 vi.mock('@supabase/supabase-js', () => ({
@@ -38,9 +34,7 @@ describe('DELETE /api/privacy/delete-cache', () => {
   });
 
   it('returns 401 when user is not authenticated', async () => {
-    const { createRouteHandlerClient } = await import(
-      '@supabase/auth-helpers-nextjs'
-    );
+    const { createRouteHandlerClient } = await import('@/lib/supabaseServer');
     (createRouteHandlerClient as any).mockReturnValueOnce({
       auth: {
         getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
@@ -59,9 +53,7 @@ describe('DELETE /api/privacy/delete-cache', () => {
   });
 
   it('returns 400 when username is missing from session', async () => {
-    const { createRouteHandlerClient } = await import(
-      '@supabase/auth-helpers-nextjs'
-    );
+    const { createRouteHandlerClient } = await import('@/lib/supabaseServer');
     (createRouteHandlerClient as any).mockReturnValueOnce({
       auth: {
         getSession: vi.fn().mockResolvedValue({
@@ -91,9 +83,7 @@ describe('DELETE /api/privacy/delete-cache', () => {
   it('successfully deletes cached resume data', async () => {
     const mockDeleteFn = vi.fn().mockResolvedValue({ error: null, count: 1 });
 
-    const { createRouteHandlerClient } = await import(
-      '@supabase/auth-helpers-nextjs'
-    );
+    const { createRouteHandlerClient } = await import('@/lib/supabaseServer');
     (createRouteHandlerClient as any).mockReturnValueOnce({
       auth: {
         getSession: vi.fn().mockResolvedValue({
@@ -134,9 +124,7 @@ describe('DELETE /api/privacy/delete-cache', () => {
   });
 
   it('returns 500 when SUPABASE_KEY is not set', async () => {
-    const { createRouteHandlerClient } = await import(
-      '@supabase/auth-helpers-nextjs'
-    );
+    const { createRouteHandlerClient } = await import('@/lib/supabaseServer');
     (createRouteHandlerClient as any).mockReturnValueOnce({
       auth: {
         getSession: vi.fn().mockResolvedValue({

--- a/apps/registry/app/api/privacy/delete-cache/route.ts
+++ b/apps/registry/app/api/privacy/delete-cache/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@/lib/supabaseServer';
 import logger from '@/lib/logger';
 import { SUPABASE_URL } from '@/lib/supabaseConfig';
 
@@ -12,8 +11,7 @@ import { SUPABASE_URL } from '@/lib/supabaseConfig';
 export async function DELETE(request: Request) {
   try {
     // Verify user authentication via Supabase Auth
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = await createRouteHandlerClient();
 
     const {
       data: { session },

--- a/apps/registry/app/auth/callback/route.ts
+++ b/apps/registry/app/auth/callback/route.ts
@@ -1,5 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
-import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@/lib/supabaseServer';
 import { NextResponse } from 'next/server';
 import logger from '@/lib/logger';
 import { notifyUserSignup } from '@/lib/discord/notifiers';
@@ -9,8 +8,7 @@ export async function GET(request: Request) {
   const code = requestUrl.searchParams.get('code');
 
   if (code) {
-    const cookieStore = cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = await createRouteHandlerClient();
 
     // Exchange code for session
     const {

--- a/apps/registry/lib/supabaseConfig.js
+++ b/apps/registry/lib/supabaseConfig.js
@@ -28,6 +28,14 @@ const SUPABASE_URL =
   process.env.NEXT_PUBLIC_SUPABASE_URL || DEFAULT_SUPABASE_URL;
 
 /**
+ * Public anon key (browser-safe). Prefer env var, fall back to the
+ * documented public anon key so clients keep working if unset.
+ */
+const SUPABASE_ANON_KEY =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0eHVodnZ3cnlldXp1eWlocGtwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MDc5OTA4NjQsImV4cCI6MjAyMzU2Njg2NH0.oEs0H2aumAHsiLn6i9ic1-iwWDo3bJkFkC7NCeUrIfA';
+
+/**
  * Create a Supabase client with the service-role key (server-only).
  * Throws if SUPABASE_KEY is not configured.
  * @returns {import('@supabase/supabase-js').SupabaseClient}
@@ -55,11 +63,13 @@ function createAnonClient() {
 
 module.exports = {
   SUPABASE_URL,
+  SUPABASE_ANON_KEY,
   DEFAULT_SUPABASE_URL,
   createServiceClient,
   createAnonClient,
 };
 module.exports.SUPABASE_URL = SUPABASE_URL;
+module.exports.SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
 module.exports.DEFAULT_SUPABASE_URL = DEFAULT_SUPABASE_URL;
 module.exports.createServiceClient = createServiceClient;
 module.exports.createAnonClient = createAnonClient;

--- a/apps/registry/lib/supabaseServer.ts
+++ b/apps/registry/lib/supabaseServer.ts
@@ -1,0 +1,32 @@
+/**
+ * Cookie-session Supabase client for App Router route handlers.
+ *
+ * Replaces the deprecated `@supabase/auth-helpers-nextjs`
+ * `createRouteHandlerClient` with the `@supabase/ssr` equivalent
+ * (`createServerClient` + the getAll/setAll cookie adapter from the
+ * official Next.js App Router docs). See issue #480.
+ */
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabaseConfig';
+
+/**
+ * Create a Supabase client bound to the request's auth cookies.
+ * Route handlers may set cookies, so session refreshes persist.
+ */
+export async function createRouteHandlerClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) =>
+          cookieStore.set(name, value, options)
+        );
+      },
+    },
+  });
+}

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -35,7 +35,7 @@
     "@prisma/client": "^6.16.3",
     "@repo/theme-config": "workspace:*",
     "@repo/ui": "workspace:*",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
+    "@supabase/ssr": "^0.12.3",
     "@supabase/supabase-js": "^2.39.6",
     "@tailwindcss/typography": "^0.5.13",
     "@vercel/analytics": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,9 +313,9 @@ importers:
       '@repo/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@supabase/auth-helpers-nextjs':
-        specifier: ^0.10.0
-        version: 0.10.0(@supabase/supabase-js@2.77.0)
+      '@supabase/ssr':
+        specifier: ^0.12.3
+        version: 0.12.3(@supabase/supabase-js@2.77.0)
       '@supabase/supabase-js':
         specifier: ^2.39.6
         version: 2.77.0
@@ -8694,27 +8694,6 @@ packages:
       file-system-cache: 2.3.0
     dev: true
 
-  /@supabase/auth-helpers-nextjs@0.10.0(@supabase/supabase-js@2.77.0):
-    resolution: {integrity: sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==}
-    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
-    peerDependencies:
-      '@supabase/supabase-js': ^2.39.8
-    dependencies:
-      '@supabase/auth-helpers-shared': 0.7.0(@supabase/supabase-js@2.77.0)
-      '@supabase/supabase-js': 2.77.0
-      set-cookie-parser: 2.7.2
-    dev: false
-
-  /@supabase/auth-helpers-shared@0.7.0(@supabase/supabase-js@2.77.0):
-    resolution: {integrity: sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==}
-    deprecated: This package is now deprecated - please use the @supabase/ssr package instead.
-    peerDependencies:
-      '@supabase/supabase-js': ^2.39.8
-    dependencies:
-      '@supabase/supabase-js': 2.77.0
-      jose: 4.15.9
-    dev: false
-
   /@supabase/auth-js@2.77.0:
     resolution: {integrity: sha512-IRxyj2l46EutSX7AbGkHA7LSmrgqnXjPfKouBlGT6NqS1YOm+jMMwfdhf6zP5EZ4giUfdt2u+yHIBgyXU/LEtg==}
     dependencies:
@@ -8754,6 +8733,15 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
+
+  /@supabase/ssr@0.12.3(@supabase/supabase-js@2.77.0):
+    resolution: {integrity: sha512-qWXJ/dI7CiYDKyTgIPqJ4Qkh8y5edh2LdF/nkN48z47mmEVzAO2OE+YErYeQ/UemVfonn/F4kFz+lhLqoVMdpw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.110.5
+    dependencies:
+      '@supabase/supabase-js': 2.77.0
+      cookie: 1.1.1
     dev: false
 
   /@supabase/storage-js@2.77.0:
@@ -12365,6 +12353,11 @@ packages:
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
     dev: false
 
   /cookiejar@2.1.4:
@@ -17516,10 +17509,6 @@ packages:
       '@standard-schema/spec': 1.1.0
     dev: true
 
-  /jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
-    dev: false
-
   /jose@6.1.0:
     resolution: {integrity: sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==}
     dev: false
@@ -22303,10 +22292,6 @@ packages:
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-    dev: false
-
-  /set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
     dev: false
 
   /set-function-length@1.2.2:


### PR DESCRIPTION
Fixes #480

`@supabase/auth-helpers-nextjs` is deprecated; its 0.15.0 stub removes `createRouteHandlerClient`. Migrated to `@supabase/ssr`.

Changes:
- New `apps/registry/lib/supabaseServer.ts`: `createRouteHandlerClient()` wrapping `createServerClient` with the official getAll/setAll cookie adapter (`await cookies()` — Next 16 async API).
- `lib/supabaseConfig.js`: added `SUPABASE_ANON_KEY` export (env var + documented public fallback), same pattern as `app/lib/supabase.ts`.
- Migrated call sites, behavior unchanged: `app/auth/callback/route.ts` (exchangeCodeForSession + updateUser), `app/api/privacy/delete-cache/route.ts` (getSession + admin delete), `app/api/my-jobs/route.js`, `app/api/my-jobs/mark/route.js` (getSession).
- `delete-cache/route.test.ts`: mocks now target `@/lib/supabaseServer`; dropped obsolete `next/headers` mock.
- `package.json`: `@supabase/auth-helpers-nextjs` removed, `@supabase/ssr@^0.12.3` added; lockfile updated.

Verified locally: unit suite (1649 passed), `turbo build --filter=registry --force`, `tsc --noEmit`, prettier. Cookie format (`sb-<ref>-auth-token`) is unchanged between the two packages, so existing sessions survive.

Needs manual post-deploy check: GitHub OAuth login round-trip (login -> /auth/callback code exchange -> session cookie set), since live Supabase login can't be exercised locally.

Note: no `.github/dependabot.yml` exists on master (issue mentions removing an ignore entry — nothing to remove).

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session handling across job, privacy, and callback flows.
  * Enhanced reliability when reading and updating login sessions in server-side requests.

* **Improvements**
  * Centralized Supabase server authentication handling.
  * Added consistent access to the public Supabase configuration for supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->