### PR TITLE
docs: fix wrong package names in CONTRIBUTING + repo-structure docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,7 +352,7 @@ Fixes #456
 
 Want to add your resume theme to the registry? Here's everything you need to know.
 
-### Quick Start: Using @resume/core Components (Recommended)
+### Quick Start: Using @jsonresume/core Components (Recommended)
 
 The fastest way to build a new theme is using our composable component library:
 
@@ -364,7 +364,7 @@ import {
   ListItem,
   DateRange,
   BadgeList,
-} from '@resume/core';
+} from '@jsonresume/core';
 
 export function render(resume) {
   const html = `
@@ -373,7 +373,7 @@ export function render(resume) {
     <head>
       <meta charset="UTF-8">
       <title>${resume.basics.name}</title>
-      <link rel="stylesheet" href="https://unpkg.com/@resume/core@0.1.0/src/styles/tokens.css">
+      <link rel="stylesheet" href="https://unpkg.com/@jsonresume/core@0.3.1/src/styles/tokens.css">
       <style>
         body {
           font-family: var(--resume-font-sans);
@@ -473,7 +473,7 @@ export function render(resume) {
 - ES6 imports for templates and styles
 - Build-time bundling (Vite, webpack, rollup)
 - All assets inlined at compile time
-- **OR** @resume/core components (recommended)
+- **OR** @jsonresume/core components (recommended)
 
 ### Quick Start: Converting Your Theme
 
@@ -631,8 +631,8 @@ export function render(resume) {
 
 Check these themes in the repo for reference:
 
-- **@resume/core components:** `packages/themes/jsonresume-theme-reference` (complete example)
-- **@resume/core with custom styles:** `packages/themes/jsonresume-theme-modern` (card-based design)
+- **@jsonresume/core components:** `packages/themes/jsonresume-theme-reference` (complete example)
+- **@jsonresume/core with custom styles:** `packages/themes/jsonresume-theme-modern` (card-based design)
 - **Simple approach:** `packages/themes/jsonresume-theme-standard`
 - **Vite bundling:** `packages/themes/jsonresume-theme-professional`
 - **Handlebars templates:** `packages/themes/jsonresume-theme-spartacus`

--- a/apps/docs/content/docs/002-repository-structure.md
+++ b/apps/docs/content/docs/002-repository-structure.md
@@ -317,7 +317,7 @@ This package centralizes shared theme configuration and metadata for JSON Resume
 
 ### Key Points
 
-- Named `@repo/theme-config`.
+- Named `@jsonresume/theme-metadata`.
 - Exports main module and submodules for metadata and themes.
 - Contains lint script.
 - Private package with MIT license.
@@ -402,7 +402,7 @@ flowchart TD
     RegistryApp --> Core
     RegistryApp --> Themes
     Themes --> Core
-    Themes --> ThemeConfig["@repo/theme-config"]
+    Themes --> ThemeConfig["@jsonresume/theme-metadata"]
     UI --> ESLintConfig
     Core --> ESLintConfig
     Themes --> ESLintConfig


### PR DESCRIPTION
the theme quick-start in CONTRIBUTING.md told people to import from `@resume/core` which doesn't exist — anyone following the guide hit a resolve error on step one. real name is `@jsonresume/core` (bumped the unpkg pin to 0.3.1 too, verified the tokens.css path serves). also 002-repository-structure.md called the theme-config package `@repo/theme-config`, actual published name is `@jsonresume/theme-metadata`.

both were flagged during the docs accuracy sweep (#504), longstanding bugs rather than fallout from this week's changes.

— AI