### PR TITLE
feat(homepage2): add YAMLResume to projects list and getting started

### DIFF
--- a/apps/homepage2/app/getting-started/components/CLISection.tsx
+++ b/apps/homepage2/app/getting-started/components/CLISection.tsx
@@ -81,11 +81,26 @@ export function CLISection() {
           import JSON Resume directly:
         </p>
         <p>
+          YAMLResume requires Node.js 22 or newer. Convert your existing resume:
+          <br />
+          <br />
           <code>npx json2yamlresume resume.json</code>
           <br />
           <br />
-          Then simply
+          Install the YAMLResume CLI:
           <br />
+          <br />
+          <code>npm install -g yamlresume</code>
+          <br />
+          <br />
+          For PDF output, install a supported LaTeX engine following the{' '}
+          <a target="_blank" href="https://yamlresume.dev/docs/installation">
+            YAMLResume installation guide
+          </a>
+          , then verify your environment and build:
+          <br />
+          <br />
+          <code>yamlresume doctor</code>
           <br />
           <code>yamlresume build resume.yml</code>
         </p>

--- a/apps/homepage2/app/getting-started/components/CLISection.tsx
+++ b/apps/homepage2/app/getting-started/components/CLISection.tsx
@@ -70,6 +70,25 @@ export function CLISection() {
             https://registry.jsonresume.org/thomasdavis.rendercv
           </a>
         </p>
+        <h2>YAML</h2>
+        <p>
+          If you prefer maintaining your resume as YAML,{' '}
+          <a target="_blank" href="https://yamlresume.dev">
+            YAMLResume
+          </a>{' '}
+          is a TypeScript toolchain that renders pixel-perfect PDFs via LaTeX
+          typesetting, with built-in i18n support and schema validation. It can
+          import JSON Resume directly:
+        </p>
+        <p>
+          <code>npx json2yamlresume resume.json</code>
+          <br />
+          <br />
+          Then simply
+          <br />
+          <br />
+          <code>yamlresume build resume.yml</code>
+        </p>
         <h2>Maintaining and Deploying Multiple Versions</h2>
         <p>
           The registry supports multiple resume files via the{' '}

--- a/apps/homepage2/app/projects/data/projects/integrations.js
+++ b/apps/homepage2/app/projects/data/projects/integrations.js
@@ -74,7 +74,10 @@ export const projects = [
   {
     name: 'YAMLResume',
     description:
-      'YAMLResume is a TypeScript toolchain that lets you create and version control resumes as code in YAML, and generate pixel-perfect resumes in multiple formats (PDF, HTML, Markdown, etc.) with pro-grade LaTeX typesetting, built-in i18n support and a developer-friendly CLI.',
+      'YAMLResume is a TypeScript toolchain that lets you create and version ' +
+      'control resumes as code in YAML, and generate pixel-perfect resumes in ' +
+      'multiple formats (PDF, HTML, Markdown, etc.) with pro-grade LaTeX ' +
+      'typesetting, built-in i18n support and a developer-friendly CLI.',
     link: 'https://yamlresume.dev',
     category: 'framework',
     language: 'TypeScript',

--- a/apps/homepage2/app/projects/data/projects/integrations.js
+++ b/apps/homepage2/app/projects/data/projects/integrations.js
@@ -72,6 +72,14 @@ export const projects = [
     language: 'Python/Typst',
   },
   {
+    name: 'YAMLResume',
+    description:
+      'YAMLResume is a TypeScript toolchain that lets you create and version control resumes as code in YAML, and generate pixel-perfect resumes in multiple formats (PDF, HTML, Markdown, etc.) with pro-grade LaTeX typesetting, built-in i18n support and a developer-friendly CLI.',
+    link: 'https://yamlresume.dev',
+    category: 'framework',
+    language: 'TypeScript',
+  },
+  {
     name: 'hugo-mod-json-resume',
     description:
       'A Hugo module containing templates to integrate multilingual JSON Resume data into your Hugo website.',


### PR DESCRIPTION
## Summary

Adds [YAMLResume](https://yamlresume.dev) (resumes-as-code toolchain in YAML by PPResume, TypeScript, LaTeX typesetting) to the homepage in two places:

- **Projects list** (`integrations.js`): new entry in the `framework` category, right after RenderCV — both are YAML-authored resume toolchains
- **Getting started** (`CLISection.tsx`): new "YAML" section after the existing "Latex"/RenderCV block, documenting the JSON Resume interop path:
  - `npx json2yamlresume resume.json` — converts JSON Resume to YAMLResume format (all standard sections)
  - `yamlresume build resume.yml` — renders pixel-perfect PDF via LaTeX

## Notes

- YAMLResume is independent of RenderCV (does not use it under the hood) — description kept factual
- Source repo: https://github.com/yamlresume/yamlresume

## Commands run

- `pnpm --filter homepage2 lint` ✅
- `pnpm --filter homepage2 typecheck` ✅
- `pnpm --filter homepage2 build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the YAMLResume getting-started guide with Node.js 22+ prerequisites, CLI installation instructions, LaTeX engine setup guidance, environment verification, and resume build steps.
  - Clarified the recommended setup sequence before generating a resume with YAMLResume.
- **Integrations**
  - YAMLResume remains listed with information about its resume-generation capabilities and supported technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->