### PR TITLE
fix(registry): keep salary min:0 and fix open-ended date ranges

### DIFF
--- a/apps/registry/app/[username]/decisions/components/ResumeSections.jsx
+++ b/apps/registry/app/[username]/decisions/components/ResumeSections.jsx
@@ -6,7 +6,7 @@
 
 'use client';
 
-import { formatDate } from './resumeUtils';
+import { formatDateRange } from './resumeUtils';
 
 export function ResumeIdentity({ basics, yearsOfExperience }) {
   return (
@@ -105,7 +105,7 @@ export function ResumeWork({ work }) {
               {(job.startDate || job.endDate) && (
                 <span className="text-slate-400">
                   {' • '}
-                  {formatDate(job.startDate)} - {formatDate(job.endDate)}
+                  {formatDateRange(job.startDate, job.endDate)}
                 </span>
               )}
             </div>

--- a/apps/registry/app/[username]/decisions/components/resumeUtils.js
+++ b/apps/registry/app/[username]/decisions/components/resumeUtils.js
@@ -12,6 +12,17 @@ export function formatDate(dateStr) {
   });
 }
 
+// Format a work date range. "Present" is only ever used for a missing END date
+// (an ongoing role) — a job with only an endDate renders just that date rather
+// than the nonsensical "Present - Jan 2020".
+export function formatDateRange(startDate, endDate) {
+  if (startDate && endDate)
+    return `${formatDate(startDate)} - ${formatDate(endDate)}`;
+  if (startDate) return `${formatDate(startDate)} - Present`;
+  if (endDate) return formatDate(endDate);
+  return '';
+}
+
 // Estimate total years of experience by summing work date ranges.
 // Ongoing roles (no endDate) count through today. Matches the original
 // month-based rounding.

--- a/apps/registry/app/[username]/decisions/components/resumeUtils.test.js
+++ b/apps/registry/app/[username]/decisions/components/resumeUtils.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { formatDate, calcYearsOfExperience } from './resumeUtils';
+import {
+  formatDate,
+  formatDateRange,
+  calcYearsOfExperience,
+} from './resumeUtils';
 
 describe('formatDate', () => {
   it('returns "Present" for a missing date', () => {
@@ -10,6 +14,26 @@ describe('formatDate', () => {
 
   it('formats a date as "Mon YYYY"', () => {
     expect(formatDate('2021-03-15')).toBe('Mar 2021');
+  });
+});
+
+describe('formatDateRange', () => {
+  it('joins a closed range', () => {
+    expect(formatDateRange('2018-01-15', '2020-03-15')).toBe(
+      'Jan 2018 - Mar 2020'
+    );
+  });
+
+  it('renders an ongoing role (no endDate) as "… - Present"', () => {
+    expect(formatDateRange('2018-01-15', undefined)).toBe('Jan 2018 - Present');
+  });
+
+  it('renders a lone endDate as just that date, not "Present - …"', () => {
+    expect(formatDateRange(undefined, '2020-03-15')).toBe('Mar 2020');
+  });
+
+  it('returns an empty string when neither date is present', () => {
+    expect(formatDateRange(undefined, undefined)).toBe('');
   });
 });
 

--- a/apps/registry/app/api/decisions/evaluate/prompt.js
+++ b/apps/registry/app/api/decisions/evaluate/prompt.js
@@ -51,9 +51,10 @@ export const buildPreferencesInfo = (preferences) =>
  */
 const disabledHint = (pref, text) => (pref?.enabled === false ? text : '');
 
-const salaryHint = (salaryPref) => {
+export const salaryHint = (salaryPref) => {
   if (salaryPref?.enabled === false) return '(User disabled - be lenient)';
-  if (salaryPref?.value?.min) {
+  // Use != null so a legitimate min of 0 still produces a hint (0 is falsy).
+  if (salaryPref?.value?.min != null) {
     return `(User expects ${salaryPref.value.min}-${salaryPref.value.max})`;
   }
   return '';

--- a/apps/registry/app/api/decisions/evaluate/prompt.test.js
+++ b/apps/registry/app/api/decisions/evaluate/prompt.test.js
@@ -3,6 +3,7 @@ import {
   buildJobContext,
   buildPreferencesInfo,
   buildEvaluationPrompt,
+  salaryHint,
 } from './prompt';
 
 describe('buildJobContext', () => {
@@ -58,6 +59,29 @@ describe('buildPreferencesInfo', () => {
         '- location: ENABLED (use standard evaluation)',
       ].join('\n')
     );
+  });
+});
+
+describe('salaryHint', () => {
+  it('renders the expected range for a normal min', () => {
+    expect(salaryHint({ enabled: true, value: { min: 100, max: 200 } })).toBe(
+      '(User expects 100-200)'
+    );
+  });
+
+  it('keeps a min of 0 instead of dropping it', () => {
+    expect(salaryHint({ enabled: true, value: { min: 0, max: 50000 } })).toBe(
+      '(User expects 0-50000)'
+    );
+  });
+
+  it('flags a disabled preference as lenient', () => {
+    expect(salaryHint({ enabled: false })).toBe('(User disabled - be lenient)');
+  });
+
+  it('returns empty string when no value is supplied', () => {
+    expect(salaryHint(undefined)).toBe('');
+    expect(salaryHint({ enabled: true, value: {} })).toBe('');
   });
 });
 


### PR DESCRIPTION
the two legit bugs coderabbit caught in the #503 refactor — the refactor just moved this code so they were pre-existing, grabbing them now that everything's settled on master.

- **salaryHint dropped min:0** — `if (salaryPref?.value?.min)` is falsy when min is 0, so a custom `{min:0, max:50000}` range rendered no hint at all. now guards with `!= null`.
- **'Present - Jan 2020' for lone endDate** — a job with only an endDate rendered a nonsense 'Present - ...'. added a `formatDateRange` helper that reserves 'Present' for a missing END date (ongoing role) only; a lone endDate just shows that date.

both covered by unit tests (incl. the min:0 and lone-endDate cases). full registry suite green at 1717. this closes out the coderabbit thread on #503 — the third finding (open-ended ranges in general) is the same thing tracked in #416 for the v1 text formatter, separate surface.

— AI