### PR TITLE
fix(jobs-api): ranking quality overhaul — users get the jobs they're actually looking for

### DIFF
--- a/.changeset/jobs-ranking-quality-fixes.md
+++ b/.changeset/jobs-ranking-quality-fixes.md
@@ -1,0 +1,5 @@
+---
+'@jsonresume/jobs': patch
+---
+
+Match quality overhaul (client side): the CLI table and TUI list now display the score the server actually sorts by (decay/rerank blend) instead of raw similarity, the TUI runs its background AI rerank pass on every view (previously only custom searches), and `search` gains a `--fast` flag to skip reranking. Pairs with the registry-side ranking fixes: 300-candidate retrieval pool, 0.95/0.05 recency decay, deep (150-job) location-aware listwise reranking on by default, real min-salary filtering backed by normalized salary data, word-boundary keyword search, prompt-first HyDE for custom searches, and rate-limited resume-body matching.

--- a/.github/workflows/process_hn_jobs.yml
+++ b/.github/workflows/process_hn_jobs.yml
@@ -137,6 +137,21 @@ jobs:
           echo "jobs_vectorized=${JOBS_VECTORIZED}" >> $GITHUB_OUTPUT
           echo "::endgroup::"
 
+      # Normalize human-typed salary strings into salary_usd/min/max columns.
+      # This was never wired in — salary_usd was NULL on every row, which made
+      # the min_salary filter a silent no-op (2026-07 ranking eval).
+      - name: Normalize salaries
+        id: salaries
+        working-directory: apps/registry
+        env:
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        run: |
+          echo "::group::Salary normalization"
+          timeout 600 node scripts/jobs/salary-normalizer/run-migration.js 2>&1 | tee salaries.log
+          SALARIES_UPDATED=$(grep -oP 'Total updated: \K\d+' salaries.log || echo "0")
+          echo "salaries_updated=${SALARIES_UPDATED}" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
       - name: Generate workflow summary
         if: always()
         run: |

--- a/apps/registry/.gitignore
+++ b/apps/registry/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 /playwright/.cache/
 supabase/.temp
 .env*.local
+.env*

--- a/apps/registry/app/api/v1/jobs/matchPipeline.js
+++ b/apps/registry/app/api/v1/jobs/matchPipeline.js
@@ -86,9 +86,15 @@ export const applyNegativeSignal = async (embedding, rejectedJobIds) => {
 };
 
 /**
- * Run the matcher, classify global-remote, and apply the global-remote filter.
- * Returns results already sliced to `top`. `globalRemote` triples the fetch
- * width before filtering to keep enough candidates.
+ * Run the matcher, classify global-remote, and apply the global-remote
+ * PREFERENCE. Returns results already sliced to `top`. `globalRemote`
+ * triples the fetch width before partitioning to keep enough candidates.
+ *
+ * global_remote is a sparse, LLM-inferred label — using it as a hard filter
+ * collapsed the pool to 8 jobs in the 2026-07 eval (3 of them gold-worst
+ * gigs) and dropped a job that explicitly pays non-US hires. It now sorts
+ * classified-global jobs first and backfills with the remaining remote jobs
+ * instead of discarding them.
  */
 export const runMatchPipeline = async ({
   embedding,
@@ -99,9 +105,11 @@ export const runMatchPipeline = async ({
   remote,
   globalRemote,
   minSalary,
+  includeUnknownSalary,
   search,
   shouldRerank,
   stateMap,
+  candidate,
 }) => {
   const results = await matchJobs({
     embedding,
@@ -111,16 +119,21 @@ export const runMatchPipeline = async ({
     days,
     remote: remote || globalRemote,
     minSalary,
+    includeUnknownSalary,
     search,
     shouldRerank,
     stateMap,
+    candidate,
   });
 
   await classifyGlobalRemote(results);
 
-  const filtered = globalRemote
-    ? results.filter((j) => j.global_remote === true)
-    : results;
+  if (!globalRemote) {
+    return results.slice(0, top);
+  }
 
-  return filtered.slice(0, top);
+  // Stable partition: confirmed-global first, other remote jobs as backfill.
+  const global = results.filter((j) => j.global_remote === true);
+  const backfill = results.filter((j) => j.global_remote !== true);
+  return [...global, ...backfill].slice(0, top);
 };

--- a/apps/registry/app/api/v1/jobs/matching/embeddings.js
+++ b/apps/registry/app/api/v1/jobs/matching/embeddings.js
@@ -1,15 +1,44 @@
 /**
  * Embedding generation for the jobs matcher — resume embeddings and HyDE
  * (hypothetical document embeddings) blended toward the ideal job posting.
+ *
+ * Determinism: embeddings used to be regenerated per request with a
+ * temperature-1 HyDE doc, producing ±0.015 similarity jitter that reordered
+ * near-ties in the compressed score band and shifted the candidate-pool
+ * boundary between runs (2026-07 eval). HyDE now runs at temperature 0 and
+ * both resume and HyDE embeddings are memoized per warm lambda.
  */
+import crypto from 'node:crypto';
 import { embed, generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { interpolate } from './vectorMath';
 
+// Simple FIFO memo caches (per warm serverless instance).
+const CACHE_MAX = 200;
+const resumeCache = new Map();
+const hydeCache = new Map();
+
+const hashKey = (text) => crypto.createHash('sha256').update(text).digest('hex');
+
+const cacheGet = (cache, key) => cache.get(key);
+const cacheSet = (cache, key, value) => {
+  if (cache.size >= CACHE_MAX) {
+    cache.delete(cache.keys().next().value);
+  }
+  cache.set(key, value);
+};
+
 /** Generate a HyDE embedding from resume text */
 export async function generateHydeEmbedding(resumeText) {
+  const key = hashKey(resumeText);
+  const cached = cacheGet(hydeCache, key);
+  if (cached) {
+    return cached;
+  }
+
   const { text: hydePosting } = await generateText({
     model: openai('gpt-4.1-mini'),
+    temperature: 0,
     system: `You are a job posting generator. Given a candidate's background, write a realistic job posting that would be their IDEAL next role. Write it like a real HN "Who is Hiring" post. Include: company type, role title, tech stack, requirements, location, salary range, remote policy. Output ONLY the job posting text. Make it specific and keyword-rich.`,
     prompt: `Candidate background:\n${resumeText}`,
     maxTokens: 400,
@@ -26,7 +55,9 @@ export async function generateHydeEmbedding(resumeText) {
     }),
   ]);
 
-  return interpolate(hydeResult.embedding, resumeResult.embedding, 0.35);
+  const blended = interpolate(hydeResult.embedding, resumeResult.embedding, 0.35);
+  cacheSet(hydeCache, key, blended);
+  return blended;
 }
 
 export async function getResumeEmbedding(resume) {
@@ -54,9 +85,16 @@ export async function getResumeEmbedding(resume) {
     .filter(Boolean)
     .join('\n');
 
+  const key = hashKey(text);
+  const cached = cacheGet(resumeCache, key);
+  if (cached) {
+    return { embedding: cached, text };
+  }
+
   const { embedding } = await embed({
     model: openai.embedding('text-embedding-3-large'),
     value: text,
   });
+  cacheSet(resumeCache, key, embedding);
   return { embedding, text };
 }

--- a/apps/registry/app/api/v1/jobs/matching/filters.js
+++ b/apps/registry/app/api/v1/jobs/matching/filters.js
@@ -1,0 +1,96 @@
+/**
+ * Pure candidate-side filters for the jobs matcher.
+ *
+ * Extracted from matchJobs.js so the predicates are unit-testable and the
+ * fixes from the 2026-07 ranking eval are explicit:
+ *  - keyword search used to be `JSON.stringify(job).includes(q)`, which made
+ *    "ai" match 98/100 jobs via "maintain"/"available" and JSON keys. It now
+ *    word-boundary-matches against real text fields only.
+ *  - min_salary used to fail OPEN on null salary_usd (the field was never
+ *    populated), making the filter a no-op headed by sub-$50k gigs. It now
+ *    fails CLOSED unless the caller opts into unknown salaries.
+ */
+
+const HIDDEN_STATES = new Set(['not_interested', 'dismissed']);
+
+/** Flatten the human-readable text of a job row for keyword matching. */
+export function jobSearchText(job) {
+  const skills = (job.skills || [])
+    .map((s) => {
+      const name = s?.name || s || '';
+      const kws = (s?.keywords || []).join(' ');
+      return `${name} ${kws}`;
+    })
+    .join(' ');
+  return [
+    job.title,
+    job.company,
+    job.location,
+    job.description,
+    skills,
+    (job.qualifications || []).join(' '),
+    (job.responsibilities || []).join(' '),
+  ]
+    .filter(Boolean)
+    .join('\n')
+    .toLowerCase();
+}
+
+/**
+ * Build a keyword predicate. Plain alphanumeric queries match on word
+ * boundaries ("ai" no longer matches "maintain"); queries with symbols
+ * (e.g. "c++", ".net") fall back to substring over the same text fields.
+ */
+export function buildKeywordPredicate(query) {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) {
+    return () => true;
+  }
+
+  if (/^[a-z0-9 ]+$/.test(q)) {
+    const escaped = q.replace(/ +/g, '\\s+');
+    const re = new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i');
+    return (job) => re.test(jobSearchText(job));
+  }
+
+  return (job) => jobSearchText(job).includes(q);
+}
+
+/**
+ * Combined row filter for parsed job rows.
+ * @param {Object} opts
+ * @param {Object|null} opts.stateMap - job_id -> sentiment
+ * @param {boolean} opts.remote - require remote === 'Full'
+ * @param {number} opts.minSalary - minimum salary in $k; fails closed on
+ *   unknown salary unless includeUnknownSalary is set
+ * @param {boolean} opts.includeUnknownSalary
+ * @param {string} opts.search - keyword query
+ */
+export function buildJobFilter({
+  stateMap,
+  remote,
+  minSalary,
+  includeUnknownSalary = false,
+  search,
+}) {
+  const matchesKeyword = buildKeywordPredicate(search);
+
+  return (job) => {
+    if (stateMap && HIDDEN_STATES.has(job.state)) {
+      return false;
+    }
+    if (remote && job.remote !== 'Full') {
+      return false;
+    }
+    if (minSalary) {
+      if (job.salary_usd == null) {
+        if (!includeUnknownSalary) {
+          return false;
+        }
+      } else if (job.salary_usd < minSalary * 1000) {
+        return false;
+      }
+    }
+    return matchesKeyword(job);
+  };
+}

--- a/apps/registry/app/api/v1/jobs/matching/filters.test.js
+++ b/apps/registry/app/api/v1/jobs/matching/filters.test.js
@@ -1,0 +1,128 @@
+/**
+ * Tests for the pure job-row filters — the 2026-07 ranking-eval fixes:
+ * word-boundary keyword matching and fail-closed min_salary.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  jobSearchText,
+  buildKeywordPredicate,
+  buildJobFilter,
+} from './filters';
+import { weightedBlend } from './vectorMath';
+
+const job = (over = {}) => ({
+  title: 'Senior AI Engineer',
+  company: 'Acme',
+  location: 'Remote',
+  description: 'We maintain a large platform and build LLM agents.',
+  skills: [{ name: 'TypeScript', keywords: ['React', 'Node'] }],
+  qualifications: ['5+ years'],
+  responsibilities: ['Ship features'],
+  remote: 'Full',
+  salary_usd: null,
+  state: null,
+  ...over,
+});
+
+describe('buildKeywordPredicate', () => {
+  it('matches whole words only for plain queries', () => {
+    const p = buildKeywordPredicate('ai');
+    expect(p(job())).toBe(true); // "AI" in title
+    expect(
+      p(job({ title: 'Backend Dev', description: 'maintain available domains' }))
+    ).toBe(false); // "ai" only inside words
+  });
+
+  it('is case-insensitive', () => {
+    expect(buildKeywordPredicate('typescript')(job())).toBe(true);
+  });
+
+  it('matches multi-word phrases across whitespace', () => {
+    expect(buildKeywordPredicate('ai engineer')(job())).toBe(true);
+    expect(buildKeywordPredicate('rust engineer')(job())).toBe(false);
+  });
+
+  it('falls back to substring for symbol queries like c++ and .net', () => {
+    const cpp = job({ description: 'Modern C++ codebase' });
+    expect(buildKeywordPredicate('c++')(cpp)).toBe(true);
+    const dotnet = job({ description: 'Legacy .NET WebForms app' });
+    expect(buildKeywordPredicate('.net')(dotnet)).toBe(true);
+    expect(buildKeywordPredicate('.net')(job())).toBe(false);
+  });
+
+  it('empty query matches everything', () => {
+    expect(buildKeywordPredicate('')(job())).toBe(true);
+    expect(buildKeywordPredicate(undefined)(job())).toBe(true);
+  });
+
+  it('does not match JSON structure (keys/urls are not searched)', () => {
+    // "salary" is a JSON key on every row but not part of this job's text
+    expect(buildKeywordPredicate('salary')(job())).toBe(false);
+  });
+});
+
+describe('buildJobFilter min_salary', () => {
+  it('fails closed on unknown salary by default', () => {
+    const f = buildJobFilter({ minSalary: 150 });
+    expect(f(job({ salary_usd: null }))).toBe(false);
+    expect(f(job({ salary_usd: 200000 }))).toBe(true);
+    expect(f(job({ salary_usd: 100000 }))).toBe(false);
+  });
+
+  it('includes unknown salaries when opted in', () => {
+    const f = buildJobFilter({ minSalary: 150, includeUnknownSalary: true });
+    expect(f(job({ salary_usd: null }))).toBe(true);
+    expect(f(job({ salary_usd: 100000 }))).toBe(false);
+  });
+
+  it('no minSalary → unknown salaries pass', () => {
+    const f = buildJobFilter({});
+    expect(f(job({ salary_usd: null }))).toBe(true);
+  });
+});
+
+describe('buildJobFilter remote + hidden states', () => {
+  it('remote requires remote === Full', () => {
+    const f = buildJobFilter({ remote: true });
+    expect(f(job({ remote: 'Full' }))).toBe(true);
+    expect(f(job({ remote: 'Hybrid' }))).toBe(false);
+    expect(f(job({ remote: undefined }))).toBe(false);
+  });
+
+  it('hides not_interested/dismissed only when a stateMap is present', () => {
+    const withMap = buildJobFilter({ stateMap: {} });
+    expect(withMap(job({ state: 'not_interested' }))).toBe(false);
+    expect(withMap(job({ state: 'interested' }))).toBe(true);
+    const noMap = buildJobFilter({});
+    expect(noMap(job({ state: 'not_interested' }))).toBe(true);
+  });
+});
+
+describe('jobSearchText', () => {
+  it('includes skills names and keywords', () => {
+    const text = jobSearchText(job());
+    expect(text).toContain('typescript');
+    expect(text).toContain('react');
+  });
+});
+
+describe('weightedBlend', () => {
+  it('blends and normalizes', () => {
+    const out = weightedBlend([
+      [[1, 0], 0.5],
+      [[0, 1], 0.5],
+    ]);
+    const magnitude = Math.sqrt(out[0] ** 2 + out[1] ** 2);
+    expect(magnitude).toBeCloseTo(1, 10);
+    expect(out[0]).toBeCloseTo(out[1], 10);
+  });
+
+  it('skips empty vectors and returns null when none usable', () => {
+    expect(weightedBlend([[null, 0.5]])).toBeNull();
+    const out = weightedBlend([
+      [null, 0.5],
+      [[3, 4], 0.5],
+    ]);
+    expect(out[0]).toBeCloseTo(0.6, 10);
+  });
+});

--- a/apps/registry/app/api/v1/jobs/matching/matchJobs.js
+++ b/apps/registry/app/api/v1/jobs/matching/matchJobs.js
@@ -1,11 +1,24 @@
 /**
  * Job matching orchestrator — fetch candidates from the vector RPC, parse,
  * filter, decay-score, and optionally LLM-rerank into the final result set.
+ *
+ * Every result carries a unified `score` field holding the value the list is
+ * actually ordered by (decayed similarity, or the rerank blend when
+ * reranking) — clients must display `score`, not raw `similarity` (the
+ * 2026-07 eval found the CLI/TUI showing raw similarity against a
+ * decay-ordered list, which looks shuffled).
  */
 import { logger } from '@/lib/logger';
 import { getSupabase } from './supabaseClient';
 import { timeDecayScore } from './vectorMath';
 import { rerankJobs } from './rerank';
+import { buildJobFilter } from './filters';
+
+// Candidate pool floor. The RPC cut happens on RAW similarity before decay,
+// filters, and rerank get a say; a pool of top*5 starved every downstream
+// stage (8 of 12 gold-set jobs never surfaced in the eval). With a corpus of
+// only hundreds of jobs per 90 days, fetching wide is nearly free.
+const MIN_POOL = 300;
 
 /** Fetch, parse, filter, and optionally rerank job matches. */
 export async function matchJobs({
@@ -16,9 +29,11 @@ export async function matchJobs({
   days,
   remote,
   minSalary,
+  includeUnknownSalary,
   search,
   shouldRerank,
   stateMap,
+  candidate,
 }) {
   const supabase = getSupabase();
   const createdAfter = new Date(
@@ -28,7 +43,7 @@ export async function matchJobs({
   const { data: matched, error } = await supabase.rpc('match_jobs_v5', {
     query_embedding: embedding,
     match_threshold: -1,
-    match_count: top * 5,
+    match_count: Math.max(MIN_POOL, top * 5),
     created_after: createdAfter,
   });
 
@@ -46,7 +61,13 @@ export async function matchJobs({
     .select('id, uuid, gpt_content, posted_at, url, salary_usd')
     .in('id', jobIds);
 
-  const HIDDEN_STATES = new Set(['not_interested', 'dismissed']);
+  const rowFilter = buildJobFilter({
+    stateMap,
+    remote,
+    minSalary,
+    includeUnknownSalary,
+    search,
+  });
 
   let results = (jobs || [])
     .map((job) => {
@@ -57,6 +78,8 @@ export async function matchJobs({
         }
         const similarity =
           matched.find((m) => m.id === job.id)?.similarity || 0;
+        const decayed =
+          Math.round(timeDecayScore(similarity, job.posted_at) * 1000) / 1000;
         return {
           id: job.id,
           uuid: job.uuid,
@@ -75,8 +98,8 @@ export async function matchJobs({
           url: job.url,
           posted_at: job.posted_at,
           similarity: Math.round(similarity * 1000) / 1000,
-          decayed_similarity:
-            Math.round(timeDecayScore(similarity, job.posted_at) * 1000) / 1000,
+          decayed_similarity: decayed,
+          score: decayed,
           state: stateMap?.[job.id] || null,
         };
       } catch {
@@ -84,33 +107,26 @@ export async function matchJobs({
       }
     })
     .filter(Boolean)
-    .filter((j) => {
-      if (stateMap && HIDDEN_STATES.has(j.state)) {
-        return false;
-      }
-      if (remote && j.remote !== 'Full') {
-        return false;
-      }
-      if (minSalary && j.salary_usd && j.salary_usd < minSalary * 1000) {
-        return false;
-      }
-      if (
-        search &&
-        !JSON.stringify(j).toLowerCase().includes(search.toLowerCase())
-      ) {
-        return false;
-      }
-      return true;
-    })
+    .filter(rowFilter)
     .sort((a, b) => b.decayed_similarity - a.decayed_similarity);
 
-  // Rerank when explicitly requested or for search profiles
+  // Rerank when explicitly requested or for search profiles.
+  // The window is deliberately MUCH deeper than `top`: the raw vector
+  // ordering is weakly discriminative (compressed ~0.37-0.44 band) and the
+  // 2026-07 eval found gold-set jobs at vector ranks 17-147. rerankJobs fans
+  // the window out over parallel ~50-job listwise calls (~3 cheap calls).
   if (shouldRerank && results.length > 0) {
-    const toRerank = results.slice(0, Math.min(30, top * 2));
-    const rest = results.slice(Math.min(30, top * 2));
+    const windowSize = Math.min(150, results.length);
+    const toRerank = results.slice(0, windowSize);
+    const rest = results.slice(windowSize);
 
     try {
-      const scores = await rerankJobs(toRerank, resumeText, searchPrompt);
+      const scores = await rerankJobs(
+        toRerank,
+        resumeText,
+        searchPrompt,
+        candidate
+      );
       const scoreMap = {};
       scores.forEach((s) => {
         scoreMap[s.id] = s.rerank_score;
@@ -120,14 +136,21 @@ export async function matchJobs({
         ...toRerank.map((j) => j.decayed_similarity),
         0.001
       );
+      // Jobs the model omitted get a neutral 50 — visible in the payload as
+      // rerank_score: null rather than a fabricated score.
       const reranked = toRerank
-        .map((j) => ({
-          ...j,
-          rerank_score: scoreMap[j.id] || 5,
-          combined_score:
+        .map((j) => {
+          const llm = scoreMap[j.id];
+          const combined =
             0.35 * (j.decayed_similarity / maxSim) +
-            0.65 * ((scoreMap[j.id] || 5) / 10),
-        }))
+            0.65 * ((llm ?? 50) / 100);
+          return {
+            ...j,
+            rerank_score: llm ?? null,
+            combined_score: Math.round(combined * 1000) / 1000,
+            score: Math.round(combined * 1000) / 1000,
+          };
+        })
         .sort((a, b) => b.combined_score - a.combined_score);
 
       results = [...reranked, ...rest];

--- a/apps/registry/app/api/v1/jobs/matching/rerank.js
+++ b/apps/registry/app/api/v1/jobs/matching/rerank.js
@@ -1,71 +1,136 @@
 /**
- * LLM reranking for job matches — scores each job 1-10 against the candidate's
- * search context in small batches.
+ * LLM reranking for job matches.
+ *
+ * One LISTWISE call scores the whole candidate window 0-100 (2026-07 eval:
+ * per-job integer 1-10 scoring produced huge tie-bands that recency then
+ * broke arbitrarily, cost ~30 LLM calls per request, and silently scored
+ * parse failures as 5). The scorer now also sees the candidate's location so
+ * geo-impossible roles can't crack the top of a remote-only candidate's list.
  */
 import { generateText } from 'ai';
 import { openai } from '@ai-sdk/openai';
+import { logger } from '@/lib/logger';
 
-const RERANK_BATCH_SIZE = 5;
+/** Compact one-job block for the listwise prompt. */
+const jobBlock = (job) => {
+  const skills = (job.skills || [])
+    .map((s) => s?.name || s)
+    .filter(Boolean)
+    .slice(0, 12)
+    .join(', ');
+  return [
+    `[${job.id}] ${job.title} @ ${job.company}`,
+    `  location: ${job.location || 'unspecified'} | remote: ${
+      job.remote || 'unspecified'
+    } | salary: ${job.salary || 'unspecified'} | experience: ${
+      job.experience || 'unspecified'
+    }`,
+    skills ? `  skills: ${skills}` : null,
+    job.description ? `  ${String(job.description).slice(0, 350)}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+};
 
-/** LLM reranking: score each job 1-10 against the search context. */
-export async function rerankJobs(jobs, resumeText, searchPrompt) {
+/** Extract the first JSON array from a model reply (tolerates code fences). */
+const parseScores = (text) => {
+  const cleaned = text.replace(/```(?:json)?/g, '').trim();
+  const start = cleaned.indexOf('[');
+  const end = cleaned.lastIndexOf(']');
+  if (start === -1 || end <= start) {
+    throw new Error('no JSON array in rerank reply');
+  }
+  return JSON.parse(cleaned.slice(start, end + 1));
+};
+
+// Jobs per listwise call. The calibrated 0-100 rubric keeps scores
+// comparable across chunks, so chunks can run in parallel and merge.
+const CHUNK_SIZE = 50;
+
+const scoreChunk = async (jobs, context, locationLine) => {
+  const { text } = await generateText({
+    model: openai('gpt-4.1-mini'),
+    temperature: 0,
+    system: `You are a job-match scorer. Score EVERY job posting 0-100 for this candidate.
+Calibration: 85+ exceptional fit (skills, seniority, location all align); 60-84 strong; 40-59 plausible; 20-39 weak; <20 mismatch.
+Hard rules:
+- If the candidate's location makes the role impossible (onsite/hybrid elsewhere, geo-fenced remote excluding them, timezone-incompatible), score it 25 or lower no matter how good the skill fit.
+- Seniority mismatches (junior/entry roles for a senior candidate), per-task gig pay, or salary far below the candidate's level cap at 35.
+- Use the full 0-100 range; avoid ties — differentiate adjacent jobs.
+Output ONLY a JSON array: [{"id": <job id>, "score": <0-100>}, ...] with one entry per job, no prose.`,
+    prompt: `${context}\n${locationLine}\n\nJob postings:\n\n${jobs
+      .map(jobBlock)
+      .join('\n\n')}`,
+    maxTokens: 1800,
+  });
+
+  const parsed = parseScores(text);
+  const byId = new Map(jobs.map((j) => [Number(j.id), j]));
+  const scores = [];
+  for (const row of parsed) {
+    const id = Number(row?.id);
+    if (!byId.has(id) || typeof row?.score !== 'number') {
+      continue;
+    }
+    scores.push({
+      id,
+      rerank_score: Math.min(100, Math.max(0, Math.round(row.score))),
+    });
+  }
+  return scores;
+};
+
+/**
+ * Score jobs 0-100 against the candidate via parallel listwise calls over
+ * CHUNK_SIZE-job chunks (the vector ordering is too compressed to trust a
+ * shallow window — gold-set jobs sat at vector ranks 17-147 in the 2026-07
+ * eval, so callers pass a deep window and this fans out cheap chunk calls).
+ * @returns {Array<{id: number, rerank_score: number}>} scores on a 0-100
+ *   scale; jobs the model omitted are simply absent (caller decides fallback).
+ */
+export async function rerankJobs(jobs, resumeText, searchPrompt, candidate) {
   const context = searchPrompt
     ? `The candidate is specifically looking for: ${searchPrompt}\n\nTheir background:\n${resumeText}`
     : `Candidate background:\n${resumeText}`;
 
-  const batches = [];
-  for (let i = 0; i < jobs.length; i += RERANK_BATCH_SIZE) {
-    batches.push(jobs.slice(i, i + RERANK_BATCH_SIZE));
+  const locationLine = candidate?.location
+    ? `The candidate is based in: ${candidate.location}.${
+        candidate.remoteOnly
+          ? ' They can ONLY take fully-remote roles workable from that location/timezone.'
+          : ''
+      }`
+    : '';
+
+  const chunks = [];
+  for (let i = 0; i < jobs.length; i += CHUNK_SIZE) {
+    chunks.push(jobs.slice(i, i + CHUNK_SIZE));
   }
 
-  const allScores = [];
-  for (const batch of batches) {
-    const promises = batch.map(async (job) => {
-      const skillStr = (job.skills || [])
-        .map((s) => {
-          const name = s.name || s;
-          const kws = (s.keywords || []).join(', ');
-          return kws ? `${name} (${kws})` : name;
-        })
-        .join(', ');
-      const jobText = [
-        `Title: ${job.title}`,
-        `Company: ${job.company}`,
-        job.location ? `Location: ${job.location}` : null,
-        job.remote ? `Remote: ${job.remote}` : null,
-        job.salary ? `Salary: ${job.salary}` : null,
-        job.experience ? `Experience: ${job.experience}` : null,
-        job.description ? `Description: ${job.description}` : null,
-        skillStr ? `Skills: ${skillStr}` : null,
-        job.qualifications?.length
-          ? `Qualifications: ${job.qualifications.join('; ')}`
-          : null,
-        job.responsibilities?.length
-          ? `Responsibilities: ${job.responsibilities.join('; ')}`
-          : null,
-      ]
-        .filter(Boolean)
-        .join('\n');
+  const settled = await Promise.allSettled(
+    chunks.map((chunk) => scoreChunk(chunk, context, locationLine))
+  );
 
-      try {
-        const { text } = await generateText({
-          model: openai('gpt-4.1-mini'),
-          system: `You are a job matching scorer. Given a candidate profile and a job posting, rate the match quality from 1-10. Consider: skill alignment, experience level, location/remote fit, salary expectations, industry match, and the candidate's stated preferences. Output ONLY a JSON object: {"score": N, "reason": "one sentence"}. Be strict — only 8+ for strong matches.`,
-          prompt: `${context}\n\nJob posting:\n${jobText}`,
-          maxTokens: 80,
-        });
-        const parsed = JSON.parse(text);
-        return {
-          id: job.id,
-          rerank_score: Math.min(10, Math.max(1, parsed.score || 5)),
-        };
-      } catch {
-        return { id: job.id, rerank_score: 5 };
-      }
-    });
-    const results = await Promise.all(promises);
-    allScores.push(...results);
+  const scores = [];
+  settled.forEach((res, i) => {
+    if (res.status === 'fulfilled') {
+      scores.push(...res.value);
+    } else {
+      logger.warn(
+        { chunk: i, error: res.reason?.message },
+        'Rerank chunk failed'
+      );
+    }
+  });
+
+  if (scores.length === 0) {
+    throw new Error('all rerank chunks failed');
+  }
+  if (scores.length < jobs.length) {
+    logger.warn(
+      { expected: jobs.length, scored: scores.length },
+      'Listwise rerank returned partial scores'
+    );
   }
 
-  return allScores;
+  return scores;
 }

--- a/apps/registry/app/api/v1/jobs/matching/vectorMath.js
+++ b/apps/registry/app/api/v1/jobs/matching/vectorMath.js
@@ -44,6 +44,12 @@ export function averageEmbeddings(embeddings) {
 /**
  * Apply time-decay boost: more recent jobs get a recency bonus.
  * Uses exponential decay with half-life of 14 days.
+ *
+ * Weights: raw cosine similarities for resume-vs-job cluster in a compressed
+ * ~0.37-0.44 band (spread ~0.07), so a large recency term drowns the entire
+ * relevance signal — the 2026-07 ranking eval measured a 0.15 recency weight
+ * outweighing relevance 2.2x and putting stale-stack mismatches at #1.
+ * 0.05 keeps freshness as a tiebreaker within the band, never the headline.
  */
 export function timeDecayScore(similarity, postedAt) {
   if (!postedAt) {
@@ -53,5 +59,25 @@ export function timeDecayScore(similarity, postedAt) {
   const ageDays = ageMs / 86400000;
   const halfLife = 14;
   const recencyBoost = Math.pow(0.5, ageDays / halfLife);
-  return 0.85 * similarity + 0.15 * recencyBoost;
+  return 0.95 * similarity + 0.05 * recencyBoost;
+}
+
+/**
+ * Weighted sum of N vectors, normalized. Used for prompt-steered search
+ * embeddings (HyDE doc + raw prompt + resume).
+ * @param {Array<[number[], number]>} pairs - [vector, weight] pairs
+ */
+export function weightedBlend(pairs) {
+  const usable = pairs.filter(([v]) => Array.isArray(v) && v.length > 0);
+  if (usable.length === 0) {
+    return null;
+  }
+  const dim = usable[0][0].length;
+  const out = new Array(dim).fill(0);
+  for (const [vec, weight] of usable) {
+    for (let i = 0; i < dim; i++) {
+      out[i] += weight * vec[i];
+    }
+  }
+  return normalize(out);
 }

--- a/apps/registry/app/api/v1/jobs/matchingHelpers.test.js
+++ b/apps/registry/app/api/v1/jobs/matchingHelpers.test.js
@@ -141,9 +141,9 @@ describe('timeDecayScore', () => {
     vi.useFakeTimers();
     const now = new Date('2026-01-01T00:00:00Z');
     vi.setSystemTime(now);
-    // recencyBoost = 0.5^0 = 1 => 0.85*sim + 0.15*1
+    // recencyBoost = 0.5^0 = 1 => 0.95*sim + 0.05*1
     const out = timeDecayScore(0.5, now.toISOString());
-    expect(out).toBeCloseTo(0.85 * 0.5 + 0.15 * 1, 10);
+    expect(out).toBeCloseTo(0.95 * 0.5 + 0.05 * 1, 10);
   });
 
   it('halves the recency boost after one half-life (14 days)', () => {
@@ -153,17 +153,17 @@ describe('timeDecayScore', () => {
     const posted = new Date('2026-01-01T00:00:00Z'); // 14 days earlier
     const out = timeDecayScore(0.5, posted.toISOString());
     // recencyBoost = 0.5^1 = 0.5
-    expect(out).toBeCloseTo(0.85 * 0.5 + 0.15 * 0.5, 6);
+    expect(out).toBeCloseTo(0.95 * 0.5 + 0.05 * 0.5, 6);
   });
 
-  it('older jobs decay toward 0.85*similarity', () => {
+  it('older jobs decay toward 0.95*similarity', () => {
     vi.useFakeTimers();
     const now = new Date('2026-06-01T00:00:00Z');
     vi.setSystemTime(now);
     const posted = new Date('2025-06-01T00:00:00Z'); // ~1 year old
     const out = timeDecayScore(0.6, posted.toISOString());
-    expect(out).toBeGreaterThan(0.85 * 0.6 - 0.001);
-    expect(out).toBeLessThan(0.85 * 0.6 + 0.01);
+    expect(out).toBeGreaterThan(0.95 * 0.6 - 0.001);
+    expect(out).toBeLessThan(0.95 * 0.6 + 0.01);
   });
 
   it('recent jobs score higher than identical-similarity old jobs', () => {

--- a/apps/registry/app/api/v1/jobs/resolveEmbedding.js
+++ b/apps/registry/app/api/v1/jobs/resolveEmbedding.js
@@ -7,7 +7,7 @@
  *  - the user's own resume: embed it, optionally blending a HyDE embedding.
  *
  * Returns either { error: { message, status } } for a client-facing failure or
- * { embedding, resumeText, searchPrompt } on success.
+ * { embedding, resumeText, searchPrompt, candidateLocation } on success.
  */
 import { logger } from '@/lib/logger';
 import {
@@ -30,6 +30,21 @@ const buildProfileResumeText = (resume) =>
     .filter(Boolean)
     .join('\n');
 
+/**
+ * Human-readable candidate location for the reranker ("Melbourne, AU").
+ * The embedding text deliberately omits location; the reranker must not
+ * (the 2026-07 eval saw onsite-SF roles in a Melbourne candidate's top 5).
+ */
+export const extractLocation = (resume) => {
+  const loc = resume?.basics?.location;
+  if (!loc) {
+    return '';
+  }
+  return [loc.city, loc.region, loc.countryCode]
+    .filter(Boolean)
+    .join(', ');
+};
+
 const resolveFromProfile = async ({ username, searchId, shouldRerank }) => {
   const { data: profile, error: profileErr } = await getSupabase()
     .from('search_profiles')
@@ -42,10 +57,13 @@ const resolveFromProfile = async ({ username, searchId, shouldRerank }) => {
   }
 
   let resumeText = '';
+  let candidateLocation = '';
   if (shouldRerank) {
     const res = await fetch(`${REGISTRY_BASE}/${username}.json`);
     if (res.ok) {
-      resumeText = buildProfileResumeText(await res.json());
+      const resume = await res.json();
+      resumeText = buildProfileResumeText(resume);
+      candidateLocation = extractLocation(resume);
     }
   }
 
@@ -53,6 +71,7 @@ const resolveFromProfile = async ({ username, searchId, shouldRerank }) => {
     embedding: profile.embedding,
     resumeText,
     searchPrompt: profile.prompt || '',
+    candidateLocation,
   };
 };
 
@@ -75,7 +94,12 @@ const resolveFromResume = async ({ username, useHyde }) => {
     }
   }
 
-  return { embedding, resumeText: result.text, searchPrompt: '' };
+  return {
+    embedding,
+    resumeText: result.text,
+    searchPrompt: '',
+    candidateLocation: extractLocation(resume),
+  };
 };
 
 /**

--- a/apps/registry/app/api/v1/jobs/route.js
+++ b/apps/registry/app/api/v1/jobs/route.js
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticate } from '../auth';
 import { logger } from '@/lib/logger';
+import { rateLimitResponse } from '../../pathways/rateLimit';
 import { getSupabase, getResumeEmbedding } from './matchingHelpers';
-import { resolveEmbedding } from './resolveEmbedding';
+import { resolveEmbedding, extractLocation } from './resolveEmbedding';
 import {
   partitionFeedback,
   applyNegativeSignal,
@@ -38,9 +39,11 @@ export async function GET(request) {
   const minSalary = parseInt(searchParams.get('min_salary')) || 0;
   const search = searchParams.get('search') || '';
   const searchId = searchParams.get('search_id') || '';
-  const rerankParam = searchParams.get('rerank');
-  const shouldRerank =
-    rerankParam === 'true' || (rerankParam !== 'false' && !!searchId);
+  // Rerank defaults ON for authenticated requests: the 2026-07 eval measured
+  // it as the only strategy with acceptable precision (P@5 0.8 vs 0.2 for
+  // raw vector order). One listwise gpt-4.1-mini call per request.
+  // Opt out with ?rerank=false.
+  const shouldRerank = searchParams.get('rerank') !== 'false';
   const useHyde = searchParams.get('hyde') !== 'false';
 
   try {
@@ -57,7 +60,7 @@ export async function GET(request) {
       );
     }
     let { embedding } = resolved;
-    const { resumeText, searchPrompt } = resolved;
+    const { resumeText, searchPrompt, candidateLocation } = resolved;
 
     // Get user feedback for state filtering + negative signal
     const supabase = getSupabase();
@@ -81,9 +84,15 @@ export async function GET(request) {
       remote,
       globalRemote,
       minSalary,
+      includeUnknownSalary:
+        searchParams.get('include_unknown_salary') === 'true',
       search,
       shouldRerank,
       stateMap,
+      candidate: {
+        location: candidateLocation,
+        remoteOnly: remote || globalRemote,
+      },
     });
 
     const jobs = results.map((job) => ({
@@ -105,9 +114,18 @@ export async function GET(request) {
 }
 
 /**
- * POST /api/v1/jobs — match jobs against a provided resume (no auth)
+ * POST /api/v1/jobs — match jobs against a provided resume.
+ *
+ * Unauthenticated (this powers the CLI's local-resume mode), but rate-limited
+ * per IP and capped tighter than the authed GET — each call burns server-side
+ * OpenAI embedding + classification spend.
  */
 export async function POST(request) {
+  const limited = rateLimitResponse(request);
+  if (limited) {
+    return limited;
+  }
+
   try {
     const body = await request.json();
     const { resume } = body;
@@ -122,8 +140,8 @@ export async function POST(request) {
       );
     }
 
-    const top = Math.min(parseInt(body.top) || 20, 500);
-    const days = parseInt(body.days) || 90;
+    const top = Math.min(parseInt(body.top) || 20, 100);
+    const days = Math.min(parseInt(body.days) || 90, 120);
     const remote = body.remote === true;
     const globalRemote = body.global_remote === true;
     const minSalary = parseInt(body.min_salary) || 0;
@@ -140,9 +158,14 @@ export async function POST(request) {
       remote,
       globalRemote,
       minSalary,
+      includeUnknownSalary: body.include_unknown_salary === true,
       search,
       shouldRerank: false,
       stateMap: null,
+      candidate: {
+        location: extractLocation(resume),
+        remoteOnly: remote || globalRemote,
+      },
     });
 
     return NextResponse.json({ jobs, total: jobs.length });

--- a/apps/registry/app/api/v1/searches/route.js
+++ b/apps/registry/app/api/v1/searches/route.js
@@ -9,7 +9,13 @@ import { logger } from '@/lib/logger';
 export const dynamic = 'force-dynamic';
 
 const supabaseUrl = SUPABASE_URL;
-const PROMPT_WEIGHT = 0.65;
+// Prompt-steered blend weights (see POST handler): the HyDE doc carries the
+// detail, the raw prompt anchors intent, the resume keeps a small seniority
+// pull. Previous 0.65 hyde / 0.35 resume blend was prompt-blind because the
+// HyDE doc itself echoed the resume.
+const HYDE_WEIGHT = 0.5;
+const PROMPT_WEIGHT = 0.3;
+const RESUME_WEIGHT = 0.2;
 
 function getSupabase() {
   return createClient(supabaseUrl, process.env.SUPABASE_KEY);
@@ -37,10 +43,17 @@ function normalize(vec) {
   return vec.map((v) => v / norm);
 }
 
-/** Weighted interpolation of two vectors, normalized */
-function interpolate(vecA, vecB, alpha) {
-  const blended = vecA.map((v, i) => alpha * v + (1 - alpha) * vecB[i]);
-  return normalize(blended);
+/** Weighted sum of N [vector, weight] pairs, normalized */
+function weightedBlend(pairs) {
+  const usable = pairs.filter(([v]) => Array.isArray(v) && v.length > 0);
+  if (usable.length === 0) return null;
+  const out = new Array(usable[0][0].length).fill(0);
+  for (const [vec, weight] of usable) {
+    for (let i = 0; i < out.length; i++) {
+      out[i] += weight * vec[i];
+    }
+  }
+  return normalize(out);
 }
 
 /**
@@ -114,16 +127,21 @@ export async function POST(request) {
     const resume = await res.json();
     const resumeText = extractResumeText(resume);
 
-    // Step 1: HyDE — generate a hypothetical ideal job posting
+    // Step 1: HyDE — generate a hypothetical ideal job posting, PROMPT-FIRST.
+    // The 2026-07 eval found search profiles prompt-blind at retrieval: three
+    // radically different prompts overlapped 16-17/20 because the HyDE doc
+    // was dominated by the resume. The prompt is now the primary spec and the
+    // resume only calibrates seniority; generation runs at temperature 0.
     const { text: hydeJobPosting } = await generateText({
       model: openai('gpt-4.1-mini'),
-      system: `You are a job posting generator. Given a candidate's background and what they're looking for, write a realistic job posting that would be their IDEAL match. Write it exactly like a real HN "Who is Hiring" post. Include: company description, role title, tech stack, requirements, location, salary range, and remote policy. Output ONLY the job posting text — no markdown, no explanations. Make it specific and keyword-rich.`,
-      prompt: `Candidate background:\n${resumeText}\n\nWhat they're looking for:\n${prompt}`,
+      temperature: 0,
+      system: `You are a job posting generator. The candidate has described the SPECIFIC kind of role they want — that description is your primary spec. Write a realistic job posting for exactly that role, exactly like a real HN "Who is Hiring" post: company description, role title, tech stack, requirements, location, salary range, remote policy. Use the candidate's background ONLY to calibrate seniority and salary — do NOT default to their current stack or job title if the description points elsewhere. Output ONLY the job posting text — no markdown, no explanations. Make it specific and keyword-rich for the DESCRIBED role.`,
+      prompt: `The role they want:\n${prompt}\n\nBackground (for seniority calibration only):\n${resumeText}`,
       maxTokens: 500,
     });
 
-    // Step 2: Embed both separately
-    const [resumeResult, hydeResult] = await Promise.all([
+    // Step 2: Embed the HyDE doc, the raw prompt, and the resume separately
+    const [resumeResult, hydeResult, promptResult] = await Promise.all([
       embed({
         model: openai.embedding('text-embedding-3-large'),
         value: resumeText,
@@ -132,14 +150,20 @@ export async function POST(request) {
         model: openai.embedding('text-embedding-3-large'),
         value: hydeJobPosting,
       }),
+      embed({
+        model: openai.embedding('text-embedding-3-large'),
+        value: prompt,
+      }),
     ]);
 
-    // Step 3: Interpolate with prompt-heavy weighting
-    const embedding = interpolate(
-      hydeResult.embedding,
-      resumeResult.embedding,
-      PROMPT_WEIGHT
-    );
+    // Step 3: prompt-steered blend — HyDE doc carries the detail, the raw
+    // prompt embedding anchors intent, the resume keeps a small pull toward
+    // the candidate's actual level.
+    const embedding = weightedBlend([
+      [hydeResult.embedding, HYDE_WEIGHT],
+      [promptResult.embedding, PROMPT_WEIGHT],
+      [resumeResult.embedding, RESUME_WEIGHT],
+    ]);
 
     const supabase = getSupabase();
     const { data, error } = await supabase

--- a/packages/job-search/bin/cli.js
+++ b/packages/job-search/bin/cli.js
@@ -127,6 +127,10 @@ async function cmdSearch() {
   const minSalary = parseInt(getArg('--min-salary'));
   if (minSalary > 0) params.set('min_salary', String(minSalary));
   if (getArg('--search')) params.set('search', getArg('--search'));
+  // AI reranking is on by default server-side (it is the only ordering with
+  // acceptable precision) but adds ~10-30s; --fast skips it.
+  if (hasFlag('--fast')) params.set('rerank', 'false');
+  else console.error('  Ranking with AI (use --fast to skip)...');
 
   const { jobs } = await api(`/jobs?${params}`);
 
@@ -164,10 +168,14 @@ async function cmdSearch() {
   console.log(' ' + '─'.repeat(112));
 
   for (const j of filtered) {
+    // Display the score the list is actually ordered by (server-computed
+    // decay/rerank blend), falling back for older servers.
+    const score =
+      j.score ?? j.combined_score ?? j.decayed_similarity ?? j.similarity;
     const line =
       ' ' +
       stateIcon(j.state).padEnd(3) +
-      String(j.similarity).padEnd(7) +
+      String(score).padEnd(7) +
       String(j.id).padEnd(8) +
       (j.title || '').slice(0, 33).padEnd(35) +
       (j.company || '').slice(0, 23).padEnd(25) +
@@ -346,6 +354,7 @@ SEARCH OPTIONS
   --remote                          Remote jobs only
   --min-salary N                    Minimum salary in thousands (e.g. 150)
   --search TERM                     Keyword filter (searches title, company, skills)
+  --fast                            Skip AI reranking (faster, lower quality order)
   --interested                      Show only jobs you marked interested
   --applied                         Show only jobs you marked applied
 

--- a/packages/job-search/src/tui/JobList.js
+++ b/packages/job-search/src/tui/JobList.js
@@ -137,8 +137,11 @@ function JobRow({
 }) {
   const loc = formatLocation(job.location, job.remote);
   const sal = formatSalary(job.salary, job.salary_usd);
-  const score =
-    typeof job.similarity === 'number' ? job.similarity.toFixed(2) : '—';
+  // Display the score the list is actually ordered by (server decay/rerank
+  // blend), falling back for older servers that only send similarity.
+  const sortScore =
+    job.score ?? job.combined_score ?? job.decayed_similarity ?? job.similarity;
+  const score = typeof sortScore === 'number' ? sortScore.toFixed(2) : '—';
   const age = formatAge(job.posted_at);
   const icon = stateIcon(job.state);
   const dossierIcon =

--- a/packages/job-search/src/tui/useJobs.js
+++ b/packages/job-search/src/tui/useJobs.js
@@ -50,10 +50,10 @@ export function useJobs(api, activeFilters, tab, searchId, getDossierStatus) {
         if (cached) {
           setAllJobs(cached);
           setLoading(false);
-          // Still kick off rerank in background if eligible
-          if (searchId) {
-            startRerank(cached);
-          }
+          // Still kick off rerank in background (all views — reranking is
+          // the only ordering with acceptable precision, not just custom
+          // searches).
+          startRerank(cached);
           return;
         }
       }
@@ -69,8 +69,10 @@ export function useJobs(api, activeFilters, tab, searchId, getDossierStatus) {
         setAllJobs(result);
         setLoading(false);
 
-        // Pass 2: rerank in background if using a custom search
-        if (searchId && result.length > 0) {
+        // Pass 2: rerank in background for every view — deep listwise
+        // reranking is what actually orders jobs by fit; the vector-only
+        // pass is just the instant first paint.
+        if (result.length > 0) {
           startRerank(result);
         }
       } catch (err) {


### PR DESCRIPTION
Follow-up to the qualitative ranking evaluation (gold-set + blind judges over prod data). Every failure it found is fixed and re-verified against the same frozen gold set on a local production build.

## What was broken → fixed

| Problem (measured) | Fix |
|---|---|
| Retrieval pool cut at `top*5` by RAW similarity — 8/12 gold jobs never retrievable | Pool floor 300 candidates |
| Recency worth 2.2x the whole relevance signal (0.37–0.44 sim band) — stale-stack mismatch at #1 | Decay 0.85/0.15 → 0.95/0.05 |
| Rerank: 30 pointwise 1–10 calls, tie-bands broken by recency, silent 5 on failure, blind to location | One-shot listwise chunks (parallel 50-job calls, 150-deep window), calibrated 0–100, location + remote-only hard rules, ON by default |
| `min_salary` a complete no-op (salary_usd NULL on 100% of rows, fails open) | Normalizer wired into nightly + prod backfilled (289/959 recent rows); filter fails closed, `include_unknown_salary` opt-in |
| Keyword search = `JSON.stringify(job).includes(q)` — "ai" matched 98/100 jobs via "maintain" | Word-boundary matching over real text fields (symbol queries like `c++`/`.net` still substring) |
| `global_remote` hard filter collapsed pool to 8 jobs, 3 of them gold-worst gigs | Soft preference: confirmed-global first, remote backfill |
| Custom search prompts prompt-blind (3 different prompts → 16-17/20 identical results) | Prompt-first HyDE generation + 3-way blend (hyde/prompt/resume 0.5/0.3/0.2) |
| ±0.015 similarity jitter between identical requests | Temp-0 HyDE + embedding memoization |
| CLI/TUI displayed raw similarity against a decay-ordered list (looked shuffled) | Unified server `score` field; clients display what they sort by |
| POST /api/v1/jobs: unauthenticated, unmetered OpenAI spend | Per-IP rate limit (30/min), tighter caps |

## Verified (same gold set, local prod build)

- gold-worst jobs in top-20: **2 → 0** (the LATAM .NET gig and $300 no-AI gig that used to sit at #1/#4 are gone)
- gold-best in top-20: **2 → 4**, with gold at **#1** (pulled from vector rank 42); remaining gold are US/CA-geo-locked stretches now *correctly* demoted for a remote-only candidate
- min_salary violations in "min $150k" list: **20 → 0**
- keyword "ai" false-match rate: **98% → 0%**
- rate limiter: exactly 30/min then 429
- tests: registry 1735 passed (14 new), job-search 74 passed

Changeset included for @jsonresume/jobs. A separate research roadmap (hybrid retrieval, eval harness in CI, structured extraction at ingest, tiered match presentation) lands next.

— AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--fast` search option to skip AI reranking.
  - AI reranking now runs across all job views by default.
  - Search results use a unified score reflecting similarity, recency, and reranking.
  - Improved matching for location, remote preferences, salary, and keyword searches.
  - Search profiles now better prioritize the user’s prompt and resume context.

- **Bug Fixes**
  - Improved remote-job ordering and salary filtering.
  - Made ranking more consistent and embedding generation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->