### PR TITLE
fix(ci): isolate Playwright from Chrome apt rollovers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,12 @@ jobs:
           cache: pnpm
       - name: Install system dependencies
         run: |
+          # The hosted runner preinstalls Chrome and its apt source, but these
+          # tests use Playwright's own browser. Disable that unrelated source
+          # so a Chrome CDN index rollover cannot break every E2E run.
+          sudo rm -f \
+            /etc/apt/sources.list.d/google-chrome.list \
+            /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y libasound2t64 libicu-dev libffi-dev libx264-dev
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- disable the hosted runner's unrelated Google Chrome apt source before the Playwright job updates system packages
- keep the existing Playwright browser install and E2E coverage unchanged

The runner already includes Chrome, while this job downloads Playwright's own browser. During Google's 2026-09-09 repository rollover, the preinstalled source served a package index whose bytes did not match its new Release hash. That made `apt-get update` fail before the project or tests ran on both master and the generated release PR.

Evidence:

- master run 34383082094 failed twice at `Install system dependencies`
- release PR run 34383189206 failed at the same step
- both received the same `dl.google.com` `Hash Sum mismatch`
- PR #528's E2E suite passed immediately before the upstream repository rollover

## Verification

This PR's E2E job exercises the modified setup from a clean hosted runner. All other project checks remain required.

— Codex
