### PR TITLE
fix(cli): theme-resolution edge cases from bug-hunt wave 16

### DIFF
--- a/.changeset/bughunt-416-cli-theme-resolution.md
+++ b/.changeset/bughunt-416-cli-theme-resolution.md
@@ -1,0 +1,5 @@
+---
+'resume-cli': patch
+---
+
+Fix theme-resolution edge cases from the Wave 16 bug-hunt (#416): the `jsonresume-theme-` prefix fallback guard in renderHTML tested the wrong variable (so it ran unconditionally, even for scoped specifiers); `resume serve` printed a leftover debug object on every rebuild; and PDF export resolved themes with its own `cwd/node_modules/<theme>/index.js` lookup, so hoisted installs or themes with a non-`index.js` entry point could render HTML fine but spuriously fail PDF export. Theme resolution is now shared between the HTML and PDF paths.

--- a/packages/cli/lib/export-resume.js
+++ b/packages/cli/lib/export-resume.js
@@ -1,4 +1,4 @@
-import renderHTML from './render-html';
+import renderHTML, { resolveThemePath } from './render-html';
 import { promisify } from 'util';
 import fs from 'fs';
 
@@ -72,19 +72,12 @@ const extractFileFormat = (fileName) => {
   return fileName.substring(dotPos + 1).toLowerCase();
 };
 const getThemePkg = (theme) => {
-  if (theme[0] === '.') {
-    theme = path.join(process.cwd(), theme, 'index.js');
-  } else {
-    theme = path.join(process.cwd(), 'node_modules', theme, 'index.js');
-  }
-  try {
-    const themePkg = require(theme);
-    return themePkg;
-  } catch (err) {
-    // Theme not installed. Throw a typed error so the caller can render an
-    // actionable, stack-trace-free message and exit with a non-zero code.
-    throw new ThemeNotFoundError(theme);
-  }
+  // Resolve with the same rules renderHTML uses (require-path lookup with a
+  // `jsonresume-theme-` prefix fallback) so a theme that renders to HTML can
+  // never spuriously fail PDF export (hoisted installs, non-index entries).
+  // resolveThemePath throws ThemeNotFoundError so the caller can render an
+  // actionable, stack-trace-free message and exit with a non-zero code.
+  return require(resolveThemePath(theme));
 };
 
 async function createHtml(resumeJson, fileName, themePath, format, callback) {

--- a/packages/cli/lib/export-resume.test.js
+++ b/packages/cli/lib/export-resume.test.js
@@ -1,0 +1,58 @@
+const exportResume = require('./export-resume');
+const { ThemeNotFoundError } = require('./theme-errors');
+
+describe('exportResume', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('surfaces ThemeNotFoundError from the PDF path for unresolvable themes', (done) => {
+    // PDF export resolves the theme (via the shared renderHTML resolver)
+    // before puppeteer is ever launched, so a missing theme fails fast with a
+    // typed error instead of a raw require() stack trace.
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    exportResume(
+      {
+        resume: { basics: { name: 'test' } },
+        fileName: 'out.pdf',
+        theme: 'jsonresume-theme-definitely-not-installed',
+        format: 'pdf',
+      },
+      (error, fileName, format) => {
+        try {
+          expect(error).toBeInstanceOf(ThemeNotFoundError);
+          expect(error.theme).toBe('jsonresume-theme-definitely-not-installed');
+          expect(fileName).toBe('out');
+          expect(format).toBe('.pdf');
+          // ThemeNotFoundError is reported by the caller; no raw dump here.
+          expect(errorSpy).not.toHaveBeenCalled();
+          done();
+        } catch (assertion) {
+          done(assertion);
+        }
+      },
+    );
+  });
+
+  it('surfaces ThemeNotFoundError from the HTML path for unresolvable themes', (done) => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    exportResume(
+      {
+        resume: { basics: { name: 'test' } },
+        fileName: 'out.html',
+        theme: 'jsonresume-theme-definitely-not-installed',
+        format: 'html',
+      },
+      (error) => {
+        try {
+          expect(error).toBeInstanceOf(ThemeNotFoundError);
+          done();
+        } catch (assertion) {
+          done(assertion);
+        }
+      },
+    );
+  });
+});

--- a/packages/cli/lib/render-html.js
+++ b/packages/cli/lib/render-html.js
@@ -8,7 +8,11 @@ const tryResolve = (...args) => {
   }
 };
 
-export default async ({ resume, themePath }) => {
+// Resolve a theme reference (relative path, full package name, or short name
+// missing the `jsonresume-theme-` prefix) to an absolute module path. Shared
+// by every code path that loads a theme (HTML render, PDF export) so a theme
+// that renders to HTML can never spuriously fail to resolve elsewhere.
+export const resolveThemePath = (themePath) => {
   const cwd = process.cwd();
   let path;
   if (themePath[0] === '.') {
@@ -20,13 +24,19 @@ export default async ({ resume, themePath }) => {
   if (!path) {
     path = tryResolve(themePath, { paths: [cwd] });
   }
-  if (!path && /^[a-z0-9]/i.test(path)) {
+  // Only fall back to the `jsonresume-theme-` prefix for bare short names;
+  // scoped or otherwise non-alphanumeric-leading specifiers are used as-is.
+  if (!path && /^[a-z0-9]/i.test(themePath)) {
     path = tryResolve(`jsonresume-theme-${themePath}`, { paths: [cwd] });
   }
   if (!path) {
     throw new ThemeNotFoundError(themePath);
   }
-  const theme = require(path);
+  return path;
+};
+
+export default async ({ resume, themePath }) => {
+  const theme = require(resolveThemePath(themePath));
   if (typeof theme?.render !== 'function') {
     throw new Error('theme.render is not a function');
   }

--- a/packages/cli/lib/render-html.test.js
+++ b/packages/cli/lib/render-html.test.js
@@ -1,4 +1,8 @@
-import renderHTML from './render-html';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import renderHTML, { resolveThemePath } from './render-html';
+import { ThemeNotFoundError } from './theme-errors';
 
 describe('renderHTML', () => {
   beforeAll(() => {
@@ -55,5 +59,103 @@ describe('renderHTML', () => {
         }),
       ).toStartWith('<!doctype html>');
     });
+  });
+});
+
+describe('resolveThemePath', () => {
+  // On-disk fixtures: a fake install root with a node_modules directory so we
+  // can exercise real require.resolve behavior without touching the repo.
+  let root;
+  let cwdSpy;
+
+  const makeTheme = (dirName, { main } = {}) => {
+    const themeDir = path.join(root, 'node_modules', dirName);
+    const entryFile = path.join(themeDir, main || 'index.js');
+    fs.mkdirSync(path.dirname(entryFile), { recursive: true });
+    const pkg = { name: dirName, version: '1.0.0' };
+    if (main) {
+      pkg.main = main;
+    }
+    fs.writeFileSync(path.join(themeDir, 'package.json'), JSON.stringify(pkg));
+    fs.writeFileSync(
+      entryFile,
+      'module.exports = { render: () => "<!doctype html>" };',
+    );
+  };
+
+  beforeAll(() => {
+    root = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'resume-cli-themes-')),
+    );
+    makeTheme('jsonresume-theme-short');
+    // A literal directory the (previously broken) prefix fallback would have
+    // matched for the scoped-looking specifier "@scoped".
+    makeTheme('jsonresume-theme-@scoped');
+    makeTheme('jsonresume-theme-nested', { main: 'lib/entry.js' });
+    fs.mkdirSync(path.join(root, 'sub'), { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    if (cwdSpy) {
+      cwdSpy.mockRestore();
+      cwdSpy = undefined;
+    }
+  });
+
+  const mockCwd = (dir) => {
+    cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(dir);
+  };
+
+  it('adds the jsonresume-theme- prefix for bare short names', () => {
+    mockCwd(root);
+    expect(resolveThemePath('short')).toBe(
+      path.join(root, 'node_modules', 'jsonresume-theme-short', 'index.js'),
+    );
+  });
+
+  it('does not apply the prefix fallback to scoped specifiers', () => {
+    mockCwd(root);
+    // The old guard tested the wrong variable (`path`, always false here) and
+    // coerced it to the string "false", so the fallback ran unconditionally
+    // and "@scoped" would have resolved to jsonresume-theme-@scoped.
+    expect(() => resolveThemePath('@scoped')).toThrow(ThemeNotFoundError);
+  });
+
+  it('resolves themes hoisted to a parent node_modules', () => {
+    mockCwd(path.join(root, 'sub'));
+    expect(resolveThemePath('jsonresume-theme-short')).toBe(
+      path.join(root, 'node_modules', 'jsonresume-theme-short', 'index.js'),
+    );
+  });
+
+  it('resolves package.json main entries that are not index.js', () => {
+    mockCwd(root);
+    expect(resolveThemePath('jsonresume-theme-nested')).toBe(
+      path.join(
+        root,
+        'node_modules',
+        'jsonresume-theme-nested',
+        'lib',
+        'entry.js',
+      ),
+    );
+  });
+
+  it('throws ThemeNotFoundError for unknown themes', () => {
+    mockCwd(root);
+    expect(() => resolveThemePath('definitely-not-installed')).toThrow(
+      ThemeNotFoundError,
+    );
+  });
+
+  it('throws ThemeNotFoundError for unresolvable relative paths', () => {
+    mockCwd(root);
+    expect(() => resolveThemePath('./missing-local-theme')).toThrow(
+      ThemeNotFoundError,
+    );
   });
 });

--- a/packages/cli/lib/serve.js
+++ b/packages/cli/lib/serve.js
@@ -6,7 +6,6 @@ const bs = require('browser-sync').create();
 const builder = require('./builder');
 
 const reBuildResume = (theme, dir, resumeFilename, cb) => {
-  console.log({ theme, dir, resumeFilename, cb });
   builder(theme, dir, resumeFilename, (err, html) => {
     if (err) {
       readline.cursorTo(process.stdout, 0);

--- a/packages/cli/lib/serve.test.js
+++ b/packages/cli/lib/serve.test.js
@@ -1,0 +1,51 @@
+jest.mock('browser-sync', () => ({
+  create: jest.fn(() => ({
+    watch: jest.fn(() => ({ on: jest.fn() })),
+    init: jest.fn(),
+    reload: jest.fn(),
+  })),
+}));
+
+jest.mock('./builder', () =>
+  jest.fn((theme, dir, resumeFilename, cb) => cb(null, '<html>ok</html>')),
+);
+
+const fs = require('fs');
+const serve = require('./serve');
+
+describe('serve', () => {
+  let logSpy;
+
+  const options = {
+    port: 4000,
+    theme: 'jsonresume-theme-even',
+    silent: true,
+    dir: 'public',
+    resumeFilename: 'resume.json',
+  };
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest
+      .spyOn(fs, 'writeFile')
+      .mockImplementation((file, data, cb) => cb(null));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('prints the preview URL', () => {
+    serve(options);
+    expect(logSpy).toHaveBeenCalledWith('Preview: http://localhost:4000');
+  });
+
+  it('does not emit leftover debug objects on rebuild', () => {
+    serve(options);
+    const objectArgs = logSpy.mock.calls
+      .flat()
+      .filter((arg) => typeof arg === 'object' && arg !== null);
+    expect(objectArgs).toEqual([]);
+  });
+});


### PR DESCRIPTION
Triage of the Wave 16 bug-hunt findings (#416). Every finding was re-verified against current master; three are objective bugs with uncontroversial fixes, all in `resume-cli`, fixed here. The remaining three need a maintainer call (classification posted on the issue).

## Fixes

**1. `render-html.js` — prefix-fallback guard tested the wrong variable**
`if (!path && /^[a-z0-9]/i.test(path))` — when `!path`, `path` is `false`, and `test(false)` coerces to the string `"false"`, which matches. The guard was dead code and the `jsonresume-theme-` fallback ran unconditionally, including for scoped/non-alphanumeric specifiers. Now tests `themePath` as intended. Proven by a fixture test that fails against the old guard (a literal `node_modules/jsonresume-theme-@scoped` dir the buggy fallback would resolve).

**2. `serve.js` — leftover debug output**
`console.log({ theme, dir, resumeFilename, cb })` dumped an object (including a callback) on every rebuild. Removed; added a serve test harness (mocked browser-sync/builder/fs) asserting the preview URL still prints and no debug objects leak.

**3. `export-resume.js` — PDF export resolved the theme twice, differently**
`getThemePkg` hard-coded `cwd/node_modules/<theme>/index.js`, so a hoisted/global install or a theme with a non-`index.js` entry point could render HTML fine but spuriously fail PDF export. It now uses the shared `resolveThemePath` exported from `render-html.js`, so HTML and PDF resolution can never diverge. Covered by resolver fixture tests (hoisted parent `node_modules`, custom `package.json` main) plus `ThemeNotFoundError` surface tests for the pdf/html export paths.

## Tests

- `packages/cli`: 82 passed (11 suites), lint clean, build clean
- registry unit suite: 110 files passed, 1651 tests passed, 2 skipped

Changeset included (`resume-cli` patch).

Refs #416

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme resolution for HTML rendering and PDF export, including hoisted themes and custom package entry points.
  * Fixed edge cases involving scoped or relative theme names.
  * Missing themes now produce a clear, consistent error.
  * Removed unwanted debug output during resume rebuilds.
* **Tests**
  * Added coverage for theme resolution, PDF and HTML exports, and clean serve output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->